### PR TITLE
開発環境にvox-actorを追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/devcontainers/base:noble
 ENV CLAUDE_CONFIG_DIR=/home/vscode/.claude
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends shellcheck && \
+    apt-get install -y --no-install-recommends shellcheck libasound2-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -9,6 +9,11 @@
       "version": "1.3.4",
       "resolved": "ghcr.io/devcontainers/features/go@sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032",
       "integrity": "sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032"
+    },
+    "ghcr.io/meaningful-ooo/devcontainer-features/homebrew:2": {
+      "version": "2.0.5",
+      "resolved": "ghcr.io/meaningful-ooo/devcontainer-features/homebrew@sha256:c49ba0f6275bdd0474f4c7fcf37fc84b5739838b110c7da9c16d6a409ae48a86",
+      "integrity": "sha256:c49ba0f6275bdd0474f4c7fcf37fc84b5739838b110c7da9c16d6a409ae48a86"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,8 @@
 	"runServices": ["voicevox"],
 	"features": {
 		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers/features/go:1": {}
+		"ghcr.io/devcontainers/features/go:1": {},
+		"ghcr.io/meaningful-ooo/devcontainer-features/homebrew:2": {}
 	},
 	"remoteUser": "vscode",
 	"mounts": [

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -3,3 +3,8 @@ set -e
 
 # install Claude Code
 curl -fsSL https://claude.ai/install.sh | bash
+
+# install vox-actor via Homebrew
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+brew tap canpok1/tap
+brew install --cask vox-actor

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ go.work.sum
 
 # 一時ファイル
 .tmp/
+
+# vox-actor
+.vox-actor/


### PR DESCRIPTION
## 概要

開発環境で vox-actor を利用できるようにするためのセットアップを追加します。

## 変更内容

- `Dockerfile`: 音声再生に必要な `libasound2-dev` を追加
- `devcontainer.json` / `devcontainer-lock.json`: Homebrew feature を追加
- `post-create.sh`: Homebrew 経由で vox-actor をインストール
- `.gitignore`: `.vox-actor/` を除外対象に追加

## テスト

- devcontainer の再ビルドで vox-actor が利用可能になることを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)