### PR TITLE
feat: assemble — ffmpegでclip群と素材からmp3を生成

### DIFF
--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -1,0 +1,130 @@
+package assemble
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+const defaultPauseSec = 0.3
+
+// Result holds the output metrics for an assembled episode.
+type Result struct {
+	DurationSec float64
+	Bytes       int64
+}
+
+// Assembler assembles speech clips and assets into a final mp3.
+type Assembler struct {
+	AssetsConfig config.AssetsConfig
+	ShowConfig   model.ShowConfig
+	runFFmpeg    func(ctx context.Context, args []string) error
+	getDuration  func(path string) (float64, error)
+	getFileSize  func(path string) (int64, error)
+}
+
+// New creates a new Assembler that calls ffmpeg and ffprobe.
+func New(assetsConfig config.AssetsConfig, showConfig model.ShowConfig) *Assembler {
+	return &Assembler{
+		AssetsConfig: assetsConfig,
+		ShowConfig:   showConfig,
+		runFFmpeg:    runFFmpegCmd,
+		getDuration:  ffprobeDuration,
+		getFileSize:  osFileSize,
+	}
+}
+
+// Run assembles the given clips and script into an mp3 at outPath.
+// It returns the duration and file size of the resulting mp3.
+func (a *Assembler) Run(ctx context.Context, script model.Script, clips model.ClipsMeta, clipsDir string, outPath string) (*Result, error) {
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		return nil, fmt.Errorf("create output dir: %w", err)
+	}
+
+	pauseSec := a.ShowConfig.SegmentPauseSec
+	if pauseSec == 0 {
+		pauseSec = defaultPauseSec
+	}
+
+	bctx := BuildContext{
+		Script:   script,
+		Clips:    clips,
+		ClipsDir: clipsDir,
+		Assets:   a.AssetsConfig,
+		PauseSec: pauseSec,
+		OutPath:  outPath,
+	}
+
+	ffArgs, err := BuildFFmpegArgs(bctx)
+	if err != nil {
+		return nil, fmt.Errorf("build ffmpeg args: %w", err)
+	}
+
+	cmdArgs := buildCmdArgs(ffArgs)
+	if err := a.runFFmpeg(ctx, cmdArgs); err != nil {
+		return nil, fmt.Errorf("ffmpeg: %w", err)
+	}
+
+	dur, err := a.getDuration(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("get duration: %w", err)
+	}
+
+	size, err := a.getFileSize(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("get file size: %w", err)
+	}
+
+	return &Result{DurationSec: dur, Bytes: size}, nil
+}
+
+// buildCmdArgs converts FFmpegArgs into a flat argument slice for exec.Command.
+func buildCmdArgs(ffArgs *FFmpegArgs) []string {
+	var args []string
+	for _, inp := range ffArgs.Inputs {
+		args = append(args, "-i", inp)
+	}
+	args = append(args, "-filter_complex", ffArgs.FilterComplex)
+	args = append(args, ffArgs.OutputArgs...)
+	args = append(args, "-y", ffArgs.OutputPath)
+	return args
+}
+
+func runFFmpegCmd(ctx context.Context, args []string) error {
+	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func ffprobeDuration(path string) (float64, error) {
+	out, err := exec.Command("ffprobe",
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		path,
+	).Output()
+	if err != nil {
+		return 0, fmt.Errorf("ffprobe: %w", err)
+	}
+	s := strings.TrimSpace(string(out))
+	dur, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse duration %q: %w", s, err)
+	}
+	return dur, nil
+}
+
+func osFileSize(path string) (int64, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}

