### PR TITLE
feat: prune — 直近N件に絞り古い音声を削除する保持管理

### DIFF
--- a/internal/publish/prune.go
+++ b/internal/publish/prune.go
@@ -1,0 +1,58 @@
+package publish
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path"
+
+	"github.com/canpok1/vox-radio/internal/publish/hosting"
+)
+
+// Pruner trims episodes.json to at most Keep entries and deletes evicted audio files.
+type Pruner struct {
+	Hosting hosting.Hosting
+	Keep    int
+}
+
+// NewPruner creates a Pruner that retains at most keep episodes.
+func NewPruner(h hosting.Hosting, keep int) *Pruner {
+	return &Pruner{Hosting: h, Keep: keep}
+}
+
+// Run loads episodes, removes the oldest beyond Keep, deletes their audio, and saves.
+func (p *Pruner) Run(ctx context.Context) error {
+	eps, err := p.Hosting.LoadEpisodes(ctx)
+	if err != nil {
+		return fmt.Errorf("load episodes: %w", err)
+	}
+
+	if len(eps.Episodes) <= p.Keep {
+		return nil
+	}
+
+	for _, ep := range eps.Episodes[p.Keep:] {
+		name, err := audioBaseName(ep.AudioURL)
+		if err != nil {
+			return fmt.Errorf("parse audio url %q: %w", ep.AudioURL, err)
+		}
+		if err := p.Hosting.DeleteAudio(ctx, name); err != nil {
+			return fmt.Errorf("delete audio %q: %w", name, err)
+		}
+	}
+
+	eps.Episodes = eps.Episodes[:p.Keep]
+	if err := p.Hosting.SaveEpisodes(ctx, eps); err != nil {
+		return fmt.Errorf("save episodes: %w", err)
+	}
+
+	return nil
+}
+
+func audioBaseName(audioURL string) (string, error) {
+	u, err := url.Parse(audioURL)
+	if err != nil {
+		return "", err
+	}
+	return path.Base(u.Path), nil
+}

--- a/internal/publish/prune.go
+++ b/internal/publish/prune.go
@@ -9,6 +9,9 @@ import (
 	"github.com/canpok1/vox-radio/internal/publish/hosting"
 )
 
+// DefaultKeep is the number of episodes retained when no explicit limit is configured.
+const DefaultKeep = 7
+
 // Pruner trims episodes.json to at most Keep entries and deletes evicted audio files.
 type Pruner struct {
 	Hosting hosting.Hosting

--- a/internal/publish/prune_test.go
+++ b/internal/publish/prune_test.go
@@ -114,3 +114,19 @@ func TestPruner_Run_EmptyEpisodes(t *testing.T) {
 		t.Errorf("expected no deletions, got %v", h.deletedAudio)
 	}
 }
+
+func TestPruner_Run_DeletesMultipleExcessEpisodes(t *testing.T) {
+	h := &pruneHosting{episodes: makeTestEpisodes(10)}
+	p := NewPruner(h, 7)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.deletedAudio) != 3 {
+		t.Fatalf("expected 3 deletions, got %d: %v", len(h.deletedAudio), h.deletedAudio)
+	}
+	if len(h.savedEps.Episodes) != 7 {
+		t.Errorf("expected 7 saved episodes, got %d", len(h.savedEps.Episodes))
+	}
+}

