### PR TITLE
feat: script/llm — OpenAI互換LLMクライアント（構造化出力・検証・リトライ）

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,12 @@ module github.com/canpok1/vox-radio
 
 go 1.26.1
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/xeipuuv/gojsonschema v1.2.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,16 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/script/llm/client.go
+++ b/internal/script/llm/client.go
@@ -28,8 +28,9 @@ type Config struct {
 }
 
 type openAIClient struct {
-	cfg Config
-	hc  *http.Client
+	cfg      Config
+	hc       *http.Client
+	endpoint string
 }
 
 // NewClient creates a new OpenAI-compatible LLM client.
@@ -41,8 +42,9 @@ func NewClient(cfg Config) Client {
 		cfg.Model = DefaultModel
 	}
 	return &openAIClient{
-		cfg: cfg,
-		hc:  &http.Client{Timeout: 60 * time.Second},
+		cfg:      cfg,
+		hc:       &http.Client{Timeout: 60 * time.Second},
+		endpoint: strings.TrimRight(cfg.BaseURL, "/") + "/chat/completions",
 	}
 }
 
@@ -80,6 +82,10 @@ func (c *openAIClient) Complete(ctx context.Context, req CompletionRequest) (jso
 	msgs := make([]Message, len(req.Messages))
 	copy(msgs, req.Messages)
 
+	if len(req.JSONSchema) == 0 {
+		return c.callAPI(ctx, req, msgs)
+	}
+
 	maxRetries := c.cfg.MaxRetries
 	if maxRetries < 0 {
 		maxRetries = 0
@@ -89,10 +95,6 @@ func (c *openAIClient) Complete(ctx context.Context, req CompletionRequest) (jso
 		raw, err := c.callAPI(ctx, req, msgs)
 		if err != nil {
 			return nil, err
-		}
-
-		if len(req.JSONSchema) == 0 {
-			return raw, nil
 		}
 
 		errs, err := validateAgainstSchema(raw, req.JSONSchema)
@@ -131,18 +133,13 @@ func (c *openAIClient) callAPI(ctx context.Context, req CompletionRequest, msgs 
 		Temperature: temperature,
 	}
 
+	apiReq.ResponseFormat = &responseFormat{Type: "json_object"}
 	if len(req.JSONSchema) > 0 {
-		apiReq.ResponseFormat = &responseFormat{
-			Type: "json_schema",
-			JSONSchema: &schemaSpec{
-				Name:   "output",
-				Schema: req.JSONSchema,
-				Strict: true,
-			},
-		}
-	} else {
-		apiReq.ResponseFormat = &responseFormat{
-			Type: "json_object",
+		apiReq.ResponseFormat.Type = "json_schema"
+		apiReq.ResponseFormat.JSONSchema = &schemaSpec{
+			Name:   "output",
+			Schema: req.JSONSchema,
+			Strict: true,
 		}
 	}
 
@@ -151,8 +148,7 @@ func (c *openAIClient) callAPI(ctx context.Context, req CompletionRequest, msgs 
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	url := strings.TrimRight(c.cfg.BaseURL, "/") + "/chat/completions"
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}

--- a/internal/script/llm/client.go
+++ b/internal/script/llm/client.go
@@ -1,0 +1,218 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/xeipuuv/gojsonschema"
+)
+
+const (
+	DefaultBaseURL = "https://generativelanguage.googleapis.com/v1beta/openai"
+	DefaultModel   = "gemini-3.1-flash-lite"
+)
+
+// Config holds the settings for the OpenAI-compatible LLM client.
+type Config struct {
+	BaseURL     string
+	APIKey      string
+	Model       string
+	MaxRetries  int
+	Temperature float64
+}
+
+type openAIClient struct {
+	cfg Config
+	hc  *http.Client
+}
+
+// NewClient creates a new OpenAI-compatible LLM client.
+func NewClient(cfg Config) Client {
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = DefaultBaseURL
+	}
+	if cfg.Model == "" {
+		cfg.Model = DefaultModel
+	}
+	return &openAIClient{
+		cfg: cfg,
+		hc:  &http.Client{Timeout: 60 * time.Second},
+	}
+}
+
+type apiRequest struct {
+	Model          string          `json:"model"`
+	Messages       []Message       `json:"messages"`
+	ResponseFormat *responseFormat `json:"response_format,omitempty"`
+	Temperature    float64         `json:"temperature,omitempty"`
+}
+
+type responseFormat struct {
+	Type       string      `json:"type"`
+	JSONSchema *schemaSpec `json:"json_schema,omitempty"`
+}
+
+type schemaSpec struct {
+	Name   string          `json:"name"`
+	Schema json.RawMessage `json:"schema"`
+	Strict bool            `json:"strict"`
+}
+
+type apiResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+	Error *struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+	} `json:"error,omitempty"`
+}
+
+func (c *openAIClient) Complete(ctx context.Context, req CompletionRequest) (json.RawMessage, error) {
+	msgs := make([]Message, len(req.Messages))
+	copy(msgs, req.Messages)
+
+	maxRetries := c.cfg.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		raw, err := c.callAPI(ctx, req, msgs)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(req.JSONSchema) == 0 {
+			return raw, nil
+		}
+
+		errs, err := validateAgainstSchema(raw, req.JSONSchema)
+		if err != nil {
+			return nil, fmt.Errorf("validate schema: %w", err)
+		}
+		if len(errs) == 0 {
+			return raw, nil
+		}
+
+		if attempt < maxRetries {
+			msgs = append(msgs,
+				Message{Role: "assistant", Content: string(raw)},
+				Message{Role: "user", Content: buildRepairPrompt(errs)},
+			)
+		}
+	}
+
+	return nil, fmt.Errorf("validation failed after %d retries", c.cfg.MaxRetries)
+}
+
+func (c *openAIClient) callAPI(ctx context.Context, req CompletionRequest, msgs []Message) (json.RawMessage, error) {
+	model := req.Model
+	if model == "" {
+		model = c.cfg.Model
+	}
+
+	temperature := req.Temperature
+	if temperature == 0 {
+		temperature = c.cfg.Temperature
+	}
+
+	apiReq := apiRequest{
+		Model:       model,
+		Messages:    msgs,
+		Temperature: temperature,
+	}
+
+	if len(req.JSONSchema) > 0 {
+		apiReq.ResponseFormat = &responseFormat{
+			Type: "json_schema",
+			JSONSchema: &schemaSpec{
+				Name:   "output",
+				Schema: req.JSONSchema,
+				Strict: true,
+			},
+		}
+	} else {
+		apiReq.ResponseFormat = &responseFormat{
+			Type: "json_object",
+		}
+	}
+
+	body, err := json.Marshal(apiReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := strings.TrimRight(c.cfg.BaseURL, "/") + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", "Bearer "+c.cfg.APIKey)
+
+	resp, err := c.hc.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("http do: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("api error (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var apiResp apiResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	if apiResp.Error != nil {
+		return nil, fmt.Errorf("api error: %s", apiResp.Error.Message)
+	}
+
+	if len(apiResp.Choices) == 0 {
+		return nil, fmt.Errorf("empty choices in response")
+	}
+
+	return json.RawMessage(apiResp.Choices[0].Message.Content), nil
+}
+
+func validateAgainstSchema(data json.RawMessage, schema json.RawMessage) ([]string, error) {
+	if !json.Valid(data) {
+		return []string{"response is not valid JSON"}, nil
+	}
+
+	schemaLoader := gojsonschema.NewBytesLoader(schema)
+	dataLoader := gojsonschema.NewBytesLoader(data)
+
+	result, err := gojsonschema.Validate(schemaLoader, dataLoader)
+	if err != nil {
+		return nil, err
+	}
+
+	var errs []string
+	for _, e := range result.Errors() {
+		errs = append(errs, e.String())
+	}
+	return errs, nil
+}
+
+func buildRepairPrompt(errs []string) string {
+	return "Your previous response did not conform to the required JSON schema. Validation errors:\n" +
+		strings.Join(errs, "\n") +
+		"\nPlease provide a corrected JSON response that strictly follows the schema."
+}

--- a/internal/script/llm/client_test.go
+++ b/internal/script/llm/client_test.go
@@ -1,0 +1,297 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+func makeAPIResponse(t *testing.T, content string) []byte {
+	t.Helper()
+	type msgWrapper struct {
+		Content string `json:"content"`
+	}
+	type choice struct {
+		Message msgWrapper `json:"message"`
+	}
+	type resp struct {
+		Choices []choice `json:"choices"`
+	}
+	r := resp{Choices: []choice{{Message: msgWrapper{Content: content}}}}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal api response: %v", err)
+	}
+	return b
+}
+
+func TestComplete_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeAPIResponse(t, `{"value":"hello"}`))
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(llm.Config{
+		BaseURL:    ts.URL,
+		APIKey:     "test-key",
+		Model:      "test-model",
+		MaxRetries: 0,
+	})
+
+	result, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: "user", Content: "hello"}},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !json.Valid(result) {
+		t.Fatalf("result is not valid JSON: %s", string(result))
+	}
+}
+
+func TestComplete_SetsAuthorizationHeader(t *testing.T) {
+	var gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeAPIResponse(t, `{}`))
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(llm.Config{
+		BaseURL: ts.URL,
+		APIKey:  "my-secret-key",
+		Model:   "test-model",
+	})
+
+	_, _ = c.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: "user", Content: "hello"}},
+	})
+
+	if gotAuth != "Bearer my-secret-key" {
+		t.Errorf("expected Authorization: Bearer my-secret-key, got %q", gotAuth)
+	}
+}
+
+func TestComplete_WithSchema_Success(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"}
+		},
+		"required": ["name"]
+	}`)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeAPIResponse(t, `{"name":"hello"}`))
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(llm.Config{
+		BaseURL:    ts.URL,
+		APIKey:     "test-key",
+		Model:      "test-model",
+		MaxRetries: 0,
+	})
+
+	result, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
+		JSONSchema: schema,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(result, &got); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if got["name"] != "hello" {
+		t.Errorf("expected name=hello, got %q", got["name"])
+	}
+}
+
+func TestComplete_ValidationRetrySuccess(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"}
+		},
+		"required": ["name"]
+	}`)
+
+	var callCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		n := callCount.Add(1)
+		if n == 1 {
+			_, _ = w.Write(makeAPIResponse(t, `{"wrong":"value"}`))
+		} else {
+			_, _ = w.Write(makeAPIResponse(t, `{"name":"hello"}`))
+		}
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(llm.Config{
+		BaseURL:    ts.URL,
+		APIKey:     "test-key",
+		Model:      "test-model",
+		MaxRetries: 3,
+	})
+
+	result, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
+		JSONSchema: schema,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(result, &got); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if got["name"] != "hello" {
+		t.Errorf("expected name=hello, got %q", got["name"])
+	}
+	if callCount.Load() != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount.Load())
+	}
+}
+
+func TestComplete_RetryIncludesRepairContext(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"}
+		},
+		"required": ["name"]
+	}`)
+
+	var requestBodies [][]byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		requestBodies = append(requestBodies, body)
+		w.Header().Set("Content-Type", "application/json")
+		if len(requestBodies) == 1 {
+			_, _ = w.Write(makeAPIResponse(t, `{"wrong":"value"}`))
+		} else {
+			_, _ = w.Write(makeAPIResponse(t, `{"name":"hello"}`))
+		}
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(llm.Config{
+		BaseURL:    ts.URL,
+		APIKey:     "test-key",
+		Model:      "test-model",
+		MaxRetries: 2,
+	})
+
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
+		JSONSchema: schema,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(requestBodies) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(requestBodies))
+	}
+
+	type apiReq struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+
+	var secondReq apiReq
+	if err := json.Unmarshal(requestBodies[1], &secondReq); err != nil {
+		t.Fatalf("unmarshal second request: %v", err)
+	}
+
+	// original message + assistant (invalid response) + user (repair prompt) = 3 messages
+	if len(secondReq.Messages) != 3 {
+		t.Errorf("expected 3 messages in retry request, got %d", len(secondReq.Messages))
+	}
+	if secondReq.Messages[1].Role != "assistant" {
+		t.Errorf("expected messages[1].role=assistant, got %q", secondReq.Messages[1].Role)
+	}
+	if secondReq.Messages[2].Role != "user" {
+		t.Errorf("expected messages[2].role=user, got %q", secondReq.Messages[2].Role)
+	}
+}
+
+func TestComplete_ExhaustsRetries(t *testing.T) {
+	schema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"}
+		},
+		"required": ["name"]
+	}`)
+
+	var callCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		callCount.Add(1)
+		_, _ = w.Write(makeAPIResponse(t, `{"wrong":"value"}`))
+	}))
+	defer ts.Close()
+
+	maxRetries := 2
+	c := llm.NewClient(llm.Config{
+		BaseURL:    ts.URL,
+		APIKey:     "test-key",
+		Model:      "test-model",
+		MaxRetries: maxRetries,
+	})
+
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
+		JSONSchema: schema,
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if int(callCount.Load()) != maxRetries+1 {
+		t.Errorf("expected %d API calls, got %d", maxRetries+1, callCount.Load())
+	}
+}
+
+func TestComplete_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"internal error","type":"server_error"}}`))
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(llm.Config{
+		BaseURL:    ts.URL,
+		APIKey:     "test-key",
+		Model:      "test-model",
+		MaxRetries: 3,
+	})
+
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: "user", Content: "hello"}},
+	})
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/script/llm/client_test.go
+++ b/internal/script/llm/client_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
 
+// testRequiredNameSchema is a minimal JSON Schema requiring a "name" string field.
+var testRequiredNameSchema = json.RawMessage(`{
+	"type": "object",
+	"properties": {
+		"name": {"type": "string"}
+	},
+	"required": ["name"]
+}`)
+
 func makeAPIResponse(t *testing.T, content string) []byte {
 	t.Helper()
 	type msgWrapper struct {
@@ -82,14 +91,6 @@ func TestComplete_SetsAuthorizationHeader(t *testing.T) {
 }
 
 func TestComplete_WithSchema_Success(t *testing.T) {
-	schema := json.RawMessage(`{
-		"type": "object",
-		"properties": {
-			"name": {"type": "string"}
-		},
-		"required": ["name"]
-	}`)
-
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write(makeAPIResponse(t, `{"name":"hello"}`))
@@ -105,7 +106,7 @@ func TestComplete_WithSchema_Success(t *testing.T) {
 
 	result, err := c.Complete(context.Background(), llm.CompletionRequest{
 		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
-		JSONSchema: schema,
+		JSONSchema: testRequiredNameSchema,
 	})
 
 	if err != nil {
@@ -122,14 +123,6 @@ func TestComplete_WithSchema_Success(t *testing.T) {
 }
 
 func TestComplete_ValidationRetrySuccess(t *testing.T) {
-	schema := json.RawMessage(`{
-		"type": "object",
-		"properties": {
-			"name": {"type": "string"}
-		},
-		"required": ["name"]
-	}`)
-
 	var callCount atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -151,7 +144,7 @@ func TestComplete_ValidationRetrySuccess(t *testing.T) {
 
 	result, err := c.Complete(context.Background(), llm.CompletionRequest{
 		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
-		JSONSchema: schema,
+		JSONSchema: testRequiredNameSchema,
 	})
 
 	if err != nil {
@@ -171,14 +164,6 @@ func TestComplete_ValidationRetrySuccess(t *testing.T) {
 }
 
 func TestComplete_RetryIncludesRepairContext(t *testing.T) {
-	schema := json.RawMessage(`{
-		"type": "object",
-		"properties": {
-			"name": {"type": "string"}
-		},
-		"required": ["name"]
-	}`)
-
 	var requestBodies [][]byte
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -201,7 +186,7 @@ func TestComplete_RetryIncludesRepairContext(t *testing.T) {
 
 	_, err := c.Complete(context.Background(), llm.CompletionRequest{
 		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
-		JSONSchema: schema,
+		JSONSchema: testRequiredNameSchema,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -236,14 +221,6 @@ func TestComplete_RetryIncludesRepairContext(t *testing.T) {
 }
 
 func TestComplete_ExhaustsRetries(t *testing.T) {
-	schema := json.RawMessage(`{
-		"type": "object",
-		"properties": {
-			"name": {"type": "string"}
-		},
-		"required": ["name"]
-	}`)
-
 	var callCount atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -262,7 +239,7 @@ func TestComplete_ExhaustsRetries(t *testing.T) {
 
 	_, err := c.Complete(context.Background(), llm.CompletionRequest{
 		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
-		JSONSchema: schema,
+		JSONSchema: testRequiredNameSchema,
 	})
 
 	if err == nil {


### PR DESCRIPTION
## Summary

- `internal/script/llm` パッケージに OpenAI 互換 HTTP クライアント (`openAIClient`) を実装
- `base_url` / `api_key` / `model` / `max_retries` / `temperature` を `Config` で注入
- `response_format` に `json_schema`（スキーマ指定時）または `json_object` を使い構造化出力を要求
- JSON スキーマ検証（`gojsonschema`）＋検証失敗時の自己修復リトライを実装
  - 失敗時は検証エラーをメッセージに追加してリトライ（最大 `max_retries` 回）
- デフォルト: Gemini `gemini-3.1-flash-lite`（`base_url` + `model` の設定差し替えのみでプロバイダ切替可）
- モック HTTP サーバーを使ったテスト: 成功・検証失敗→リトライ→成功・リトライ上限超過 の経路をカバー

## Test plan

- [x] `TestComplete_Success` — スキーマなし成功
- [x] `TestComplete_SetsAuthorizationHeader` — APIキーがBearerトークンで送信される
- [x] `TestComplete_WithSchema_Success` — スキーマ検証成功
- [x] `TestComplete_ValidationRetrySuccess` — 1回失敗→リトライ→成功
- [x] `TestComplete_RetryIncludesRepairContext` — リトライ時に修復コンテキストが含まれる
- [x] `TestComplete_ExhaustsRetries` — リトライ上限超過でエラー
- [x] `TestComplete_APIError` — HTTP 500 でエラー
- [x] `make fmt` / `make lint` / `make test` 全パス

Closes #9

---
🤖 Generated with [Claude Code](https://claude.ai/code)