--- a/internal/assemble/assemble_test.go
+++ b/internal/assemble/assemble_test.go
@@ -1,0 +1,171 @@
+package assemble
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+func newTestAssembler(ffmpegErr error, duration float64, size int64) *Assembler {
+	return &Assembler{
+		AssetsConfig: config.AssetsConfig{},
+		ShowConfig:   model.ShowConfig{SegmentPauseSec: 0.5},
+		runFFmpeg:    func(_ context.Context, _ []string) error { return ffmpegErr },
+		getDuration:  func(_ string) (float64, error) { return duration, nil },
+		getFileSize:  func(_ string) (int64, error) { return size, nil },
+	}
+}
+
+func TestAssembler_Run_ReturnsResult(t *testing.T) {
+	var capturedArgs []string
+	a := &Assembler{
+		AssetsConfig: config.AssetsConfig{},
+		ShowConfig:   model.ShowConfig{SegmentPauseSec: 0.5},
+		runFFmpeg: func(_ context.Context, args []string) error {
+			capturedArgs = args
+			return nil
+		},
+		getDuration: func(_ string) (float64, error) { return 60.0, nil },
+		getFileSize: func(_ string) (int64, error) { return 1024, nil },
+	}
+
+	script := model.Script{
+		Segments: []model.ScriptSegment{
+			{Type: model.SegmentTypeSpeech, Text: "hello"},
+		},
+	}
+	clips := model.ClipsMeta{
+		Clips: []model.ClipMeta{
+			{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+		},
+	}
+
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.mp3")
+	result, err := a.Run(context.Background(), script, clips, dir, outPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.DurationSec != 60.0 {
+		t.Errorf("duration: got %.1f, want 60.0", result.DurationSec)
+	}
+	if result.Bytes != 1024 {
+		t.Errorf("bytes: got %d, want 1024", result.Bytes)
+	}
+
+	if len(capturedArgs) == 0 {
+		t.Error("ffmpeg was not called")
+	}
+	foundOut := false
+	for _, arg := range capturedArgs {
+		if arg == outPath {
+			foundOut = true
+		}
+	}
+	if !foundOut {
+		t.Errorf("output path not found in ffmpeg args: %v", capturedArgs)
+	}
+}
+
+func TestAssembler_Run_FFmpegError(t *testing.T) {
+	a := newTestAssembler(errors.New("ffmpeg failed"), 0, 0)
+
+	script := model.Script{
+		Segments: []model.ScriptSegment{
+			{Type: model.SegmentTypeSpeech, Text: "hello"},
+		},
+	}
+	clips := model.ClipsMeta{
+		Clips: []model.ClipMeta{
+			{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+		},
+	}
+
+	dir := t.TempDir()
+	_, err := a.Run(context.Background(), script, clips, dir, filepath.Join(dir, "out.mp3"))
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+func TestAssembler_Run_NoClips_Error(t *testing.T) {
+	a := newTestAssembler(nil, 0, 0)
+
+	script := model.Script{}
+	clips := model.ClipsMeta{Clips: make([]model.ClipMeta, 0)}
+
+	dir := t.TempDir()
+	_, err := a.Run(context.Background(), script, clips, dir, filepath.Join(dir, "out.mp3"))
+	if err == nil {
+		t.Error("expected error for no clips, got nil")
+	}
+}
+
+func TestAssembler_Run_CreatesOutputDir(t *testing.T) {
+	a := newTestAssembler(nil, 30.0, 512)
+
+	script := model.Script{
+		Segments: []model.ScriptSegment{
+			{Type: model.SegmentTypeSpeech, Text: "hello"},
+		},
+	}
+	clips := model.ClipsMeta{
+		Clips: []model.ClipMeta{
+			{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+		},
+	}
+
+	outDir := filepath.Join(t.TempDir(), "nested", "output")
+	outPath := filepath.Join(outDir, "episode.mp3")
+	_, err := a.Run(context.Background(), script, clips, t.TempDir(), outPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, statErr := os.Stat(outDir); os.IsNotExist(statErr) {
+		t.Errorf("output dir not created: %s", outDir)
+	}
+}
+
+func TestAssembler_Run_DefaultPause(t *testing.T) {
+	var capturedArgs []string
+	a := &Assembler{
+		AssetsConfig: config.AssetsConfig{},
+		ShowConfig:   model.ShowConfig{SegmentPauseSec: 0}, // zero → default
+		runFFmpeg: func(_ context.Context, args []string) error {
+			capturedArgs = args
+			return nil
+		},
+		getDuration: func(_ string) (float64, error) { return 1.0, nil },
+		getFileSize: func(_ string) (int64, error) { return 100, nil },
+	}
+
+	script := model.Script{
+		Segments: []model.ScriptSegment{
+			{Type: model.SegmentTypeSpeech, Text: "A"},
+			{Type: model.SegmentTypeSpeech, Text: "B"},
+		},
+	}
+	clips := model.ClipsMeta{
+		Clips: []model.ClipMeta{
+			{Index: 0, File: "clip_000.wav", DurationSec: 1.0},
+			{Index: 1, File: "clip_001.wav", DurationSec: 1.0},
+		},
+	}
+
+	dir := t.TempDir()
+	_, err := a.Run(context.Background(), script, clips, dir, filepath.Join(dir, "out.mp3"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Ensure ffmpeg was called (default pause used)
+	if len(capturedArgs) == 0 {
+		t.Error("ffmpeg was not called")
+	}
+}

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -1,0 +1,215 @@
+package assemble
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+// BuildContext holds all data needed to build the ffmpeg command.
+type BuildContext struct {
+	Script   model.Script
+	Clips    model.ClipsMeta
+	ClipsDir string
+	Assets   config.AssetsConfig
+	PauseSec float64
+	OutPath  string
+}
+
+// FFmpegArgs holds the complete set of arguments for an ffmpeg call.
+type FFmpegArgs struct {
+	Inputs        []string // input file paths
+	FilterComplex string   // -filter_complex value
+	OutputArgs    []string // output options (map, codec, etc.)
+	OutputPath    string
+}
+
+type filterBuilder struct {
+	inputs  []string
+	filters []string
+	nextIdx int
+}
+
+func (b *filterBuilder) addInput(path string) int {
+	idx := b.nextIdx
+	b.inputs = append(b.inputs, path)
+	b.nextIdx++
+	return idx
+}
+
+func (b *filterBuilder) addFilter(f string) {
+	b.filters = append(b.filters, f)
+}
+
+type seEvent struct {
+	seName   string
+	offsetMs int
+}
+
+// BuildFFmpegArgs constructs the complete ffmpeg argument list for audio assembly.
+// It builds a single filter_complex covering speech concat, SE placement, BGM ducking,
+// OP/ED jingles, and loudness normalization.
+func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
+	if len(bctx.Clips.Clips) == 0 {
+		return nil, fmt.Errorf("no speech clips to assemble")
+	}
+
+	b := &filterBuilder{}
+
+	// Add clip inputs first (indices 0..N-1)
+	clipInputIdx := make([]int, len(bctx.Clips.Clips))
+	for i, clip := range bctx.Clips.Clips {
+		clipInputIdx[i] = b.addInput(filepath.Join(bctx.ClipsDir, clip.File))
+	}
+
+	// Build speech track (concat with silence between clips)
+	speechLabel := buildSpeechConcat(b, bctx.Clips.Clips, clipInputIdx, bctx.PauseSec)
+
+	// If BGM is configured, split speech so it can be used as sidechain
+	hasBGM := len(bctx.Assets.BGM) > 0
+	currentLabel := speechLabel
+
+	if hasBGM {
+		b.addFilter(fmt.Sprintf("%sasplit=2[speech_mix][speech_duck]", speechLabel))
+		currentLabel = "[speech_mix]"
+	}
+
+	// SE placement: add each SE as a separate input (even if the same file is used
+	// multiple times) so that no stream label is reused in filter_complex.
+	events := computeSEEvents(bctx.Script, bctx.Clips.Clips, bctx.PauseSec)
+	for i, ev := range events {
+		entry, ok := bctx.Assets.SE[ev.seName]
+		if !ok {
+			continue
+		}
+		seIdx := b.addInput(entry.File)
+		delayedLabel := fmt.Sprintf("[se%d]", i)
+		nextLabel := fmt.Sprintf("[after_se%d]", i)
+		b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f,adelay=%d|%d%s",
+			seIdx, entry.Volume, ev.offsetMs, ev.offsetMs, delayedLabel))
+		b.addFilter(fmt.Sprintf("%s%samix=inputs=2:duration=first:normalize=0%s",
+			currentLabel, delayedLabel, nextLabel))
+		currentLabel = nextLabel
+	}
+
+	// OP jingle: afade in, mix with speech (duration=longest so speech continues after jingle)
+	if opEntry, ok := bctx.Assets.Jingle["op"]; ok {
+		opIdx := b.addInput(opEntry.File)
+		opLabel := fmt.Sprintf("[op%d]", opIdx)
+		if opEntry.FadeIn > 0 {
+			b.addFilter(fmt.Sprintf("[%d:a]afade=t=in:d=%.3f%s", opIdx, opEntry.FadeIn, opLabel))
+		} else {
+			opLabel = fmt.Sprintf("[%d:a]", opIdx)
+		}
+		nextLabel := "[after_op]"
+		b.addFilter(fmt.Sprintf("%s%samix=inputs=2:duration=longest:normalize=0%s",
+			opLabel, currentLabel, nextLabel))
+		currentLabel = nextLabel
+	}
+
+	// ED jingle: afade out (reverse trick), mix with speech
+	if edEntry, ok := bctx.Assets.Jingle["ed"]; ok {
+		edIdx := b.addInput(edEntry.File)
+		edLabel := fmt.Sprintf("[ed%d]", edIdx)
+		if edEntry.FadeOut > 0 {
+			// Reverse → fade in → reverse = fade out from end
+			b.addFilter(fmt.Sprintf("[%d:a]areverse,afade=t=in:d=%.3f,areverse%s",
+				edIdx, edEntry.FadeOut, edLabel))
+		} else {
+			edLabel = fmt.Sprintf("[%d:a]", edIdx)
+		}
+		if edEntry.FadeIn > 0 {
+			fadedLabel := fmt.Sprintf("[ed%d_fi]", edIdx)
+			b.addFilter(fmt.Sprintf("%safade=t=in:d=%.3f%s", edLabel, edEntry.FadeIn, fadedLabel))
+			edLabel = fadedLabel
+		}
+		nextLabel := "[after_ed]"
+		b.addFilter(fmt.Sprintf("%s%samix=inputs=2:duration=longest:normalize=0%s",
+			currentLabel, edLabel, nextLabel))
+		currentLabel = nextLabel
+	}
+
+	// BGM: aloop + volume + sidechaincompress ducking
+	if hasBGM {
+		var bgmEntry config.BGMEntry
+		for _, e := range bctx.Assets.BGM {
+			bgmEntry = e
+			break
+		}
+		bgmIdx := b.addInput(bgmEntry.File)
+		bgmLabel := fmt.Sprintf("[bgm%d_vol]", bgmIdx)
+		if bgmEntry.Loop {
+			b.addFilter(fmt.Sprintf("[%d:a]aloop=loop=-1:size=999999,volume=%.2f%s",
+				bgmIdx, bgmEntry.Volume, bgmLabel))
+		} else {
+			b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f%s", bgmIdx, bgmEntry.Volume, bgmLabel))
+		}
+		if bgmEntry.DuckRatio > 0 {
+			b.addFilter(fmt.Sprintf("%s[speech_duck]sidechaincompress=threshold=0.02:ratio=%.1f[bgm_ducked]",
+				bgmLabel, bgmEntry.DuckRatio))
+			b.addFilter(fmt.Sprintf("%s[bgm_ducked]amix=inputs=2:duration=first:normalize=0[after_bgm]",
+				currentLabel))
+		} else {
+			b.addFilter(fmt.Sprintf("%s%samix=inputs=2:duration=first:normalize=0[after_bgm]",
+				currentLabel, bgmLabel))
+		}
+		currentLabel = "[after_bgm]"
+	}
+
+	// Loudnorm (EBU R128)
+	b.addFilter(fmt.Sprintf("%sloudnorm=I=-16:TP=-1.5:LRA=11[out]", currentLabel))
+
+	return &FFmpegArgs{
+		Inputs:        b.inputs,
+		FilterComplex: strings.Join(b.filters, ";"),
+		OutputArgs:    []string{"-map", "[out]", "-c:a", "libmp3lame", "-q:a", "2"},
+		OutputPath:    bctx.OutPath,
+	}, nil
+}
+
+// buildSpeechConcat generates filter entries for concatenating clips with silence between them.
+func buildSpeechConcat(b *filterBuilder, clips []model.ClipMeta, inputIdx []int, pauseSec float64) string {
+	if len(clips) == 1 {
+		return fmt.Sprintf("[%d:a]", inputIdx[0])
+	}
+
+	var parts []string
+	for i := range clips {
+		parts = append(parts, fmt.Sprintf("[%d:a]", inputIdx[i]))
+		if i < len(clips)-1 {
+			b.addFilter(fmt.Sprintf("anullsrc=cl=stereo:r=44100,atrim=d=%.3f[p%d]", pauseSec, i))
+			parts = append(parts, fmt.Sprintf("[p%d]", i))
+		}
+	}
+	n := 2*len(clips) - 1
+	b.addFilter(fmt.Sprintf("%sconcat=n=%d:v=0:a=1[speech]", strings.Join(parts, ""), n))
+	return "[speech]"
+}
+
+// computeSEEvents processes the script to determine the timeline offset of each SE segment.
+// The offset is measured in milliseconds from the start of the assembled audio.
+func computeSEEvents(script model.Script, clips []model.ClipMeta, pauseSec float64) []seEvent {
+	var events []seEvent
+	clipIdx := 0
+	offsetMs := 0.0
+
+	for _, seg := range script.Segments {
+		switch seg.Type {
+		case model.SegmentTypeSpeech:
+			if clipIdx < len(clips) {
+				offsetMs += clips[clipIdx].DurationSec * 1000
+				clipIdx++
+			}
+			offsetMs += pauseSec * 1000
+		case model.SegmentTypeSE:
+			events = append(events, seEvent{
+				seName:   seg.SEName,
+				offsetMs: int(offsetMs),
+			})
+		}
+	}
+	return events
+}

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -1,0 +1,398 @@
+package assemble
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+func TestBuildFFmpegArgs_NoClips_Error(t *testing.T) {
+	ctx := BuildContext{
+		Script:   model.Script{},
+		Clips:    model.ClipsMeta{Clips: make([]model.ClipMeta, 0)},
+		ClipsDir: "/clips",
+		Assets:   config.AssetsConfig{},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	_, err := BuildFFmpegArgs(ctx)
+	if err == nil {
+		t.Error("expected error for no clips, got nil")
+	}
+}
+
+func TestBuildFFmpegArgs_SingleClip(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets:   config.AssetsConfig{},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(args.Inputs) < 1 || args.Inputs[0] != filepath.Join("/clips", "clip_000.wav") {
+		t.Errorf("clip input not found, inputs: %v", args.Inputs)
+	}
+	if !strings.Contains(args.FilterComplex, "[0:a]") {
+		t.Errorf("filter_complex missing [0:a]: %s", args.FilterComplex)
+	}
+	if !strings.Contains(args.FilterComplex, "loudnorm") {
+		t.Errorf("filter_complex missing loudnorm: %s", args.FilterComplex)
+	}
+	if args.OutputPath != "/out.mp3" {
+		t.Errorf("output path: got %s, want /out.mp3", args.OutputPath)
+	}
+	foundCodec := false
+	for _, a := range args.OutputArgs {
+		if a == "libmp3lame" {
+			foundCodec = true
+		}
+	}
+	if !foundCodec {
+		t.Errorf("libmp3lame not in output args: %v", args.OutputArgs)
+	}
+}
+
+func TestBuildFFmpegArgs_MultipleClipsWithPauses(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "A"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "guest", Text: "B"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "C"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 1.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 1.5},
+				{Index: 2, File: "clip_002.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets:   config.AssetsConfig{},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(args.Inputs) < 3 {
+		t.Errorf("expected at least 3 inputs, got %d: %v", len(args.Inputs), args.Inputs)
+	}
+	if !strings.Contains(args.FilterComplex, "anullsrc") {
+		t.Errorf("filter_complex missing anullsrc for pauses: %s", args.FilterComplex)
+	}
+	if !strings.Contains(args.FilterComplex, "concat") {
+		t.Errorf("filter_complex missing concat: %s", args.FilterComplex)
+	}
+}
+
+func TestBuildFFmpegArgs_SESegment(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
+				{Type: model.SegmentTypeSE, SEName: "chime"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "main"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			SE: map[string]config.SEEntry{
+				"chime": {File: "/assets/chime.wav", Volume: 0.8},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundSE := false
+	for _, inp := range args.Inputs {
+		if inp == "/assets/chime.wav" {
+			foundSE = true
+		}
+	}
+	if !foundSE {
+		t.Errorf("SE input /assets/chime.wav not found in inputs: %v", args.Inputs)
+	}
+	if !strings.Contains(args.FilterComplex, "adelay") {
+		t.Errorf("filter_complex missing adelay for SE: %s", args.FilterComplex)
+	}
+	if !strings.Contains(args.FilterComplex, "amix") {
+		t.Errorf("filter_complex missing amix for SE: %s", args.FilterComplex)
+	}
+}
+
+func TestBuildFFmpegArgs_UnknownSEIgnored(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hi"},
+				{Type: model.SegmentTypeSE, SEName: "unknown_se"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 1.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets:   config.AssetsConfig{SE: map[string]config.SEEntry{}},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	_, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Errorf("unexpected error for unknown SE: %v", err)
+	}
+}
+
+func TestBuildFFmpegArgs_BGM(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			BGM: map[string]config.BGMEntry{
+				"main": {File: "/assets/bgm.mp3", Volume: 0.3, DuckRatio: 4.0, Loop: true},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundBGM := false
+	for _, inp := range args.Inputs {
+		if inp == "/assets/bgm.mp3" {
+			foundBGM = true
+		}
+	}
+	if !foundBGM {
+		t.Errorf("BGM input /assets/bgm.mp3 not found in inputs: %v", args.Inputs)
+	}
+	if !strings.Contains(args.FilterComplex, "aloop") {
+		t.Errorf("filter_complex missing aloop for BGM: %s", args.FilterComplex)
+	}
+	if !strings.Contains(args.FilterComplex, "sidechaincompress") {
+		t.Errorf("filter_complex missing sidechaincompress for BGM: %s", args.FilterComplex)
+	}
+}
+
+func TestBuildFFmpegArgs_OPJingle(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			Jingle: map[string]config.JingleEntry{
+				"op": {File: "/assets/op.wav", FadeIn: 0.5, FadeOut: 1.0},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundOP := false
+	for _, inp := range args.Inputs {
+		if inp == "/assets/op.wav" {
+			foundOP = true
+		}
+	}
+	if !foundOP {
+		t.Errorf("OP jingle input not found in inputs: %v", args.Inputs)
+	}
+	if !strings.Contains(args.FilterComplex, "afade") {
+		t.Errorf("filter_complex missing afade for OP jingle: %s", args.FilterComplex)
+	}
+}
+
+func TestBuildFFmpegArgs_EDJingle(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "bye"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			Jingle: map[string]config.JingleEntry{
+				"ed": {File: "/assets/ed.wav", FadeIn: 0.3, FadeOut: 1.5},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundED := false
+	for _, inp := range args.Inputs {
+		if inp == "/assets/ed.wav" {
+			foundED = true
+		}
+	}
+	if !foundED {
+		t.Errorf("ED jingle input not found in inputs: %v", args.Inputs)
+	}
+	if !strings.Contains(args.FilterComplex, "afade") {
+		t.Errorf("filter_complex missing afade for ED jingle: %s", args.FilterComplex)
+	}
+}
+
+func TestComputeSEEvents_PositionsAfterSpeech(t *testing.T) {
+	script := model.Script{
+		Segments: []model.ScriptSegment{
+			{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "first"},
+			{Type: model.SegmentTypeSE, SEName: "chime"},
+			{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "second"},
+		},
+	}
+	clips := []model.ClipMeta{
+		{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+		{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
+	}
+
+	events := computeSEEvents(script, clips, 0.5)
+
+	if len(events) != 1 {
+		t.Fatalf("expected 1 SE event, got %d", len(events))
+	}
+	if events[0].seName != "chime" {
+		t.Errorf("se name: got %s, want chime", events[0].seName)
+	}
+	// After clip_000 (2.0s) + pause (0.5s) = 2500ms
+	wantMs := int((2.0 + 0.5) * 1000)
+	if events[0].offsetMs != wantMs {
+		t.Errorf("SE offset: got %d ms, want %d ms", events[0].offsetMs, wantMs)
+	}
+}
+
+func TestBuildFFmpegArgs_DuplicateSEUsesDistinctInputs(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
+				{Type: model.SegmentTypeSE, SEName: "chime"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "middle"},
+				{Type: model.SegmentTypeSE, SEName: "chime"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "end"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 1.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 1.0},
+				{Index: 2, File: "clip_002.wav", DurationSec: 1.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			SE: map[string]config.SEEntry{
+				"chime": {File: "/assets/chime.wav", Volume: 0.8},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Count how many times chime.wav appears as input
+	chimeCount := 0
+	for _, inp := range args.Inputs {
+		if inp == "/assets/chime.wav" {
+			chimeCount++
+		}
+	}
+	// Each SE usage must be a distinct input to avoid stream label reuse in filter_complex
+	if chimeCount != 2 {
+		t.Errorf("chime.wav input count: got %d, want 2 (one per SE usage)", chimeCount)
+	}
+}
+
+func TestComputeSEEvents_NoSE(t *testing.T) {
+	script := model.Script{
+		Segments: []model.ScriptSegment{
+			{Type: model.SegmentTypeSpeech, Text: "only speech"},
+		},
+	}
+	clips := []model.ClipMeta{
+		{Index: 0, File: "clip_000.wav", DurationSec: 1.0},
+	}
+
+	events := computeSEEvents(script, clips, 0.3)
+	if len(events) != 0 {
+		t.Errorf("expected 0 SE events, got %d", len(events))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,10 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
+	"github.com/canpok1/vox-radio/internal/assemble"
+	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/synth"
 )
@@ -15,7 +18,7 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "Usage: vox-radio <command>")
-		fmt.Fprintln(os.Stderr, "Commands: synth")
+		fmt.Fprintln(os.Stderr, "Commands: synth, assemble")
 		os.Exit(1)
 	}
 
@@ -23,6 +26,10 @@ func main() {
 	case "synth":
 		if err := runSynth(os.Args[2:]); err != nil {
 			log.Fatalf("synth: %v", err)
+		}
+	case "assemble":
+		if err := runAssemble(os.Args[2:]); err != nil {
+			log.Fatalf("assemble: %v", err)
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
@@ -77,5 +84,73 @@ func runSynth(args []string) error {
 	}
 
 	fmt.Printf("synthesized %d clips to %s\n", len(meta.Clips), *outDir)
+	return nil
+}
+
+func runAssemble(args []string) error {
+	fs := flag.NewFlagSet("assemble", flag.ContinueOnError)
+	in := fs.String("in", "", "input script.json path (required)")
+	clipsDir := fs.String("clips", "", "directory containing clips.json and WAV files (required)")
+	out := fs.String("out", "", "output mp3 path (required)")
+	configDir := fs.String("config", "", "config directory for assets (optional)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: vox-radio assemble --in <script.json> --clips <dir> --out <mp3>")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *in == "" {
+		fs.Usage()
+		return fmt.Errorf("--in is required")
+	}
+	if *clipsDir == "" {
+		fs.Usage()
+		return fmt.Errorf("--clips is required")
+	}
+	if *out == "" {
+		fs.Usage()
+		return fmt.Errorf("--out is required")
+	}
+
+	scriptData, err := os.ReadFile(*in)
+	if err != nil {
+		return fmt.Errorf("read script: %w", err)
+	}
+	var script model.Script
+	if err := json.Unmarshal(scriptData, &script); err != nil {
+		return fmt.Errorf("parse script: %w", err)
+	}
+
+	clipsData, err := os.ReadFile(filepath.Join(*clipsDir, "clips.json"))
+	if err != nil {
+		return fmt.Errorf("read clips.json: %w", err)
+	}
+	var clips model.ClipsMeta
+	if err := json.Unmarshal(clipsData, &clips); err != nil {
+		return fmt.Errorf("parse clips.json: %w", err)
+	}
+
+	var assetsConfig config.AssetsConfig
+	var showConfig model.ShowConfig
+	if *configDir != "" {
+		cfg, err := config.Load(*configDir)
+		if err != nil {
+			return fmt.Errorf("load config: %w", err)
+		}
+		assetsConfig = cfg.Assets
+		showConfig = cfg.Show
+	} else {
+		showConfig = model.ShowConfig{SegmentPauseSec: 0.3}
+	}
+
+	a := assemble.New(assetsConfig, showConfig)
+	result, err := a.Run(context.Background(), script, clips, *clipsDir, *out)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("assembled episode: duration=%.1fs, bytes=%d\n", result.DurationSec, result.Bytes)
 	return nil
 }


### PR DESCRIPTION
## Summary

- `internal/assemble` パッケージを新規追加（TDD実装）
  - `BuildFFmpegArgs`: script/clips/assets から単一 `filter_complex` を構築
    - speech concat（`anullsrc` + `concat`）
    - SE 配置（`adelay` + `amix`、同名SE重複使用時も別入力で安全）
    - BGM ループ + 音量 + ダッキング（`aloop` + `sidechaincompress`）
    - OP/ED ジングル（`afade` + `areverse` フェード）
    - ラウドネス正規化（`loudnorm` EBU R128）→ mp3 エンコード
  - `Assembler.Run`: ffmpeg/ffprobe 呼び出しと duration/bytes 計測（ffmpeg/ffprobe を注入可能な設計でテスト容易）
- `vox-radio assemble` サブコマンドを追加
  - `--in <script.json> --clips <dir> --out <mp3> [--config <dir>]`

## Test plan

- [x] `make test` 全通過（`internal/assemble` 14テスト含む）
- [x] `make fmt` / `make lint` 0指摘
- 受け入れ条件「固定入力から mp3 を生成し duration/bytes を出力できる」はローカル実行で ffmpeg が必要（#13）

Closes #7

---
🤖 Generated with [Claude Code](https://claude.ai/code)