--- a/internal/publish/prune_test.go
+++ b/internal/publish/prune_test.go
@@ -1,0 +1,116 @@
+package publish
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+type pruneHosting struct {
+	episodes     model.Episodes
+	savedEps     model.Episodes
+	deletedAudio []string
+}
+
+func (m *pruneHosting) PutAudio(_ context.Context, name string, _ io.Reader) (string, error) {
+	return "https://example.com/audio/" + name, nil
+}
+
+func (m *pruneHosting) PutFeed(_ context.Context, _ []byte) (string, error) {
+	return "https://example.com/feed.xml", nil
+}
+
+func (m *pruneHosting) LoadEpisodes(_ context.Context) (model.Episodes, error) {
+	return m.episodes, nil
+}
+
+func (m *pruneHosting) SaveEpisodes(_ context.Context, e model.Episodes) error {
+	m.savedEps = e
+	return nil
+}
+
+func (m *pruneHosting) DeleteAudio(_ context.Context, name string) error {
+	m.deletedAudio = append(m.deletedAudio, name)
+	return nil
+}
+
+// makeTestEpisodes creates count episodes in newest-first order.
+// Episodes have dates 2026-05-{count} through 2026-05-01.
+func makeTestEpisodes(count int) model.Episodes {
+	eps := model.Episodes{Episodes: make([]model.Episode, count)}
+	for i := 0; i < count; i++ {
+		day := count - i
+		date := fmt.Sprintf("2026-05-%02d", day)
+		eps.Episodes[i] = model.Episode{
+			GUID:     "episode-" + date,
+			PubDate:  date + "T00:00:00Z",
+			AudioURL: "https://example.com/audio/episode_" + date + ".mp3",
+		}
+	}
+	return eps
+}
+
+func TestPruner_Run_NoPruneWhenAtLimit(t *testing.T) {
+	h := &pruneHosting{episodes: makeTestEpisodes(7)}
+	p := NewPruner(h, 7)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.deletedAudio) != 0 {
+		t.Errorf("expected no deletions, got %v", h.deletedAudio)
+	}
+	if len(h.savedEps.Episodes) != 0 {
+		t.Errorf("expected no save when not pruning, got %d episodes", len(h.savedEps.Episodes))
+	}
+}
+
+func TestPruner_Run_DeletesOldestEpisode(t *testing.T) {
+	h := &pruneHosting{episodes: makeTestEpisodes(8)}
+	p := NewPruner(h, 7)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.deletedAudio) != 1 {
+		t.Fatalf("expected 1 deletion, got %d: %v", len(h.deletedAudio), h.deletedAudio)
+	}
+	want := "episode_2026-05-01.mp3"
+	if h.deletedAudio[0] != want {
+		t.Errorf("deleted audio = %q, want %q", h.deletedAudio[0], want)
+	}
+}
+
+func TestPruner_Run_SavesTrimmedEpisodes(t *testing.T) {
+	h := &pruneHosting{episodes: makeTestEpisodes(8)}
+	p := NewPruner(h, 7)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.savedEps.Episodes) != 7 {
+		t.Fatalf("expected 7 saved episodes, got %d", len(h.savedEps.Episodes))
+	}
+	if h.savedEps.Episodes[0].GUID != "episode-2026-05-08" {
+		t.Errorf("newest episode should be first, got %q", h.savedEps.Episodes[0].GUID)
+	}
+}
+
+func TestPruner_Run_EmptyEpisodes(t *testing.T) {
+	h := &pruneHosting{episodes: model.Episodes{Episodes: make([]model.Episode, 0)}}
+	p := NewPruner(h, 7)
+
+	if err := p.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(h.deletedAudio) != 0 {
+		t.Errorf("expected no deletions, got %v", h.deletedAudio)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "Usage: vox-radio <command>")
-		fmt.Fprintln(os.Stderr, "Commands: collect, synth, assemble, publish")
+		fmt.Fprintln(os.Stderr, "Commands: collect, synth, assemble, publish, prune")
 		os.Exit(1)
 	}
 
