### PR TITLE
feat: publish — episodes.json更新・feed.xml生成・local公開

### DIFF
--- a/internal/publish/feed/feed.go
+++ b/internal/publish/feed/feed.go
@@ -1,0 +1,122 @@
+package feed
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"text/template"
+	"time"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+const rfc1123Z = "Mon, 02 Jan 2006 15:04:05 -0700"
+
+const feedTmplStr = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>{{x .Title}}</title>
+    <description>{{x .Description}}</description>
+    <language>{{x .Language}}</language>
+    <link>{{x .Link}}</link>
+    <itunes:author>{{x .Author}}</itunes:author>
+    <itunes:category text="{{x .Category}}"/>
+    <itunes:explicit>{{x .Explicit}}</itunes:explicit>
+    <itunes:image href="{{x .CoverImageURL}}"/>
+{{- range .Items}}
+    <item>
+      <guid isPermaLink="false">{{x .GUID}}</guid>
+      <title>{{x .Title}}</title>
+      <description>{{x .Description}}</description>
+      <pubDate>{{x .PubDate}}</pubDate>
+      <enclosure url="{{x .AudioURL}}" length="{{.Bytes}}" type="audio/mpeg"/>
+      <itunes:duration>{{x .Duration}}</itunes:duration>
+    </item>
+{{- end}}
+  </channel>
+</rss>`
+
+var feedTmpl = template.Must(template.New("feed").Funcs(template.FuncMap{
+	"x": xmlEscape,
+}).Parse(feedTmplStr))
+
+type channelData struct {
+	Title         string
+	Description   string
+	Language      string
+	Link          string
+	Author        string
+	Category      string
+	Explicit      string
+	CoverImageURL string
+	Items         []itemData
+}
+
+type itemData struct {
+	GUID        string
+	Title       string
+	Description string
+	PubDate     string
+	AudioURL    string
+	Bytes       int64
+	Duration    string
+}
+
+func Generate(cfg config.PodcastConfig, episodes model.Episodes) ([]byte, error) {
+	items := make([]itemData, len(episodes.Episodes))
+	for i, ep := range episodes.Episodes {
+		pubDate, err := formatPubDate(ep.PubDate)
+		if err != nil {
+			return nil, fmt.Errorf("episode %s: format pubDate: %w", ep.GUID, err)
+		}
+		items[i] = itemData{
+			GUID:        ep.GUID,
+			Title:       ep.Title,
+			Description: ep.Description,
+			PubDate:     pubDate,
+			AudioURL:    ep.AudioURL,
+			Bytes:       ep.Bytes,
+			Duration:    ep.Duration,
+		}
+	}
+
+	explicit := "no"
+	if cfg.Explicit {
+		explicit = "yes"
+	}
+
+	data := channelData{
+		Title:         cfg.Title,
+		Description:   cfg.Description,
+		Language:      cfg.Language,
+		Link:          cfg.SiteURL,
+		Author:        cfg.Author,
+		Category:      cfg.Category,
+		Explicit:      explicit,
+		CoverImageURL: cfg.CoverImageURL,
+		Items:         items,
+	}
+
+	var buf bytes.Buffer
+	if err := feedTmpl.Execute(&buf, data); err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+func formatPubDate(pubDate string) (string, error) {
+	t, err := time.Parse(time.RFC3339, pubDate)
+	if err != nil {
+		return "", fmt.Errorf("parse %q: %w", pubDate, err)
+	}
+	return t.UTC().Format(rfc1123Z), nil
+}
+
+func xmlEscape(s string) (string, error) {
+	var buf bytes.Buffer
+	if err := xml.EscapeText(&buf, []byte(s)); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/internal/publish/feed/feed_test.go
+++ b/internal/publish/feed/feed_test.go
@@ -1,0 +1,139 @@
+package feed_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/publish/feed"
+)
+
+var testPodcast = config.PodcastConfig{
+	Title:         "今日のテックニュース",
+	Description:   "毎日5分のニュースラジオ",
+	Language:      "ja",
+	Author:        "vox-radio",
+	Category:      "News",
+	Explicit:      false,
+	CoverImageURL: "https://example.github.io/vox-radio/cover.jpg",
+	SiteURL:       "https://example.github.io/vox-radio/",
+	MaxItems:      7,
+}
+
+func TestGenerate_GoldenTest(t *testing.T) {
+	episodes := model.Episodes{
+		Episodes: []model.Episode{
+			{
+				GUID:        "episode-2026-05-30",
+				Title:       "2026-05-30 今日のテックニュース",
+				Description: "本日の話題は新型AIチップとオープンソースの動向です",
+				PubDate:     "2026-05-30T21:00:00Z",
+				AudioURL:    "https://example.github.io/vox-radio/audio/episode_2026-05-30.mp3",
+				Bytes:       5242880,
+				Duration:    "00:05:12",
+			},
+		},
+	}
+
+	got, err := feed.Generate(testPodcast, episodes)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	goldenPath := "testdata/golden/feed.xml"
+	if os.Getenv("UPDATE_GOLDEN") == "1" {
+		if err := os.MkdirAll("testdata/golden", 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(goldenPath, got, 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		return
+	}
+
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden %s: %v", goldenPath, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("feed.xml mismatch:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestGenerate_EmptyEpisodes(t *testing.T) {
+	episodes := model.Episodes{Episodes: make([]model.Episode, 0)}
+
+	got, err := feed.Generate(testPodcast, episodes)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !bytes.Contains(got, []byte(`<?xml version="1.0" encoding="UTF-8"?>`)) {
+		t.Error("missing XML declaration")
+	}
+	if !bytes.Contains(got, []byte(`<title>今日のテックニュース</title>`)) {
+		t.Error("missing channel title")
+	}
+	if bytes.Contains(got, []byte(`<item>`)) {
+		t.Error("unexpected <item> for empty episodes")
+	}
+}
+
+func TestGenerate_XMLEscaping(t *testing.T) {
+	podcast := config.PodcastConfig{
+		Title:       "Test & Show",
+		Description: "A show with <special> chars",
+		Language:    "en",
+		SiteURL:     "https://example.com/",
+	}
+	episodes := model.Episodes{Episodes: make([]model.Episode, 0)}
+
+	got, err := feed.Generate(podcast, episodes)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !bytes.Contains(got, []byte("Test &amp; Show")) {
+		t.Errorf("& should be escaped to &amp;, got:\n%s", got)
+	}
+	if bytes.Contains(got, []byte("<special>")) {
+		t.Error("< > should be XML-escaped")
+	}
+	if !bytes.Contains(got, []byte("&lt;special&gt;")) {
+		t.Errorf("< > should be escaped to &lt;&gt;, got:\n%s", got)
+	}
+}
+
+func TestGenerate_InvalidPubDate(t *testing.T) {
+	episodes := model.Episodes{
+		Episodes: []model.Episode{
+			{
+				GUID:    "episode-bad",
+				PubDate: "not-a-date",
+			},
+		},
+	}
+
+	_, err := feed.Generate(testPodcast, episodes)
+	if err == nil {
+		t.Error("expected error for invalid pub_date")
+	}
+}
+
+func TestGenerate_ExplicitYes(t *testing.T) {
+	podcast := config.PodcastConfig{
+		Title:    "Explicit Show",
+		Language: "en",
+		SiteURL:  "https://example.com/",
+		Explicit: true,
+	}
+	episodes := model.Episodes{Episodes: make([]model.Episode, 0)}
+
+	got, err := feed.Generate(podcast, episodes)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !bytes.Contains(got, []byte("<itunes:explicit>yes</itunes:explicit>")) {
+		t.Errorf("expected explicit=yes, got:\n%s", got)
+	}
+}

--- a/internal/publish/feed/testdata/golden/feed.xml
+++ b/internal/publish/feed/testdata/golden/feed.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>今日のテックニュース</title>
+    <description>毎日5分のニュースラジオ</description>
+    <language>ja</language>
+    <link>https://example.github.io/vox-radio/</link>
+    <itunes:author>vox-radio</itunes:author>
+    <itunes:category text="News"/>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:image href="https://example.github.io/vox-radio/cover.jpg"/>
+    <item>
+      <guid isPermaLink="false">episode-2026-05-30</guid>
+      <title>2026-05-30 今日のテックニュース</title>
+      <description>本日の話題は新型AIチップとオープンソースの動向です</description>
+      <pubDate>Sat, 30 May 2026 21:00:00 +0000</pubDate>
+      <enclosure url="https://example.github.io/vox-radio/audio/episode_2026-05-30.mp3" length="5242880" type="audio/mpeg"/>
+      <itunes:duration>00:05:12</itunes:duration>
+    </item>
+  </channel>
+</rss>

--- a/internal/publish/hosting/local/local.go
+++ b/internal/publish/hosting/local/local.go
@@ -1,0 +1,107 @@
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+// Hosting implements hosting.Hosting using the local filesystem.
+type Hosting struct {
+	dir     string
+	baseURL string
+}
+
+// New creates a local Hosting that stores files under dir and constructs
+// public URLs with the given baseURL prefix (trailing slash is trimmed).
+func New(dir, baseURL string) *Hosting {
+	return &Hosting{
+		dir:     dir,
+		baseURL: strings.TrimRight(baseURL, "/"),
+	}
+}
+
+func (h *Hosting) PutAudio(_ context.Context, name string, r io.Reader) (string, error) {
+	audioDir := filepath.Join(h.dir, "audio")
+	if err := os.MkdirAll(audioDir, 0o755); err != nil {
+		return "", fmt.Errorf("create audio dir: %w", err)
+	}
+
+	path := filepath.Join(audioDir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("create audio file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return "", fmt.Errorf("write audio: %w", err)
+	}
+
+	return h.baseURL + "/audio/" + name, nil
+}
+
+func (h *Hosting) PutFeed(_ context.Context, feedXML []byte) (string, error) {
+	if err := os.MkdirAll(h.dir, 0o755); err != nil {
+		return "", fmt.Errorf("create dir: %w", err)
+	}
+
+	path := filepath.Join(h.dir, "feed.xml")
+	if err := os.WriteFile(path, feedXML, 0o644); err != nil {
+		return "", fmt.Errorf("write feed.xml: %w", err)
+	}
+
+	return h.baseURL + "/feed.xml", nil
+}
+
+func (h *Hosting) LoadEpisodes(_ context.Context) (model.Episodes, error) {
+	path := filepath.Join(h.dir, "episodes.json")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return model.Episodes{Episodes: make([]model.Episode, 0)}, nil
+	}
+	if err != nil {
+		return model.Episodes{}, fmt.Errorf("read episodes.json: %w", err)
+	}
+
+	var eps model.Episodes
+	if err := json.Unmarshal(data, &eps); err != nil {
+		return model.Episodes{}, fmt.Errorf("parse episodes.json: %w", err)
+	}
+	if eps.Episodes == nil {
+		eps.Episodes = make([]model.Episode, 0)
+	}
+	return eps, nil
+}
+
+func (h *Hosting) SaveEpisodes(_ context.Context, e model.Episodes) error {
+	if err := os.MkdirAll(h.dir, 0o755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal episodes: %w", err)
+	}
+
+	path := filepath.Join(h.dir, "episodes.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write episodes.json: %w", err)
+	}
+	return nil
+}
+
+func (h *Hosting) DeleteAudio(_ context.Context, name string) error {
+	path := filepath.Join(h.dir, "audio", name)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete audio %s: %w", name, err)
+	}
+	return nil
+}

--- a/internal/publish/hosting/local/local_test.go
+++ b/internal/publish/hosting/local/local_test.go
@@ -1,0 +1,205 @@
+package local_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/publish/hosting/local"
+)
+
+func TestHosting_PutAudio(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com")
+
+	content := []byte("fake mp3 data")
+	url, err := h.PutAudio(context.Background(), "episode_2026-05-30.mp3", bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("PutAudio: %v", err)
+	}
+
+	want := "https://example.com/audio/episode_2026-05-30.mp3"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "audio", "episode_2026-05-30.mp3"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("file content mismatch")
+	}
+}
+
+func TestHosting_PutAudio_TrailingSlash(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com/vox-radio/")
+
+	url, err := h.PutAudio(context.Background(), "ep.mp3", bytes.NewReader([]byte{}))
+	if err != nil {
+		t.Fatalf("PutAudio: %v", err)
+	}
+
+	if strings.Contains(url, "//audio/") {
+		t.Errorf("double slash in url: %q", url)
+	}
+	want := "https://example.com/vox-radio/audio/ep.mp3"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+}
+
+func TestHosting_PutFeed(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com")
+
+	feedXML := []byte(`<?xml version="1.0"?><rss></rss>`)
+	url, err := h.PutFeed(context.Background(), feedXML)
+	if err != nil {
+		t.Fatalf("PutFeed: %v", err)
+	}
+
+	want := "https://example.com/feed.xml"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "feed.xml"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !bytes.Equal(got, feedXML) {
+		t.Errorf("feed.xml content mismatch")
+	}
+}
+
+func TestHosting_LoadEpisodes_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com")
+
+	eps, err := h.LoadEpisodes(context.Background())
+	if err != nil {
+		t.Fatalf("LoadEpisodes (not found): %v", err)
+	}
+	if len(eps.Episodes) != 0 {
+		t.Errorf("expected empty episodes, got %d", len(eps.Episodes))
+	}
+}
+
+func TestHosting_LoadEpisodes_Existing(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com")
+
+	data := `{"episodes":[{"guid":"ep1","title":"T","description":"D","pub_date":"2026-05-30T21:00:00Z","audio_url":"https://example.com/a.mp3","bytes":100,"duration":"00:01:00"}]}`
+	if err := os.WriteFile(filepath.Join(dir, "episodes.json"), []byte(data), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	eps, err := h.LoadEpisodes(context.Background())
+	if err != nil {
+		t.Fatalf("LoadEpisodes: %v", err)
+	}
+	if len(eps.Episodes) != 1 {
+		t.Fatalf("expected 1 episode, got %d", len(eps.Episodes))
+	}
+	if eps.Episodes[0].GUID != "ep1" {
+		t.Errorf("guid = %q, want ep1", eps.Episodes[0].GUID)
+	}
+}
+
+func TestHosting_SaveEpisodes(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com")
+
+	eps := model.Episodes{
+		Episodes: []model.Episode{
+			{
+				GUID:        "ep1",
+				Title:       "T",
+				Description: "D",
+				PubDate:     "2026-05-30T21:00:00Z",
+				AudioURL:    "https://example.com/a.mp3",
+				Bytes:       100,
+				Duration:    "00:01:00",
+			},
+		},
+	}
+	if err := h.SaveEpisodes(context.Background(), eps); err != nil {
+		t.Fatalf("SaveEpisodes: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "episodes.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), "ep1") {
+		t.Errorf("episodes.json does not contain ep1")
+	}
+}
+
+func TestHosting_SaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com")
+
+	original := model.Episodes{
+		Episodes: []model.Episode{
+			{
+				GUID:        "ep1",
+				Title:       "T",
+				Description: "D",
+				PubDate:     "2026-05-30T21:00:00Z",
+				AudioURL:    "https://example.com/a.mp3",
+				Bytes:       100,
+				Duration:    "00:01:00",
+			},
+		},
+	}
+	if err := h.SaveEpisodes(context.Background(), original); err != nil {
+		t.Fatalf("SaveEpisodes: %v", err)
+	}
+
+	loaded, err := h.LoadEpisodes(context.Background())
+	if err != nil {
+		t.Fatalf("LoadEpisodes: %v", err)
+	}
+	if len(loaded.Episodes) != 1 {
+		t.Fatalf("expected 1 episode, got %d", len(loaded.Episodes))
+	}
+	if loaded.Episodes[0].GUID != "ep1" {
+		t.Errorf("guid = %q, want ep1", loaded.Episodes[0].GUID)
+	}
+}
+
+func TestHosting_DeleteAudio(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com")
+
+	audioDir := filepath.Join(dir, "audio")
+	if err := os.MkdirAll(audioDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(audioDir, "ep.mp3"), []byte("data"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := h.DeleteAudio(context.Background(), "ep.mp3"); err != nil {
+		t.Fatalf("DeleteAudio: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(audioDir, "ep.mp3")); !os.IsNotExist(err) {
+		t.Error("file should be deleted")
+	}
+}
+
+func TestHosting_DeleteAudio_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	h := local.New(dir, "https://example.com")
+
+	if err := h.DeleteAudio(context.Background(), "nonexistent.mp3"); err != nil {
+		t.Errorf("DeleteAudio (non-existent) should be no-op: %v", err)
+	}
+}

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -1,0 +1,151 @@
+package publish
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/publish/feed"
+	"github.com/canpok1/vox-radio/internal/publish/hosting"
+)
+
+// Publisher orchestrates the publish pipeline.
+type Publisher struct {
+	Hosting     hosting.Hosting
+	Podcast     config.PodcastConfig
+	getDuration func(path string) (float64, error)
+	getFileSize func(path string) (int64, error)
+}
+
+// Options holds optional parameters for a publish run.
+type Options struct {
+	Date        string // YYYY-MM-DD; defaults to today
+	Title       string // defaults to "<date> <podcast.title>"
+	Description string
+}
+
+// New creates a Publisher using ffprobe for duration detection.
+func New(h hosting.Hosting, podcast config.PodcastConfig) *Publisher {
+	return &Publisher{
+		Hosting:     h,
+		Podcast:     podcast,
+		getDuration: ffprobeDuration,
+		getFileSize: osFileSize,
+	}
+}
+
+// Run executes the publish pipeline: upload mp3, update episodes.json, generate and upload feed.xml.
+func (p *Publisher) Run(ctx context.Context, mp3Path string, opts Options) error {
+	date := opts.Date
+	if date == "" {
+		date = time.Now().UTC().Format("2006-01-02")
+	}
+
+	pubTime, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return fmt.Errorf("parse date %q: %w", date, err)
+	}
+
+	title := opts.Title
+	if title == "" {
+		title = date + " " + p.Podcast.Title
+	}
+
+	fileBytes, err := p.getFileSize(mp3Path)
+	if err != nil {
+		return fmt.Errorf("get file size: %w", err)
+	}
+
+	durSec, err := p.getDuration(mp3Path)
+	if err != nil {
+		return fmt.Errorf("get duration: %w", err)
+	}
+
+	f, err := os.Open(mp3Path)
+	if err != nil {
+		return fmt.Errorf("open mp3: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	audioName := "episode_" + date + ".mp3"
+	audioURL, err := p.Hosting.PutAudio(ctx, audioName, f)
+	if err != nil {
+		return fmt.Errorf("put audio: %w", err)
+	}
+
+	episodes, err := p.Hosting.LoadEpisodes(ctx)
+	if err != nil {
+		return fmt.Errorf("load episodes: %w", err)
+	}
+
+	newEp := model.Episode{
+		GUID:        "episode-" + date,
+		Title:       title,
+		Description: opts.Description,
+		PubDate:     pubTime.Format(time.RFC3339),
+		AudioURL:    audioURL,
+		Bytes:       fileBytes,
+		Duration:    formatDuration(durSec),
+	}
+
+	episodes.Episodes = append([]model.Episode{newEp}, episodes.Episodes...)
+
+	if p.Podcast.MaxItems > 0 && len(episodes.Episodes) > p.Podcast.MaxItems {
+		episodes.Episodes = episodes.Episodes[:p.Podcast.MaxItems]
+	}
+
+	if err := p.Hosting.SaveEpisodes(ctx, episodes); err != nil {
+		return fmt.Errorf("save episodes: %w", err)
+	}
+
+	feedXML, err := feed.Generate(p.Podcast, episodes)
+	if err != nil {
+		return fmt.Errorf("generate feed: %w", err)
+	}
+
+	if _, err := p.Hosting.PutFeed(ctx, feedXML); err != nil {
+		return fmt.Errorf("put feed: %w", err)
+	}
+
+	return nil
+}
+
+func formatDuration(sec float64) string {
+	total := int(sec)
+	h := total / 3600
+	m := (total % 3600) / 60
+	s := total % 60
+	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
+}
+
+func ffprobeDuration(path string) (float64, error) {
+	out, err := exec.Command("ffprobe",
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		path,
+	).Output()
+	if err != nil {
+		return 0, fmt.Errorf("ffprobe: %w", err)
+	}
+	s := strings.TrimSpace(string(out))
+	dur, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse duration %q: %w", s, err)
+	}
+	return dur, nil
+}
+
+func osFileSize(path string) (int64, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}

--- a/internal/publish/publish_test.go
+++ b/internal/publish/publish_test.go
@@ -1,0 +1,247 @@
+package publish
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+type mockHosting struct {
+	episodes  model.Episodes
+	savedEps  model.Episodes
+	savedFeed []byte
+	audioName string
+}
+
+func (m *mockHosting) PutAudio(_ context.Context, name string, r io.Reader) (string, error) {
+	m.audioName = name
+	if _, err := io.Copy(io.Discard, r); err != nil {
+		return "", err
+	}
+	return "https://example.com/audio/" + name, nil
+}
+
+func (m *mockHosting) PutFeed(_ context.Context, feedXML []byte) (string, error) {
+	m.savedFeed = feedXML
+	return "https://example.com/feed.xml", nil
+}
+
+func (m *mockHosting) LoadEpisodes(_ context.Context) (model.Episodes, error) {
+	return m.episodes, nil
+}
+
+func (m *mockHosting) SaveEpisodes(_ context.Context, e model.Episodes) error {
+	m.savedEps = e
+	return nil
+}
+
+func (m *mockHosting) DeleteAudio(_ context.Context, _ string) error {
+	return nil
+}
+
+func newTestPublisher(h *mockHosting) *Publisher {
+	podcast := config.PodcastConfig{
+		Title:         "今日のテックニュース",
+		Description:   "毎日5分のニュースラジオ",
+		Language:      "ja",
+		Author:        "vox-radio",
+		Category:      "News",
+		Explicit:      false,
+		CoverImageURL: "https://example.github.io/vox-radio/cover.jpg",
+		SiteURL:       "https://example.github.io/vox-radio/",
+		MaxItems:      7,
+	}
+	return &Publisher{
+		Hosting:     h,
+		Podcast:     podcast,
+		getDuration: func(string) (float64, error) { return 312.0, nil },
+		getFileSize: func(string) (int64, error) { return 5242880, nil },
+	}
+}
+
+func newTempMP3(t *testing.T) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "*.mp3")
+	if err != nil {
+		t.Fatalf("create temp mp3: %v", err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestPublisher_Run_CreatesEpisode(t *testing.T) {
+	h := &mockHosting{episodes: model.Episodes{Episodes: make([]model.Episode, 0)}}
+	p := newTestPublisher(h)
+
+	if err := p.Run(context.Background(), newTempMP3(t), Options{Date: "2026-05-30"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.savedEps.Episodes) != 1 {
+		t.Fatalf("expected 1 episode, got %d", len(h.savedEps.Episodes))
+	}
+	ep := h.savedEps.Episodes[0]
+	if ep.GUID != "episode-2026-05-30" {
+		t.Errorf("guid = %q, want episode-2026-05-30", ep.GUID)
+	}
+	if ep.Duration != "00:05:12" {
+		t.Errorf("duration = %q, want 00:05:12", ep.Duration)
+	}
+	if ep.Bytes != 5242880 {
+		t.Errorf("bytes = %d, want 5242880", ep.Bytes)
+	}
+	if ep.PubDate != "2026-05-30T00:00:00Z" {
+		t.Errorf("pub_date = %q, want 2026-05-30T00:00:00Z", ep.PubDate)
+	}
+}
+
+func TestPublisher_Run_AudioName(t *testing.T) {
+	h := &mockHosting{episodes: model.Episodes{Episodes: make([]model.Episode, 0)}}
+	p := newTestPublisher(h)
+
+	if err := p.Run(context.Background(), newTempMP3(t), Options{Date: "2026-05-30"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if h.audioName != "episode_2026-05-30.mp3" {
+		t.Errorf("audioName = %q, want episode_2026-05-30.mp3", h.audioName)
+	}
+}
+
+func TestPublisher_Run_DefaultTitle(t *testing.T) {
+	h := &mockHosting{episodes: model.Episodes{Episodes: make([]model.Episode, 0)}}
+	p := newTestPublisher(h)
+
+	if err := p.Run(context.Background(), newTempMP3(t), Options{Date: "2026-05-30"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	ep := h.savedEps.Episodes[0]
+	want := "2026-05-30 今日のテックニュース"
+	if ep.Title != want {
+		t.Errorf("title = %q, want %q", ep.Title, want)
+	}
+}
+
+func TestPublisher_Run_CustomTitle(t *testing.T) {
+	h := &mockHosting{episodes: model.Episodes{Episodes: make([]model.Episode, 0)}}
+	p := newTestPublisher(h)
+
+	opts := Options{Date: "2026-05-30", Title: "Custom Title", Description: "Custom Desc"}
+	if err := p.Run(context.Background(), newTempMP3(t), opts); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	ep := h.savedEps.Episodes[0]
+	if ep.Title != "Custom Title" {
+		t.Errorf("title = %q, want Custom Title", ep.Title)
+	}
+	if ep.Description != "Custom Desc" {
+		t.Errorf("description = %q, want Custom Desc", ep.Description)
+	}
+}
+
+func TestPublisher_Run_PrependNewest(t *testing.T) {
+	existing := model.Episodes{
+		Episodes: []model.Episode{
+			{GUID: "episode-2026-05-29", Title: "Old", PubDate: "2026-05-29T00:00:00Z"},
+		},
+	}
+	h := &mockHosting{episodes: existing}
+	p := newTestPublisher(h)
+
+	if err := p.Run(context.Background(), newTempMP3(t), Options{Date: "2026-05-30"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.savedEps.Episodes) != 2 {
+		t.Fatalf("expected 2 episodes, got %d", len(h.savedEps.Episodes))
+	}
+	if h.savedEps.Episodes[0].GUID != "episode-2026-05-30" {
+		t.Errorf("newest episode should be first, got %q", h.savedEps.Episodes[0].GUID)
+	}
+}
+
+func TestPublisher_Run_TrimsToMaxItems(t *testing.T) {
+	existing := model.Episodes{
+		Episodes: make([]model.Episode, 7),
+	}
+	for i := range existing.Episodes {
+		existing.Episodes[i] = model.Episode{
+			GUID:    "old",
+			PubDate: "2026-05-01T00:00:00Z",
+		}
+	}
+	h := &mockHosting{episodes: existing}
+	p := newTestPublisher(h) // MaxItems=7
+
+	if err := p.Run(context.Background(), newTempMP3(t), Options{Date: "2026-05-30"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.savedEps.Episodes) != 7 {
+		t.Errorf("expected 7 episodes after trim, got %d", len(h.savedEps.Episodes))
+	}
+	if h.savedEps.Episodes[0].GUID != "episode-2026-05-30" {
+		t.Errorf("newest episode should be first")
+	}
+}
+
+func TestPublisher_Run_MaxItemsZero_NoTrim(t *testing.T) {
+	existing := model.Episodes{
+		Episodes: []model.Episode{
+			{GUID: "ep1", PubDate: "2026-05-01T00:00:00Z"},
+			{GUID: "ep2", PubDate: "2026-05-02T00:00:00Z"},
+		},
+	}
+	h := &mockHosting{episodes: existing}
+	podcast := config.PodcastConfig{
+		Title:    "Test",
+		MaxItems: 0, // 0 = unlimited
+	}
+	p := &Publisher{
+		Hosting:     h,
+		Podcast:     podcast,
+		getDuration: func(string) (float64, error) { return 60.0, nil },
+		getFileSize: func(string) (int64, error) { return 1024, nil },
+	}
+
+	if err := p.Run(context.Background(), newTempMP3(t), Options{Date: "2026-05-30"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.savedEps.Episodes) != 3 {
+		t.Errorf("MaxItems=0 should not trim, expected 3 episodes, got %d", len(h.savedEps.Episodes))
+	}
+}
+
+func TestPublisher_Run_GeneratesFeed(t *testing.T) {
+	h := &mockHosting{episodes: model.Episodes{Episodes: make([]model.Episode, 0)}}
+	p := newTestPublisher(h)
+
+	if err := p.Run(context.Background(), newTempMP3(t), Options{Date: "2026-05-30"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.savedFeed) == 0 {
+		t.Error("feed should be generated")
+	}
+	if !bytes.Contains(h.savedFeed, []byte(`<?xml version="1.0" encoding="UTF-8"?>`)) {
+		t.Errorf("feed missing XML declaration, got:\n%s", h.savedFeed)
+	}
+}
+
+func TestPublisher_Run_InvalidDate(t *testing.T) {
+	h := &mockHosting{episodes: model.Episodes{Episodes: make([]model.Episode, 0)}}
+	p := newTestPublisher(h)
+
+	err := p.Run(context.Background(), newTempMP3(t), Options{Date: "not-a-date"})
+	if err == nil {
+		t.Error("expected error for invalid date")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,13 +13,15 @@ import (
 	"github.com/canpok1/vox-radio/internal/collect"
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/publish"
+	"github.com/canpok1/vox-radio/internal/publish/hosting/local"
 	"github.com/canpok1/vox-radio/internal/synth"
 )
 
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "Usage: vox-radio <command>")
-		fmt.Fprintln(os.Stderr, "Commands: collect, synth, assemble")
+		fmt.Fprintln(os.Stderr, "Commands: collect, synth, assemble, publish")
 		os.Exit(1)
 	}
 
@@ -35,6 +37,10 @@ func main() {
 	case "assemble":
 		if err := runAssemble(os.Args[2:]); err != nil {
 			log.Fatalf("assemble: %v", err)
+		}
+	case "publish":
+		if err := runPublish(os.Args[2:]); err != nil {
+			log.Fatalf("publish: %v", err)
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
@@ -201,5 +207,62 @@ func runAssemble(args []string) error {
 	}
 
 	fmt.Printf("assembled episode: duration=%.1fs, bytes=%d\n", result.DurationSec, result.Bytes)
+	return nil
+}
+
+func runPublish(args []string) error {
+	fs := flag.NewFlagSet("publish", flag.ContinueOnError)
+	in := fs.String("in", "", "input mp3 path (required)")
+	date := fs.String("date", "", "episode date YYYY-MM-DD (default: today)")
+	titleFlag := fs.String("title", "", "episode title (default: <date> <podcast.title>)")
+	descFlag := fs.String("description", "", "episode description")
+	configDir := fs.String("config", "config", "config directory containing podcast.yaml")
+	outDir := fs.String("out-dir", "", "output directory for local hosting (required)")
+	baseURL := fs.String("base-url", "", "base URL for audio/feed URLs (default: site_url from podcast.yaml)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: vox-radio publish --in <mp3> --out-dir <dir> [--date <YYYY-MM-DD>] [options]")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *in == "" {
+		fs.Usage()
+		return fmt.Errorf("--in is required")
+	}
+	if *outDir == "" {
+		fs.Usage()
+		return fmt.Errorf("--out-dir is required")
+	}
+
+	cfg, err := config.Load(*configDir)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	siteURL := *baseURL
+	if siteURL == "" {
+		siteURL = cfg.Podcast.SiteURL
+	}
+
+	h := local.New(*outDir, siteURL)
+	publisher := publish.New(h, cfg.Podcast)
+
+	opts := publish.Options{
+		Date:        *date,
+		Title:       *titleFlag,
+		Description: *descFlag,
+	}
+
+	if err := publisher.Run(context.Background(), *in, opts); err != nil {
+		return err
+	}
+
+	effectiveDate := *date
+	if effectiveDate == "" {
+		effectiveDate = "(today)"
+	}
+	fmt.Printf("published episode for %s to %s\n", effectiveDate, *outDir)
 	return nil
 }


### PR DESCRIPTION
## Summary

- `internal/publish/feed`: RSS 2.0 + iTunes拡張フィード生成（`text/template` + `xml.EscapeText`）
- `internal/publish/hosting/local`: ローカルファイルシステム `Hosting` 実装
- `internal/publish/publish.go`: `Publisher` オーケストレーター（mp3 アップロード → episodes.json 更新 → feed.xml 生成・アップロード）
- `main.go`: `vox-radio publish --in <mp3> --out-dir <dir> [--date YYYY-MM-DD]` サブコマンド追加

## 変更詳細

### feed パッケージ
- `Generate(cfg PodcastConfig, episodes Episodes) ([]byte, error)` でRSS 2.0 + iTunes拡張 feed.xml を生成
- XML ゴールデンテスト（`testdata/golden/feed.xml`）
- XMLインジェクション対策: 全フィールドに `xml.EscapeText` を適用

### hosting/local パッケージ
- `Hosting` インターフェースのローカルファイルシステム実装
- `audio/<name>`, `feed.xml`, `episodes.json` を `dir` 配下に保存
- `baseURL + "/audio/<name>"` 形式の URL を返す

### publish パッケージ
- `Publisher.Run(ctx, mp3Path, opts)` で公開パイプライン全体を実行
- TDD実装: mockHosting を使ったユニットテスト

## テスト

- XML ゴールデンテスト（`TestGenerate_GoldenTest`）
- ローカルホスティングの CRUD テスト
- Publisher の各シナリオ（最新エピソード先頭追加、MaxItems トリム、MaxItems=0 無制限など）
- `make fmt` / `make lint` / `make test` すべてパス

Closes #10

---
🤖 Generated with [Claude Code](https://claude.ai/code)