@@ -41,6 +41,10 @@ func main() {
 	case "publish":
 		if err := runPublish(os.Args[2:]); err != nil {
 			log.Fatalf("publish: %v", err)
+		}
+	case "prune":
+		if err := runPrune(os.Args[2:]); err != nil {
+			log.Fatalf("prune: %v", err)
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
@@ -264,5 +268,49 @@ func runPublish(args []string) error {
 		effectiveDate = "(today)"
 	}
 	fmt.Printf("published episode for %s to %s\n", effectiveDate, *outDir)
+	return nil
+}
+
+func runPrune(args []string) error {
+	fs := flag.NewFlagSet("prune", flag.ContinueOnError)
+	outDir := fs.String("out-dir", "", "output directory for local hosting (required)")
+	configDir := fs.String("config", "config", "config directory containing podcast.yaml")
+	baseURL := fs.String("base-url", "", "base URL for audio/feed URLs (default: site_url from podcast.yaml)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: vox-radio prune --out-dir <dir> [--config <dir>] [--base-url <url>]")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *outDir == "" {
+		fs.Usage()
+		return fmt.Errorf("--out-dir is required")
+	}
+
+	cfg, err := config.Load(*configDir)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	siteURL := *baseURL
+	if siteURL == "" {
+		siteURL = cfg.Podcast.SiteURL
+	}
+
+	keep := cfg.Podcast.MaxItems
+	if keep <= 0 {
+		keep = 7
+	}
+
+	h := local.New(*outDir, siteURL)
+	pruner := publish.NewPruner(h, keep)
+
+	if err := pruner.Run(context.Background()); err != nil {
+		return err
+	}
+
+	fmt.Printf("pruned to %d episodes in %s\n", keep, *outDir)
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -305,9 +305,9 @@ func runPrune(args []string) error {
 	return nil
 }
 
-func resolveSiteURL(flag, configURL string) string {
-	if flag != "" {
-		return flag
+func resolveSiteURL(override, configURL string) string {
+	if override != "" {
+		return override
 	}
 	return configURL
 }

--- a/main.go
+++ b/main.go
@@ -245,12 +245,7 @@ func runPublish(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	siteURL := *baseURL
-	if siteURL == "" {
-		siteURL = cfg.Podcast.SiteURL
-	}
-
-	h := local.New(*outDir, siteURL)
+	h := local.New(*outDir, resolveSiteURL(*baseURL, cfg.Podcast.SiteURL))
 	publisher := publish.New(h, cfg.Podcast)
 
 	opts := publish.Options{
@@ -294,17 +289,12 @@ func runPrune(args []string) error {
 		return fmt.Errorf("load config: %w", err)
 	}
 
-	siteURL := *baseURL
-	if siteURL == "" {
-		siteURL = cfg.Podcast.SiteURL
-	}
-
 	keep := cfg.Podcast.MaxItems
 	if keep <= 0 {
-		keep = 7
+		keep = publish.DefaultKeep
 	}
 
-	h := local.New(*outDir, siteURL)
+	h := local.New(*outDir, resolveSiteURL(*baseURL, cfg.Podcast.SiteURL))
 	pruner := publish.NewPruner(h, keep)
 
 	if err := pruner.Run(context.Background()); err != nil {
@@ -313,4 +303,11 @@ func runPrune(args []string) error {
 
 	fmt.Printf("pruned to %d episodes in %s\n", keep, *outDir)
 	return nil
+}
+
+func resolveSiteURL(flag, configURL string) string {
+	if flag != "" {
+		return flag
+	}
+	return configURL
 }


### PR DESCRIPTION
## Summary

- `internal/publish/prune.go`: `Pruner` 構造体と `Run` メソッドを追加
  - `Hosting.LoadEpisodes` で読み込み、先頭 Keep 件を残し余剰エピソードの音声を `DeleteAudio` で削除
  - `Hosting.SaveEpisodes` で trimmed episodes を保存
  - `publish.DefaultKeep = 7` 定数を定義
- `main.go`: `vox-radio prune` サブコマンドを追加
  - `--out-dir`（必須）, `--config`, `--base-url` オプション
  - Keep 数は `PodcastConfig.MaxItems`（0 の場合は `DefaultKeep=7`）
  - `resolveSiteURL` ヘルパーを追加し `runPublish` / `runPrune` 間の重複を排除

## Test

- `TestPruner_Run_NoPruneWhenAtLimit`: 件数がKeep以下のとき削除・保存なし
- `TestPruner_Run_DeletesOldestEpisode`: 8件→7件、最古エピソードの音声が削除される
- `TestPruner_Run_SavesTrimmedEpisodes`: 7件に絞られた状態で保存される
- `TestPruner_Run_EmptyEpisodes`: 空のエピソードリストでも正常終了
- `TestPruner_Run_DeletesMultipleExcessEpisodes`: 10件→7件、3件削除される

Closes #11

---
🤖 Generated with [Claude Code](https://claude.ai/code)