### PR TITLE
feat: script — 多段LLMパイプライン（summarize/plan/write/direct）

### DIFF
--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -2,10 +2,108 @@ package direct
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/llm"
 )
+
+var seInsertionsSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["se_insertions"],
+  "properties": {
+    "se_insertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["after_line_index", "se_name"],
+        "properties": {
+          "after_line_index": {"type": "integer", "minimum": 0},
+          "se_name":          {"type": "string"},
+          "reason":           {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
 
 type Director interface {
 	Direct(ctx context.Context, lines []model.Line, se model.SECatalog) (model.Script, error)
+}
+
+type seInsertion struct {
+	AfterLineIndex int    `json:"after_line_index"`
+	SEName         string `json:"se_name"`
+	Reason         string `json:"reason,omitempty"`
+}
+
+type seInsertionsResponse struct {
+	SEInsertions []seInsertion `json:"se_insertions"`
+}
+
+type LLMDirector struct {
+	client         llm.Client
+	promptTemplate string
+}
+
+func NewLLMDirector(client llm.Client, promptTemplate string) *LLMDirector {
+	return &LLMDirector{client: client, promptTemplate: promptTemplate}
+}
+
+func (d *LLMDirector) Direct(ctx context.Context, lines []model.Line, se model.SECatalog) (model.Script, error) {
+	linesJSON, err := json.Marshal(model.Lines{Lines: lines})
+	if err != nil {
+		return model.Script{}, fmt.Errorf("marshal lines: %w", err)
+	}
+
+	seJSON, err := json.Marshal(se)
+	if err != nil {
+		return model.Script{}, fmt.Errorf("marshal se catalog: %w", err)
+	}
+
+	prompt := strings.ReplaceAll(d.promptTemplate, "{{lines}}", string(linesJSON))
+	prompt = strings.ReplaceAll(prompt, "{{se_catalog}}", string(seJSON))
+
+	raw, err := d.client.Complete(ctx, llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: seInsertionsSchema,
+	})
+	if err != nil {
+		return model.Script{}, fmt.Errorf("llm complete: %w", err)
+	}
+
+	var resp seInsertionsResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return model.Script{}, fmt.Errorf("unmarshal se insertions: %w", err)
+	}
+
+	return buildScript(lines, resp.SEInsertions), nil
+}
+
+func buildScript(lines []model.Line, insertions []seInsertion) model.Script {
+	insertionMap := make(map[int][]seInsertion, len(insertions))
+	for _, ins := range insertions {
+		insertionMap[ins.AfterLineIndex] = append(insertionMap[ins.AfterLineIndex], ins)
+	}
+
+	segments := make([]model.ScriptSegment, 0, len(lines)+len(insertions))
+	for i, line := range lines {
+		segments = append(segments, model.ScriptSegment{
+			Type:        model.SegmentTypeSpeech,
+			SpeakerRole: line.SpeakerRole,
+			Text:        line.Text,
+		})
+		for _, ins := range insertionMap[i] {
+			segments = append(segments, model.ScriptSegment{
+				Type:   model.SegmentTypeSE,
+				SEName: ins.SEName,
+			})
+		}
+	}
+
+	return model.Script{Segments: segments}
 }

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -48,10 +48,11 @@ type seInsertionsResponse struct {
 type LLMDirector struct {
 	client         llm.Client
 	promptTemplate string
+	temperature    float64
 }
 
-func NewLLMDirector(client llm.Client, promptTemplate string) *LLMDirector {
-	return &LLMDirector{client: client, promptTemplate: promptTemplate}
+func NewLLMDirector(client llm.Client, promptTemplate string, temperature float64) *LLMDirector {
+	return &LLMDirector{client: client, promptTemplate: promptTemplate, temperature: temperature}
 }
 
 func (d *LLMDirector) Direct(ctx context.Context, lines []model.Line, se model.SECatalog) (model.Script, error) {
@@ -69,8 +70,9 @@ func (d *LLMDirector) Direct(ctx context.Context, lines []model.Line, se model.S
 	prompt = strings.ReplaceAll(prompt, "{{se_catalog}}", string(seJSON))
 
 	raw, err := d.client.Complete(ctx, llm.CompletionRequest{
-		Messages:   []llm.Message{{Role: "user", Content: prompt}},
-		JSONSchema: seInsertionsSchema,
+		Messages:    []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema:  seInsertionsSchema,
+		Temperature: d.temperature,
 	})
 	if err != nil {
 		return model.Script{}, fmt.Errorf("llm complete: %w", err)

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -23,7 +23,7 @@ func TestLLMDirector_Direct_NoSEInsertions(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"se_insertions":[]}`),
 	}
-	d := direct.NewLLMDirector(mc, "lines={{lines}} se={{se_catalog}}")
+	d := direct.NewLLMDirector(mc, "lines={{lines}} se={{se_catalog}}", 0)
 
 	lines := []model.Line{
 		{SpeakerRole: "host", Text: "こんにちは"},
@@ -49,7 +49,7 @@ func TestLLMDirector_Direct_WithSEInsertions(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"se_insertions":[{"after_line_index":0,"se_name":"chime","reason":"コーナー開始"}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}")
+	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
 
 	lines := []model.Line{
 		{SpeakerRole: "host", Text: "開始"},
@@ -83,7 +83,7 @@ func TestLLMDirector_Direct_SEAfterLastLine(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"se_insertions":[{"after_line_index":1,"se_name":"transition"}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}")
+	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
 
 	lines := []model.Line{
 		{SpeakerRole: "host", Text: "A"},
@@ -106,7 +106,7 @@ func TestLLMDirector_Direct_SEAfterLastLine(t *testing.T) {
 
 func TestLLMDirector_Direct_LLMError(t *testing.T) {
 	mc := &mockClient{err: context.Canceled}
-	d := direct.NewLLMDirector(mc, "{{lines}}")
+	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
 
 	_, err := d.Direct(context.Background(), nil, model.SECatalog{})
 	if err == nil {
@@ -118,7 +118,7 @@ func TestLLMDirector_Direct_SpeechSegmentFields(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"se_insertions":[]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}")
+	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
 
 	lines := []model.Line{
 		{SpeakerRole: "host", Text: "テストテキスト"},

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -1,0 +1,141 @@
+package direct_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/direct"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+type mockClient struct {
+	response json.RawMessage
+	err      error
+}
+
+func (m *mockClient) Complete(_ context.Context, _ llm.CompletionRequest) (json.RawMessage, error) {
+	return m.response, m.err
+}
+
+func TestLLMDirector_Direct_NoSEInsertions(t *testing.T) {
+	mc := &mockClient{
+		response: json.RawMessage(`{"se_insertions":[]}`),
+	}
+	d := direct.NewLLMDirector(mc, "lines={{lines}} se={{se_catalog}}")
+
+	lines := []model.Line{
+		{SpeakerRole: "host", Text: "こんにちは"},
+		{SpeakerRole: "guest", Text: "よろしく"},
+	}
+	se := model.SECatalog{Names: []string{"chime"}}
+
+	got, err := d.Direct(context.Background(), lines, se)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Segments) != 2 {
+		t.Errorf("Segments: got %d, want 2", len(got.Segments))
+	}
+	for i, seg := range got.Segments {
+		if seg.Type != model.SegmentTypeSpeech {
+			t.Errorf("Segment[%d].Type: got %q, want speech", i, seg.Type)
+		}
+	}
+}
+
+func TestLLMDirector_Direct_WithSEInsertions(t *testing.T) {
+	mc := &mockClient{
+		response: json.RawMessage(`{"se_insertions":[{"after_line_index":0,"se_name":"chime","reason":"コーナー開始"}]}`),
+	}
+	d := direct.NewLLMDirector(mc, "{{lines}}")
+
+	lines := []model.Line{
+		{SpeakerRole: "host", Text: "開始"},
+		{SpeakerRole: "guest", Text: "続き"},
+	}
+	se := model.SECatalog{Names: []string{"chime"}}
+
+	got, err := d.Direct(context.Background(), lines, se)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [speech(host), se(chime), speech(guest)]
+	if len(got.Segments) != 3 {
+		t.Fatalf("Segments: got %d, want 3", len(got.Segments))
+	}
+	if got.Segments[0].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[0].Type: got %q, want speech", got.Segments[0].Type)
+	}
+	if got.Segments[1].Type != model.SegmentTypeSE {
+		t.Errorf("Segment[1].Type: got %q, want se", got.Segments[1].Type)
+	}
+	if got.Segments[1].SEName != "chime" {
+		t.Errorf("Segment[1].SEName: got %q, want chime", got.Segments[1].SEName)
+	}
+	if got.Segments[2].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[2].Type: got %q, want speech", got.Segments[2].Type)
+	}
+}
+
+func TestLLMDirector_Direct_SEAfterLastLine(t *testing.T) {
+	mc := &mockClient{
+		response: json.RawMessage(`{"se_insertions":[{"after_line_index":1,"se_name":"transition"}]}`),
+	}
+	d := direct.NewLLMDirector(mc, "{{lines}}")
+
+	lines := []model.Line{
+		{SpeakerRole: "host", Text: "A"},
+		{SpeakerRole: "guest", Text: "B"},
+	}
+	se := model.SECatalog{Names: []string{"transition"}}
+
+	got, err := d.Direct(context.Background(), lines, se)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [speech, speech, se]
+	if len(got.Segments) != 3 {
+		t.Fatalf("Segments: got %d, want 3", len(got.Segments))
+	}
+	if got.Segments[2].Type != model.SegmentTypeSE {
+		t.Errorf("Segment[2].Type: got %q, want se", got.Segments[2].Type)
+	}
+}
+
+func TestLLMDirector_Direct_LLMError(t *testing.T) {
+	mc := &mockClient{err: context.Canceled}
+	d := direct.NewLLMDirector(mc, "{{lines}}")
+
+	_, err := d.Direct(context.Background(), nil, model.SECatalog{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLLMDirector_Direct_SpeechSegmentFields(t *testing.T) {
+	mc := &mockClient{
+		response: json.RawMessage(`{"se_insertions":[]}`),
+	}
+	d := direct.NewLLMDirector(mc, "{{lines}}")
+
+	lines := []model.Line{
+		{SpeakerRole: "host", Text: "テストテキスト"},
+	}
+
+	got, err := d.Direct(context.Background(), lines, model.SECatalog{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Segments) != 1 {
+		t.Fatalf("Segments: got %d, want 1", len(got.Segments))
+	}
+	seg := got.Segments[0]
+	if seg.SpeakerRole != "host" {
+		t.Errorf("SpeakerRole: got %q, want host", seg.SpeakerRole)
+	}
+	if seg.Text != "テストテキスト" {
+		t.Errorf("Text: got %q, want テストテキスト", seg.Text)
+	}
+}

--- a/internal/script/plan/plan.go
+++ b/internal/script/plan/plan.go
@@ -41,10 +41,11 @@ type Planner interface {
 type LLMPlanner struct {
 	client         llm.Client
 	promptTemplate string
+	temperature    float64
 }
 
-func NewLLMPlanner(client llm.Client, promptTemplate string) *LLMPlanner {
-	return &LLMPlanner{client: client, promptTemplate: promptTemplate}
+func NewLLMPlanner(client llm.Client, promptTemplate string, temperature float64) *LLMPlanner {
+	return &LLMPlanner{client: client, promptTemplate: promptTemplate, temperature: temperature}
 }
 
 func (p *LLMPlanner) Plan(ctx context.Context, summaries []model.Summary, show model.ShowConfig) (model.Rundown, error) {
@@ -62,8 +63,9 @@ func (p *LLMPlanner) Plan(ctx context.Context, summaries []model.Summary, show m
 	prompt = strings.ReplaceAll(prompt, "{{show_config}}", string(showJSON))
 
 	raw, err := p.client.Complete(ctx, llm.CompletionRequest{
-		Messages:   []llm.Message{{Role: "user", Content: prompt}},
-		JSONSchema: rundownSchema,
+		Messages:    []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema:  rundownSchema,
+		Temperature: p.temperature,
 	})
 	if err != nil {
 		return model.Rundown{}, fmt.Errorf("llm complete: %w", err)

--- a/internal/script/plan/plan.go
+++ b/internal/script/plan/plan.go
@@ -2,10 +2,77 @@ package plan
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/llm"
 )
+
+var rundownSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["corners"],
+  "properties": {
+    "corners": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["title", "topic", "points", "target_chars", "summary_urls"],
+        "properties": {
+          "title":       {"type": "string"},
+          "topic":       {"type": "string"},
+          "points":      {"type": "array", "items": {"type": "string"}},
+          "target_chars": {"type": "integer"},
+          "summary_urls": {"type": "array", "items": {"type": "string"}}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
 
 type Planner interface {
 	Plan(ctx context.Context, summaries []model.Summary, show model.ShowConfig) (model.Rundown, error)
+}
+
+type LLMPlanner struct {
+	client         llm.Client
+	promptTemplate string
+}
+
+func NewLLMPlanner(client llm.Client, promptTemplate string) *LLMPlanner {
+	return &LLMPlanner{client: client, promptTemplate: promptTemplate}
+}
+
+func (p *LLMPlanner) Plan(ctx context.Context, summaries []model.Summary, show model.ShowConfig) (model.Rundown, error) {
+	summariesJSON, err := json.Marshal(model.Summaries{Summaries: summaries})
+	if err != nil {
+		return model.Rundown{}, fmt.Errorf("marshal summaries: %w", err)
+	}
+
+	showJSON, err := json.Marshal(show)
+	if err != nil {
+		return model.Rundown{}, fmt.Errorf("marshal show config: %w", err)
+	}
+
+	prompt := strings.ReplaceAll(p.promptTemplate, "{{summaries}}", string(summariesJSON))
+	prompt = strings.ReplaceAll(prompt, "{{show_config}}", string(showJSON))
+
+	raw, err := p.client.Complete(ctx, llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: rundownSchema,
+	})
+	if err != nil {
+		return model.Rundown{}, fmt.Errorf("llm complete: %w", err)
+	}
+
+	var rundown model.Rundown
+	if err := json.Unmarshal(raw, &rundown); err != nil {
+		return model.Rundown{}, fmt.Errorf("unmarshal rundown: %w", err)
+	}
+
+	return rundown, nil
 }

--- a/internal/script/plan/plan_test.go
+++ b/internal/script/plan/plan_test.go
@@ -1,0 +1,87 @@
+package plan_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+	"github.com/canpok1/vox-radio/internal/script/plan"
+)
+
+type mockClient struct {
+	response json.RawMessage
+	err      error
+	captured []llm.CompletionRequest
+}
+
+func (m *mockClient) Complete(_ context.Context, req llm.CompletionRequest) (json.RawMessage, error) {
+	m.captured = append(m.captured, req)
+	return m.response, m.err
+}
+
+var rundownJSON = json.RawMessage(`{
+  "corners": [
+    {
+      "title": "AIコーナー",
+      "topic": "AI動向",
+      "points": ["ポイント1"],
+      "target_chars": 500,
+      "summary_urls": ["https://example.com/1"]
+    }
+  ]
+}`)
+
+func TestLLMPlanner_Plan_Success(t *testing.T) {
+	mc := &mockClient{response: rundownJSON}
+	p := plan.NewLLMPlanner(mc, "summaries={{summaries}} config={{show_config}}")
+
+	summaries := []model.Summary{
+		{URL: "https://example.com/1", Summary: "要約", Points: []string{"p1"}},
+	}
+	show := model.ShowConfig{TargetChars: 1000, Corners: 1}
+
+	got, err := p.Plan(context.Background(), summaries, show)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Corners) != 1 {
+		t.Errorf("Corners: got %d, want 1", len(got.Corners))
+	}
+	if got.Corners[0].Title != "AIコーナー" {
+		t.Errorf("Title: got %q, want AIコーナー", got.Corners[0].Title)
+	}
+}
+
+func TestLLMPlanner_Plan_PromptContainsSummariesAndConfig(t *testing.T) {
+	mc := &mockClient{response: rundownJSON}
+	p := plan.NewLLMPlanner(mc, "s={{summaries}} c={{show_config}}")
+
+	summaries := []model.Summary{{URL: "https://example.com/1", Summary: "要約", Points: []string{"p1"}}}
+	show := model.ShowConfig{TargetChars: 1000, Corners: 1, Persona: "ホスト"}
+
+	_, _ = p.Plan(context.Background(), summaries, show)
+
+	if len(mc.captured) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	prompt := mc.captured[0].Messages[0].Content
+	if !strings.Contains(prompt, "要約") {
+		t.Errorf("prompt should contain summaries, got: %s", prompt)
+	}
+	if !strings.Contains(prompt, "ホスト") {
+		t.Errorf("prompt should contain show config persona, got: %s", prompt)
+	}
+}
+
+func TestLLMPlanner_Plan_LLMError(t *testing.T) {
+	mc := &mockClient{err: context.Canceled}
+	p := plan.NewLLMPlanner(mc, "{{summaries}}")
+
+	_, err := p.Plan(context.Background(), nil, model.ShowConfig{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/script/plan/plan_test.go
+++ b/internal/script/plan/plan_test.go
@@ -36,7 +36,7 @@ var rundownJSON = json.RawMessage(`{
 
 func TestLLMPlanner_Plan_Success(t *testing.T) {
 	mc := &mockClient{response: rundownJSON}
-	p := plan.NewLLMPlanner(mc, "summaries={{summaries}} config={{show_config}}")
+	p := plan.NewLLMPlanner(mc, "summaries={{summaries}} config={{show_config}}", 0)
 
 	summaries := []model.Summary{
 		{URL: "https://example.com/1", Summary: "要約", Points: []string{"p1"}},
@@ -57,7 +57,7 @@ func TestLLMPlanner_Plan_Success(t *testing.T) {
 
 func TestLLMPlanner_Plan_PromptContainsSummariesAndConfig(t *testing.T) {
 	mc := &mockClient{response: rundownJSON}
-	p := plan.NewLLMPlanner(mc, "s={{summaries}} c={{show_config}}")
+	p := plan.NewLLMPlanner(mc, "s={{summaries}} c={{show_config}}", 0)
 
 	summaries := []model.Summary{{URL: "https://example.com/1", Summary: "要約", Points: []string{"p1"}}}
 	show := model.ShowConfig{TargetChars: 1000, Corners: 1, Persona: "ホスト"}
@@ -78,7 +78,7 @@ func TestLLMPlanner_Plan_PromptContainsSummariesAndConfig(t *testing.T) {
 
 func TestLLMPlanner_Plan_LLMError(t *testing.T) {
 	mc := &mockClient{err: context.Canceled}
-	p := plan.NewLLMPlanner(mc, "{{summaries}}")
+	p := plan.NewLLMPlanner(mc, "{{summaries}}", 0)
 
 	_, err := p.Plan(context.Background(), nil, model.ShowConfig{})
 	if err == nil {

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -65,11 +65,11 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, articles []model.Arti
 		return model.Script{}, err
 	}
 
-	cornerLines, err := g.writeAll(ctx, rundown, summaries, show)
+	cornerLines, summaryByURL, err := g.writeAll(ctx, rundown, summaries, show)
 	if err != nil {
 		return model.Script{}, err
 	}
-	cornerLines = g.regenIfNeeded(ctx, cornerLines, rundown, summaries, show)
+	cornerLines = g.regenIfNeeded(ctx, cornerLines, rundown, summaryByURL, show)
 	allLines := flatten(cornerLines)
 	if err := g.saveIntermediate("lines.json", model.Lines{Lines: allLines}); err != nil {
 		return model.Script{}, err
@@ -95,25 +95,22 @@ func (g *LLMScriptGenerator) summarizeAll(ctx context.Context, articles []model.
 	return summaries, nil
 }
 
-func (g *LLMScriptGenerator) writeAll(ctx context.Context, rundown model.Rundown, summaries []model.Summary, show model.ShowConfig) ([][]model.Line, error) {
-	summaryByURL := make(map[string]model.Summary, len(summaries))
-	for _, s := range summaries {
-		summaryByURL[s.URL] = s
-	}
+func (g *LLMScriptGenerator) writeAll(ctx context.Context, rundown model.Rundown, summaries []model.Summary, show model.ShowConfig) ([][]model.Line, map[string]model.Summary, error) {
+	summaryByURL := SummaryByURL(summaries)
 
 	result := make([][]model.Line, len(rundown.Corners))
 	for i, corner := range rundown.Corners {
-		relevant := cornerSummaries(corner, summaryByURL)
+		relevant := CornerSummaries(corner, summaryByURL)
 		lines, err := g.writer.Write(ctx, corner, relevant, show)
 		if err != nil {
-			return nil, fmt.Errorf("write corner %q: %w", corner.Title, err)
+			return nil, nil, fmt.Errorf("write corner %q: %w", corner.Title, err)
 		}
 		result[i] = lines
 	}
-	return result, nil
+	return result, summaryByURL, nil
 }
 
-func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]model.Line, rundown model.Rundown, summaries []model.Summary, show model.ShowConfig) [][]model.Line {
+func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]model.Line, rundown model.Rundown, summaryByURL map[string]model.Summary, show model.ShowConfig) [][]model.Line {
 	if show.TargetChars <= 0 || len(rundown.Corners) == 0 {
 		return cornerLines
 	}
@@ -123,14 +120,9 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 		totalChars += countChars(lines)
 	}
 
-	deviation := float64(abs(totalChars-show.TargetChars)) / float64(show.TargetChars)
+	deviation := float64(max(totalChars-show.TargetChars, show.TargetChars-totalChars)) / float64(show.TargetChars)
 	if deviation <= regenThreshold {
 		return cornerLines
-	}
-
-	summaryByURL := make(map[string]model.Summary, len(summaries))
-	for _, s := range summaries {
-		summaryByURL[s.URL] = s
 	}
 
 	worstIdx := 0
@@ -140,7 +132,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 			continue
 		}
 		actual := countChars(cornerLines[i])
-		dev := float64(abs(actual-corner.TargetChars)) / float64(corner.TargetChars)
+		dev := float64(max(actual-corner.TargetChars, corner.TargetChars-actual)) / float64(corner.TargetChars)
 		if dev > worstDev {
 			worstDev = dev
 			worstIdx = i
@@ -148,7 +140,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 	}
 
 	corner := rundown.Corners[worstIdx]
-	relevant := cornerSummaries(corner, summaryByURL)
+	relevant := CornerSummaries(corner, summaryByURL)
 	if newLines, err := g.writer.Write(ctx, corner, relevant, show); err == nil {
 		cornerLines[worstIdx] = newLines
 	}
@@ -170,7 +162,17 @@ func (g *LLMScriptGenerator) saveIntermediate(filename string, v any) error {
 	return nil
 }
 
-func cornerSummaries(corner model.Corner, byURL map[string]model.Summary) []model.Summary {
+// SummaryByURL builds a URL-keyed lookup map from a summaries slice.
+func SummaryByURL(summaries []model.Summary) map[string]model.Summary {
+	m := make(map[string]model.Summary, len(summaries))
+	for _, s := range summaries {
+		m[s.URL] = s
+	}
+	return m
+}
+
+// CornerSummaries returns the summaries relevant to a corner, in summary_urls order.
+func CornerSummaries(corner model.Corner, byURL map[string]model.Summary) []model.Summary {
 	result := make([]model.Summary, 0, len(corner.SummaryURLs))
 	for _, u := range corner.SummaryURLs {
 		if s, ok := byURL[u]; ok {
@@ -198,11 +200,4 @@ func countChars(lines []model.Line) int {
 		total += utf8.RuneCountInString(l.Text)
 	}
 	return total
-}
-
-func abs(x int) int {
-	if x < 0 {
-		return -x
-	}
-	return x
 }

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -2,10 +2,207 @@ package script
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"unicode/utf8"
 
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/direct"
+	"github.com/canpok1/vox-radio/internal/script/plan"
+	"github.com/canpok1/vox-radio/internal/script/summarize"
+	"github.com/canpok1/vox-radio/internal/script/write"
 )
+
+const regenThreshold = 0.20
 
 type ScriptGenerator interface {
 	Generate(ctx context.Context, articles []model.Article, show model.ShowConfig) (model.Script, error)
+}
+
+type LLMScriptGenerator struct {
+	summarizer summarize.Summarizer
+	planner    plan.Planner
+	writer     write.Writer
+	director   direct.Director
+	seCatalog  model.SECatalog
+	workDir    string
+}
+
+func NewLLMScriptGenerator(
+	s summarize.Summarizer,
+	p plan.Planner,
+	w write.Writer,
+	d direct.Director,
+	seCatalog model.SECatalog,
+	workDir string,
+) *LLMScriptGenerator {
+	return &LLMScriptGenerator{
+		summarizer: s,
+		planner:    p,
+		writer:     w,
+		director:   d,
+		seCatalog:  seCatalog,
+		workDir:    workDir,
+	}
+}
+
+func (g *LLMScriptGenerator) Generate(ctx context.Context, articles []model.Article, show model.ShowConfig) (model.Script, error) {
+	summaries, err := g.summarizeAll(ctx, articles)
+	if err != nil {
+		return model.Script{}, err
+	}
+	if err := g.saveIntermediate("summaries.json", model.Summaries{Summaries: summaries}); err != nil {
+		return model.Script{}, err
+	}
+
+	rundown, err := g.planner.Plan(ctx, summaries, show)
+	if err != nil {
+		return model.Script{}, fmt.Errorf("plan: %w", err)
+	}
+	if err := g.saveIntermediate("rundown.json", rundown); err != nil {
+		return model.Script{}, err
+	}
+
+	cornerLines, err := g.writeAll(ctx, rundown, summaries, show)
+	if err != nil {
+		return model.Script{}, err
+	}
+	cornerLines = g.regenIfNeeded(ctx, cornerLines, rundown, summaries, show)
+	allLines := flatten(cornerLines)
+	if err := g.saveIntermediate("lines.json", model.Lines{Lines: allLines}); err != nil {
+		return model.Script{}, err
+	}
+
+	scr, err := g.director.Direct(ctx, allLines, g.seCatalog)
+	if err != nil {
+		return model.Script{}, fmt.Errorf("direct: %w", err)
+	}
+
+	return scr, nil
+}
+
+func (g *LLMScriptGenerator) summarizeAll(ctx context.Context, articles []model.Article) ([]model.Summary, error) {
+	summaries := make([]model.Summary, 0, len(articles))
+	for _, a := range articles {
+		s, err := g.summarizer.Summarize(ctx, a)
+		if err != nil {
+			return nil, fmt.Errorf("summarize %q: %w", a.URL, err)
+		}
+		summaries = append(summaries, s)
+	}
+	return summaries, nil
+}
+
+func (g *LLMScriptGenerator) writeAll(ctx context.Context, rundown model.Rundown, summaries []model.Summary, show model.ShowConfig) ([][]model.Line, error) {
+	summaryByURL := make(map[string]model.Summary, len(summaries))
+	for _, s := range summaries {
+		summaryByURL[s.URL] = s
+	}
+
+	result := make([][]model.Line, len(rundown.Corners))
+	for i, corner := range rundown.Corners {
+		relevant := cornerSummaries(corner, summaryByURL)
+		lines, err := g.writer.Write(ctx, corner, relevant, show)
+		if err != nil {
+			return nil, fmt.Errorf("write corner %q: %w", corner.Title, err)
+		}
+		result[i] = lines
+	}
+	return result, nil
+}
+
+func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]model.Line, rundown model.Rundown, summaries []model.Summary, show model.ShowConfig) [][]model.Line {
+	if show.TargetChars <= 0 || len(rundown.Corners) == 0 {
+		return cornerLines
+	}
+
+	totalChars := 0
+	for _, lines := range cornerLines {
+		totalChars += countChars(lines)
+	}
+
+	deviation := float64(abs(totalChars-show.TargetChars)) / float64(show.TargetChars)
+	if deviation <= regenThreshold {
+		return cornerLines
+	}
+
+	summaryByURL := make(map[string]model.Summary, len(summaries))
+	for _, s := range summaries {
+		summaryByURL[s.URL] = s
+	}
+
+	worstIdx := 0
+	worstDev := 0.0
+	for i, corner := range rundown.Corners {
+		if corner.TargetChars <= 0 {
+			continue
+		}
+		actual := countChars(cornerLines[i])
+		dev := float64(abs(actual-corner.TargetChars)) / float64(corner.TargetChars)
+		if dev > worstDev {
+			worstDev = dev
+			worstIdx = i
+		}
+	}
+
+	corner := rundown.Corners[worstIdx]
+	relevant := cornerSummaries(corner, summaryByURL)
+	if newLines, err := g.writer.Write(ctx, corner, relevant, show); err == nil {
+		cornerLines[worstIdx] = newLines
+	}
+	return cornerLines
+}
+
+func (g *LLMScriptGenerator) saveIntermediate(filename string, v any) error {
+	if g.workDir == "" {
+		return nil
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", filename, err)
+	}
+	path := filepath.Join(g.workDir, filename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", filename, err)
+	}
+	return nil
+}
+
+func cornerSummaries(corner model.Corner, byURL map[string]model.Summary) []model.Summary {
+	result := make([]model.Summary, 0, len(corner.SummaryURLs))
+	for _, u := range corner.SummaryURLs {
+		if s, ok := byURL[u]; ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+func flatten(lines [][]model.Line) []model.Line {
+	total := 0
+	for _, l := range lines {
+		total += len(l)
+	}
+	result := make([]model.Line, 0, total)
+	for _, l := range lines {
+		result = append(result, l...)
+	}
+	return result
+}
+
+func countChars(lines []model.Line) int {
+	total := 0
+	for _, l := range lines {
+		total += utf8.RuneCountInString(l.Text)
+	}
+	return total
+}
+
+func abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
 }

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -138,6 +138,10 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 			worstIdx = i
 		}
 	}
+	// All corners have TargetChars=0 — nothing to regenerate.
+	if worstDev == 0 {
+		return cornerLines
+	}
 
 	corner := rundown.Corners[worstIdx]
 	relevant := CornerSummaries(corner, summaryByURL)

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -1,0 +1,220 @@
+package script_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script"
+)
+
+// mock implementations
+
+type mockSummarizer struct {
+	byURL map[string]model.Summary
+	err   error
+}
+
+func (m *mockSummarizer) Summarize(_ context.Context, a model.Article) (model.Summary, error) {
+	if m.err != nil {
+		return model.Summary{}, m.err
+	}
+	if s, ok := m.byURL[a.URL]; ok {
+		return s, nil
+	}
+	return model.Summary{URL: a.URL, Summary: "default", Points: []string{"p1"}}, nil
+}
+
+type mockPlanner struct {
+	rundown model.Rundown
+	err     error
+}
+
+func (m *mockPlanner) Plan(_ context.Context, _ []model.Summary, _ model.ShowConfig) (model.Rundown, error) {
+	return m.rundown, m.err
+}
+
+type mockWriter struct {
+	lines     []model.Line
+	err       error
+	callCount int
+	responses [][]model.Line
+}
+
+func (m *mockWriter) Write(_ context.Context, _ model.Corner, _ []model.Summary, _ model.ShowConfig) ([]model.Line, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if len(m.responses) > 0 && m.callCount < len(m.responses) {
+		resp := m.responses[m.callCount]
+		m.callCount++
+		return resp, nil
+	}
+	m.callCount++
+	return m.lines, nil
+}
+
+type mockDirector struct {
+	script model.Script
+	err    error
+}
+
+func (m *mockDirector) Direct(_ context.Context, lines []model.Line, _ model.SECatalog) (model.Script, error) {
+	if m.err != nil {
+		return model.Script{}, m.err
+	}
+	if m.script.Segments != nil {
+		return m.script, nil
+	}
+	segs := make([]model.ScriptSegment, len(lines))
+	for i, l := range lines {
+		segs[i] = model.ScriptSegment{Type: model.SegmentTypeSpeech, SpeakerRole: l.SpeakerRole, Text: l.Text}
+	}
+	return model.Script{Segments: segs}, nil
+}
+
+func TestLLMScriptGenerator_Generate_HappyPath(t *testing.T) {
+	articles := []model.Article{
+		{URL: "https://example.com/1", Title: "AI", Body: "本文"},
+	}
+	rundown := model.Rundown{
+		Corners: []model.Corner{
+			{Title: "AIコーナー", Topic: "AI", Points: []string{"p1"}, TargetChars: 100, SummaryURLs: []string{"https://example.com/1"}},
+		},
+	}
+	lines := []model.Line{
+		{SpeakerRole: "host", Text: "テスト"},
+	}
+
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockPlanner{rundown: rundown},
+		&mockWriter{lines: lines},
+		&mockDirector{},
+		model.SECatalog{Names: []string{"chime"}},
+		"",
+	)
+
+	got, err := gen.Generate(context.Background(), articles, model.ShowConfig{TargetChars: 500, Corners: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Segments) == 0 {
+		t.Error("expected non-empty segments")
+	}
+}
+
+func TestLLMScriptGenerator_Generate_SummarizeError(t *testing.T) {
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{err: context.Canceled},
+		&mockPlanner{},
+		&mockWriter{},
+		&mockDirector{},
+		model.SECatalog{},
+		"",
+	)
+
+	_, err := gen.Generate(context.Background(), []model.Article{{URL: "u"}}, model.ShowConfig{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLLMScriptGenerator_Generate_PlanError(t *testing.T) {
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockPlanner{err: context.Canceled},
+		&mockWriter{},
+		&mockDirector{},
+		model.SECatalog{},
+		"",
+	)
+
+	_, err := gen.Generate(context.Background(), []model.Article{{URL: "u"}}, model.ShowConfig{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLLMScriptGenerator_Generate_WriteError(t *testing.T) {
+	rundown := model.Rundown{
+		Corners: []model.Corner{{Title: "C", Topic: "T", TargetChars: 100}},
+	}
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockPlanner{rundown: rundown},
+		&mockWriter{err: context.Canceled},
+		&mockDirector{},
+		model.SECatalog{},
+		"",
+	)
+
+	_, err := gen.Generate(context.Background(), []model.Article{{URL: "u"}}, model.ShowConfig{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLLMScriptGenerator_Generate_CharCountRegen(t *testing.T) {
+	// TargetChars=100, but writer first returns 1 char total (huge deficit)
+	// should trigger regen of the worst corner
+	articles := []model.Article{{URL: "https://example.com/1"}}
+	rundown := model.Rundown{
+		Corners: []model.Corner{
+			{Title: "C", Topic: "T", TargetChars: 100, SummaryURLs: []string{"https://example.com/1"}},
+		},
+	}
+	shortLines := []model.Line{{SpeakerRole: "host", Text: "A"}}                                                  // 1 char
+	longLines := []model.Line{{SpeakerRole: "host", Text: "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえお"}} // ~45 chars, closer to 100
+
+	mw := &mockWriter{
+		responses: [][]model.Line{shortLines, longLines},
+	}
+
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockPlanner{rundown: rundown},
+		mw,
+		&mockDirector{},
+		model.SECatalog{},
+		"",
+	)
+
+	_, err := gen.Generate(context.Background(), articles, model.ShowConfig{TargetChars: 100, Corners: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Writer should have been called twice (once initial, once regen)
+	if mw.callCount < 2 {
+		t.Errorf("expected writer called at least 2 times, got %d", mw.callCount)
+	}
+}
+
+func TestLLMScriptGenerator_Generate_NoRegenWhenWithinThreshold(t *testing.T) {
+	articles := []model.Article{{URL: "https://example.com/1"}}
+	rundown := model.Rundown{
+		Corners: []model.Corner{
+			{Title: "C", Topic: "T", TargetChars: 100, SummaryURLs: []string{"https://example.com/1"}},
+		},
+	}
+	// 95 chars → 5% deviation (target=100), within 20% threshold
+	lines := []model.Line{{SpeakerRole: "host", Text: "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいう"}}
+
+	mw := &mockWriter{lines: lines}
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockPlanner{rundown: rundown},
+		mw,
+		&mockDirector{},
+		model.SECatalog{},
+		"",
+	)
+
+	_, err := gen.Generate(context.Background(), articles, model.ShowConfig{TargetChars: 100, Corners: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if mw.callCount != 1 {
+		t.Errorf("expected writer called 1 time, got %d", mw.callCount)
+	}
+}

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -218,3 +218,78 @@ func TestLLMScriptGenerator_Generate_NoRegenWhenWithinThreshold(t *testing.T) {
 		t.Errorf("expected writer called 1 time, got %d", mw.callCount)
 	}
 }
+
+func TestLLMScriptGenerator_Generate_EmptyArticles(t *testing.T) {
+	rundown := model.Rundown{
+		Corners: []model.Corner{
+			{Title: "C", Topic: "T", TargetChars: 100},
+		},
+	}
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockPlanner{rundown: rundown},
+		&mockWriter{lines: []model.Line{{SpeakerRole: "host", Text: "テスト"}}},
+		&mockDirector{},
+		model.SECatalog{},
+		"",
+	)
+
+	got, err := gen.Generate(context.Background(), []model.Article{}, model.ShowConfig{TargetChars: 100})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// no articles → no summaries; planner still called with empty summaries
+	if len(got.Segments) == 0 {
+		t.Error("expected non-empty segments from planner+writer+director")
+	}
+}
+
+func TestLLMScriptGenerator_Generate_EmptyCorners(t *testing.T) {
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockPlanner{rundown: model.Rundown{Corners: []model.Corner{}}},
+		&mockWriter{},
+		&mockDirector{},
+		model.SECatalog{},
+		"",
+	)
+
+	got, err := gen.Generate(context.Background(), []model.Article{{URL: "u"}}, model.ShowConfig{TargetChars: 100})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// no corners → no lines → director gets empty input → empty script
+	if got.Segments == nil {
+		t.Error("segments should be non-nil (empty slice expected)")
+	}
+}
+
+func TestLLMScriptGenerator_Generate_NoRegenWhenAllCornersHaveZeroTarget(t *testing.T) {
+	articles := []model.Article{{URL: "https://example.com/1"}}
+	// corners with TargetChars=0 should skip regen even with bad total char count
+	rundown := model.Rundown{
+		Corners: []model.Corner{
+			{Title: "C", Topic: "T", TargetChars: 0, SummaryURLs: []string{"https://example.com/1"}},
+		},
+	}
+	lines := []model.Line{{SpeakerRole: "host", Text: "A"}} // 1 char, show target=100
+
+	mw := &mockWriter{lines: lines}
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockPlanner{rundown: rundown},
+		mw,
+		&mockDirector{},
+		model.SECatalog{},
+		"",
+	)
+
+	_, err := gen.Generate(context.Background(), articles, model.ShowConfig{TargetChars: 100})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// corners with TargetChars=0 → no regen triggered
+	if mw.callCount != 1 {
+		t.Errorf("expected writer called 1 time (no regen), got %d", mw.callCount)
+	}
+}

--- a/internal/script/summarize/summarize.go
+++ b/internal/script/summarize/summarize.go
@@ -27,10 +27,11 @@ type Summarizer interface {
 type LLMSummarizer struct {
 	client         llm.Client
 	promptTemplate string
+	temperature    float64
 }
 
-func NewLLMSummarizer(client llm.Client, promptTemplate string) *LLMSummarizer {
-	return &LLMSummarizer{client: client, promptTemplate: promptTemplate}
+func NewLLMSummarizer(client llm.Client, promptTemplate string, temperature float64) *LLMSummarizer {
+	return &LLMSummarizer{client: client, promptTemplate: promptTemplate, temperature: temperature}
 }
 
 type summaryResponse struct {
@@ -47,8 +48,9 @@ func (s *LLMSummarizer) Summarize(ctx context.Context, a model.Article) (model.S
 	prompt := strings.ReplaceAll(s.promptTemplate, "{{article}}", string(articleJSON))
 
 	raw, err := s.client.Complete(ctx, llm.CompletionRequest{
-		Messages:   []llm.Message{{Role: "user", Content: prompt}},
-		JSONSchema: summarySchema,
+		Messages:    []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema:  summarySchema,
+		Temperature: s.temperature,
 	})
 	if err != nil {
 		return model.Summary{}, fmt.Errorf("llm complete: %w", err)

--- a/internal/script/summarize/summarize.go
+++ b/internal/script/summarize/summarize.go
@@ -2,10 +2,66 @@ package summarize
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/llm"
 )
+
+var summarySchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["summary", "points"],
+  "properties": {
+    "summary": {"type": "string"},
+    "points": {"type": "array", "items": {"type": "string"}}
+  },
+  "additionalProperties": false
+}`)
 
 type Summarizer interface {
 	Summarize(ctx context.Context, a model.Article) (model.Summary, error)
+}
+
+type LLMSummarizer struct {
+	client         llm.Client
+	promptTemplate string
+}
+
+func NewLLMSummarizer(client llm.Client, promptTemplate string) *LLMSummarizer {
+	return &LLMSummarizer{client: client, promptTemplate: promptTemplate}
+}
+
+type summaryResponse struct {
+	Summary string   `json:"summary"`
+	Points  []string `json:"points"`
+}
+
+func (s *LLMSummarizer) Summarize(ctx context.Context, a model.Article) (model.Summary, error) {
+	articleJSON, err := json.Marshal(a)
+	if err != nil {
+		return model.Summary{}, fmt.Errorf("marshal article: %w", err)
+	}
+
+	prompt := strings.ReplaceAll(s.promptTemplate, "{{article}}", string(articleJSON))
+
+	raw, err := s.client.Complete(ctx, llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: summarySchema,
+	})
+	if err != nil {
+		return model.Summary{}, fmt.Errorf("llm complete: %w", err)
+	}
+
+	var resp summaryResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return model.Summary{}, fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	return model.Summary{
+		URL:     a.URL,
+		Summary: resp.Summary,
+		Points:  resp.Points,
+	}, nil
 }

--- a/internal/script/summarize/summarize_test.go
+++ b/internal/script/summarize/summarize_test.go
@@ -1,0 +1,95 @@
+package summarize_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+	"github.com/canpok1/vox-radio/internal/script/summarize"
+)
+
+type mockClient struct {
+	response json.RawMessage
+	err      error
+	captured []llm.CompletionRequest
+}
+
+func (m *mockClient) Complete(_ context.Context, req llm.CompletionRequest) (json.RawMessage, error) {
+	m.captured = append(m.captured, req)
+	return m.response, m.err
+}
+
+func TestLLMSummarizer_Summarize_Success(t *testing.T) {
+	mc := &mockClient{
+		response: json.RawMessage(`{"summary":"AIチップ要約","points":["性能2倍","省電力"]}`),
+	}
+	s := summarize.NewLLMSummarizer(mc, "記事: {{article}}")
+
+	article := model.Article{
+		URL:   "https://example.com/1",
+		Title: "AIチップ",
+		Body:  "新型AIチップが登場",
+	}
+
+	got, err := s.Summarize(context.Background(), article)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.URL != article.URL {
+		t.Errorf("URL: got %q, want %q", got.URL, article.URL)
+	}
+	if got.Summary != "AIチップ要約" {
+		t.Errorf("Summary: got %q, want %q", got.Summary, "AIチップ要約")
+	}
+	if len(got.Points) != 2 {
+		t.Errorf("Points: got %d, want 2", len(got.Points))
+	}
+}
+
+func TestLLMSummarizer_Summarize_PromptContainsArticleJSON(t *testing.T) {
+	mc := &mockClient{
+		response: json.RawMessage(`{"summary":"要約","points":["p1"]}`),
+	}
+	s := summarize.NewLLMSummarizer(mc, "記事: {{article}}")
+
+	article := model.Article{URL: "https://example.com/1", Title: "タイトル", Body: "本文"}
+	_, _ = s.Summarize(context.Background(), article)
+
+	if len(mc.captured) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	prompt := mc.captured[0].Messages[0].Content
+	if len(prompt) == 0 {
+		t.Fatal("prompt is empty")
+	}
+	// プロンプトにarticle JSONが含まれることを確認
+	articleJSON, _ := json.Marshal(article)
+	if !containsString(prompt, string(articleJSON)) {
+		t.Errorf("prompt should contain article JSON, got: %s", prompt)
+	}
+}
+
+func TestLLMSummarizer_Summarize_LLMError(t *testing.T) {
+	mc := &mockClient{err: context.Canceled}
+	s := summarize.NewLLMSummarizer(mc, "{{article}}")
+
+	_, err := s.Summarize(context.Background(), model.Article{URL: "u"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func containsString(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstring(s, sub))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/script/summarize/summarize_test.go
+++ b/internal/script/summarize/summarize_test.go
@@ -3,6 +3,7 @@ package summarize_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/model"
@@ -25,7 +26,7 @@ func TestLLMSummarizer_Summarize_Success(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"summary":"AIチップ要約","points":["性能2倍","省電力"]}`),
 	}
-	s := summarize.NewLLMSummarizer(mc, "記事: {{article}}")
+	s := summarize.NewLLMSummarizer(mc, "記事: {{article}}", 0)
 
 	article := model.Article{
 		URL:   "https://example.com/1",
@@ -52,7 +53,7 @@ func TestLLMSummarizer_Summarize_PromptContainsArticleJSON(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"summary":"要約","points":["p1"]}`),
 	}
-	s := summarize.NewLLMSummarizer(mc, "記事: {{article}}")
+	s := summarize.NewLLMSummarizer(mc, "記事: {{article}}", 0)
 
 	article := model.Article{URL: "https://example.com/1", Title: "タイトル", Body: "本文"}
 	_, _ = s.Summarize(context.Background(), article)
@@ -64,32 +65,18 @@ func TestLLMSummarizer_Summarize_PromptContainsArticleJSON(t *testing.T) {
 	if len(prompt) == 0 {
 		t.Fatal("prompt is empty")
 	}
-	// プロンプトにarticle JSONが含まれることを確認
 	articleJSON, _ := json.Marshal(article)
-	if !containsString(prompt, string(articleJSON)) {
+	if !strings.Contains(prompt, string(articleJSON)) {
 		t.Errorf("prompt should contain article JSON, got: %s", prompt)
 	}
 }
 
 func TestLLMSummarizer_Summarize_LLMError(t *testing.T) {
 	mc := &mockClient{err: context.Canceled}
-	s := summarize.NewLLMSummarizer(mc, "{{article}}")
+	s := summarize.NewLLMSummarizer(mc, "{{article}}", 0)
 
 	_, err := s.Summarize(context.Background(), model.Article{URL: "u"})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
-}
-
-func containsString(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstring(s, sub))
-}
-
-func containsSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/script/write/write.go
+++ b/internal/script/write/write.go
@@ -2,10 +2,76 @@ package write
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/llm"
 )
 
+var linesSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["lines"],
+  "properties": {
+    "lines": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["speaker_role", "text"],
+        "properties": {
+          "speaker_role": {"type": "string"},
+          "text":         {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
+
 type Writer interface {
-	Write(ctx context.Context, corner model.Corner, summary model.Summary, show model.ShowConfig) ([]model.Line, error)
+	Write(ctx context.Context, corner model.Corner, summaries []model.Summary, show model.ShowConfig) ([]model.Line, error)
+}
+
+type LLMWriter struct {
+	client         llm.Client
+	promptTemplate string
+}
+
+func NewLLMWriter(client llm.Client, promptTemplate string) *LLMWriter {
+	return &LLMWriter{client: client, promptTemplate: promptTemplate}
+}
+
+func (w *LLMWriter) Write(ctx context.Context, corner model.Corner, summaries []model.Summary, show model.ShowConfig) ([]model.Line, error) {
+	cornerJSON, err := json.Marshal(corner)
+	if err != nil {
+		return nil, fmt.Errorf("marshal corner: %w", err)
+	}
+
+	summariesJSON, err := json.Marshal(model.Summaries{Summaries: summaries})
+	if err != nil {
+		return nil, fmt.Errorf("marshal summaries: %w", err)
+	}
+
+	prompt := strings.ReplaceAll(w.promptTemplate, "{{corner}}", string(cornerJSON))
+	prompt = strings.ReplaceAll(prompt, "{{summaries}}", string(summariesJSON))
+	prompt = strings.ReplaceAll(prompt, "{{summary}}", string(summariesJSON))
+	prompt = strings.ReplaceAll(prompt, "{{persona}}", show.Persona)
+
+	raw, err := w.client.Complete(ctx, llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: linesSchema,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("llm complete: %w", err)
+	}
+
+	var resp model.Lines
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal lines: %w", err)
+	}
+
+	return resp.Lines, nil
 }

--- a/internal/script/write/write.go
+++ b/internal/script/write/write.go
@@ -38,10 +38,11 @@ type Writer interface {
 type LLMWriter struct {
 	client         llm.Client
 	promptTemplate string
+	temperature    float64
 }
 
-func NewLLMWriter(client llm.Client, promptTemplate string) *LLMWriter {
-	return &LLMWriter{client: client, promptTemplate: promptTemplate}
+func NewLLMWriter(client llm.Client, promptTemplate string, temperature float64) *LLMWriter {
+	return &LLMWriter{client: client, promptTemplate: promptTemplate, temperature: temperature}
 }
 
 func (w *LLMWriter) Write(ctx context.Context, corner model.Corner, summaries []model.Summary, show model.ShowConfig) ([]model.Line, error) {
@@ -56,13 +57,13 @@ func (w *LLMWriter) Write(ctx context.Context, corner model.Corner, summaries []
 	}
 
 	prompt := strings.ReplaceAll(w.promptTemplate, "{{corner}}", string(cornerJSON))
-	prompt = strings.ReplaceAll(prompt, "{{summaries}}", string(summariesJSON))
 	prompt = strings.ReplaceAll(prompt, "{{summary}}", string(summariesJSON))
 	prompt = strings.ReplaceAll(prompt, "{{persona}}", show.Persona)
 
 	raw, err := w.client.Complete(ctx, llm.CompletionRequest{
-		Messages:   []llm.Message{{Role: "user", Content: prompt}},
-		JSONSchema: linesSchema,
+		Messages:    []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema:  linesSchema,
+		Temperature: w.temperature,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("llm complete: %w", err)

--- a/internal/script/write/write_test.go
+++ b/internal/script/write/write_test.go
@@ -1,0 +1,94 @@
+package write_test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+	"github.com/canpok1/vox-radio/internal/script/write"
+)
+
+type mockClient struct {
+	response  json.RawMessage
+	err       error
+	callCount int
+	responses []json.RawMessage
+	captured  []llm.CompletionRequest
+}
+
+func (m *mockClient) Complete(_ context.Context, req llm.CompletionRequest) (json.RawMessage, error) {
+	m.captured = append(m.captured, req)
+	if len(m.responses) > 0 {
+		idx := m.callCount
+		m.callCount++
+		if idx < len(m.responses) {
+			return m.responses[idx], m.err
+		}
+	}
+	return m.response, m.err
+}
+
+var linesJSON = json.RawMessage(`{
+  "lines": [
+    {"speaker_role": "host", "text": "こんにちは"},
+    {"speaker_role": "guest", "text": "よろしく"}
+  ]
+}`)
+
+func TestLLMWriter_Write_Success(t *testing.T) {
+	mc := &mockClient{response: linesJSON}
+	w := write.NewLLMWriter(mc, "corner={{corner}} summaries={{summaries}} persona={{persona}}")
+
+	corner := model.Corner{Title: "コーナー1", Topic: "AI", Points: []string{"p1"}, TargetChars: 100}
+	summaries := []model.Summary{{URL: "https://example.com/1", Summary: "要約", Points: []string{"p1"}}}
+	show := model.ShowConfig{Persona: "ホスト設定", TargetChars: 1000}
+
+	got, err := w.Write(context.Background(), corner, summaries, show)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("Lines: got %d, want 2", len(got))
+	}
+	if got[0].SpeakerRole != "host" {
+		t.Errorf("SpeakerRole: got %q, want host", got[0].SpeakerRole)
+	}
+}
+
+func TestLLMWriter_Write_PromptContainsCornerAndSummaries(t *testing.T) {
+	mc := &mockClient{response: linesJSON}
+	w := write.NewLLMWriter(mc, "c={{corner}} s={{summaries}} p={{persona}}")
+
+	corner := model.Corner{Title: "AIコーナー", Topic: "AI", Points: []string{"p1"}, TargetChars: 100}
+	summaries := []model.Summary{{URL: "https://example.com/1", Summary: "AI要約", Points: []string{"p1"}}}
+	show := model.ShowConfig{Persona: "キャラ設定テキスト"}
+
+	_, _ = w.Write(context.Background(), corner, summaries, show)
+
+	if len(mc.captured) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	prompt := mc.captured[0].Messages[0].Content
+	if !strings.Contains(prompt, "AIコーナー") {
+		t.Errorf("prompt should contain corner title, got: %s", prompt)
+	}
+	if !strings.Contains(prompt, "AI要約") {
+		t.Errorf("prompt should contain summary, got: %s", prompt)
+	}
+	if !strings.Contains(prompt, "キャラ設定テキスト") {
+		t.Errorf("prompt should contain persona, got: %s", prompt)
+	}
+}
+
+func TestLLMWriter_Write_LLMError(t *testing.T) {
+	mc := &mockClient{err: context.Canceled}
+	w := write.NewLLMWriter(mc, "{{corner}}")
+
+	_, err := w.Write(context.Background(), model.Corner{}, nil, model.ShowConfig{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/internal/script/write/write_test.go
+++ b/internal/script/write/write_test.go
@@ -40,7 +40,7 @@ var linesJSON = json.RawMessage(`{
 
 func TestLLMWriter_Write_Success(t *testing.T) {
 	mc := &mockClient{response: linesJSON}
-	w := write.NewLLMWriter(mc, "corner={{corner}} summaries={{summaries}} persona={{persona}}")
+	w := write.NewLLMWriter(mc, "corner={{corner}} summaries={{summary}} persona={{persona}}", 0)
 
 	corner := model.Corner{Title: "コーナー1", Topic: "AI", Points: []string{"p1"}, TargetChars: 100}
 	summaries := []model.Summary{{URL: "https://example.com/1", Summary: "要約", Points: []string{"p1"}}}
@@ -60,7 +60,7 @@ func TestLLMWriter_Write_Success(t *testing.T) {
 
 func TestLLMWriter_Write_PromptContainsCornerAndSummaries(t *testing.T) {
 	mc := &mockClient{response: linesJSON}
-	w := write.NewLLMWriter(mc, "c={{corner}} s={{summaries}} p={{persona}}")
+	w := write.NewLLMWriter(mc, "c={{corner}} s={{summary}} p={{persona}}", 0)
 
 	corner := model.Corner{Title: "AIコーナー", Topic: "AI", Points: []string{"p1"}, TargetChars: 100}
 	summaries := []model.Summary{{URL: "https://example.com/1", Summary: "AI要約", Points: []string{"p1"}}}
@@ -85,7 +85,7 @@ func TestLLMWriter_Write_PromptContainsCornerAndSummaries(t *testing.T) {
 
 func TestLLMWriter_Write_LLMError(t *testing.T) {
 	mc := &mockClient{err: context.Canceled}
-	w := write.NewLLMWriter(mc, "{{corner}}")
+	w := write.NewLLMWriter(mc, "{{corner}}", 0)
 
 	_, err := w.Write(context.Background(), model.Corner{}, nil, model.ShowConfig{})
 	if err == nil {

--- a/main.go
+++ b/main.go
@@ -487,7 +487,7 @@ func runScriptWrite(ctx context.Context, workDir string, c llm.Client, cfg *conf
 	summaryByURL := script.SummaryByURL(sums.Summaries)
 
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(cfg, "write"))
-	var allLines []model.Line
+	allLines := make([]model.Line, 0)
 	for _, corner := range rundown.Corners {
 		relevant := script.CornerSummaries(corner, summaryByURL)
 		lines, err := w.Write(ctx, corner, relevant, cfg.Show)
@@ -555,6 +555,7 @@ func stepTemp(cfg *config.Config, name string) float64 {
 	if s, ok := cfg.LLM.Steps[name]; ok && s.Temperature != nil {
 		return *s.Temperature
 	}
+	// 0 causes the LLM client to fall back to its configured global temperature.
 	return 0
 }
 

--- a/main.go
+++ b/main.go
@@ -15,13 +15,19 @@ import (
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/publish"
 	"github.com/canpok1/vox-radio/internal/publish/hosting/local"
+	"github.com/canpok1/vox-radio/internal/script"
+	"github.com/canpok1/vox-radio/internal/script/direct"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+	"github.com/canpok1/vox-radio/internal/script/plan"
+	"github.com/canpok1/vox-radio/internal/script/summarize"
+	"github.com/canpok1/vox-radio/internal/script/write"
 	"github.com/canpok1/vox-radio/internal/synth"
 )
 
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintln(os.Stderr, "Usage: vox-radio <command>")
-		fmt.Fprintln(os.Stderr, "Commands: collect, synth, assemble, publish, prune")
+		fmt.Fprintln(os.Stderr, "Commands: collect, script, synth, assemble, publish, prune")
 		os.Exit(1)
 	}
 
@@ -29,6 +35,10 @@ func main() {
 	case "collect":
 		if err := runCollect(os.Args[2:]); err != nil {
 			log.Fatalf("collect: %v", err)
+		}
+	case "script":
+		if err := runScript(os.Args[2:]); err != nil {
+			log.Fatalf("script: %v", err)
 		}
 	case "synth":
 		if err := runSynth(os.Args[2:]); err != nil {
@@ -310,4 +320,265 @@ func resolveSiteURL(override, configURL string) string {
 		return override
 	}
 	return configURL
+}
+
+func runScript(args []string) error {
+	fs := flag.NewFlagSet("script", flag.ContinueOnError)
+	in := fs.String("in", "", "input articles.json path (required for full pipeline or summarize step)")
+	out := fs.String("out", "", "output script.json path (required)")
+	step := fs.String("step", "", "run a single step: summarize|plan|write|direct")
+	configDir := fs.String("config", "config", "config directory containing llm.yaml, show.yaml, assets.yaml")
+	promptsDir := fs.String("prompts", "prompts", "directory containing prompt templates")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "Usage: vox-radio script --out <script.json> [--in <articles.json>] [--step summarize|plan|write|direct]")
+		fs.PrintDefaults()
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *out == "" {
+		fs.Usage()
+		return fmt.Errorf("--out is required")
+	}
+
+	cfg, err := config.Load(*configDir)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
+	llmClient := llm.NewClient(llm.Config{
+		BaseURL:     cfg.LLM.BaseURL,
+		APIKey:      apiKey,
+		Model:       cfg.LLM.Model,
+		Temperature: cfg.LLM.Temperature,
+		MaxRetries:  cfg.LLM.MaxRetries,
+	})
+
+	prompts, err := loadPrompts(*promptsDir)
+	if err != nil {
+		return fmt.Errorf("load prompts: %w", err)
+	}
+
+	workDir := filepath.Dir(*out)
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		return fmt.Errorf("create work dir: %w", err)
+	}
+
+	seCatalog := buildSECatalog(cfg.Assets)
+
+	switch *step {
+	case "":
+		return runScriptFull(context.Background(), *in, *out, workDir, llmClient, cfg, prompts, seCatalog)
+	case "summarize":
+		return runScriptSummarize(context.Background(), *in, workDir, llmClient, cfg, prompts)
+	case "plan":
+		return runScriptPlan(context.Background(), workDir, llmClient, cfg, prompts)
+	case "write":
+		return runScriptWrite(context.Background(), workDir, llmClient, cfg, prompts)
+	case "direct":
+		return runScriptDirect(context.Background(), workDir, *out, llmClient, cfg, prompts, seCatalog)
+	default:
+		return fmt.Errorf("unknown step %q: use summarize|plan|write|direct", *step)
+	}
+}
+
+func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, cfg *config.Config, prompts map[string]string, seCatalog model.SECatalog) error {
+	if in == "" {
+		return fmt.Errorf("--in is required for full pipeline")
+	}
+	articles, err := readArticles(in)
+	if err != nil {
+		return err
+	}
+
+	gen := script.NewLLMScriptGenerator(
+		summarize.NewLLMSummarizer(c, prompts["summarize"]),
+		plan.NewLLMPlanner(c, prompts["plan"]),
+		write.NewLLMWriter(c, prompts["write"]),
+		direct.NewLLMDirector(c, prompts["direct"]),
+		seCatalog,
+		workDir,
+	)
+
+	scr, err := gen.Generate(ctx, articles.Articles, cfg.Show)
+	if err != nil {
+		return fmt.Errorf("generate: %w", err)
+	}
+
+	return writeJSON(out, scr)
+}
+
+func runScriptSummarize(ctx context.Context, in, workDir string, c llm.Client, cfg *config.Config, prompts map[string]string) error {
+	if in == "" {
+		return fmt.Errorf("--in is required for summarize step")
+	}
+	articles, err := readArticles(in)
+	if err != nil {
+		return err
+	}
+
+	s := summarize.NewLLMSummarizer(c, prompts["summarize"])
+	summaries := make([]model.Summary, 0, len(articles.Articles))
+	for _, a := range articles.Articles {
+		sum, err := s.Summarize(ctx, a)
+		if err != nil {
+			return fmt.Errorf("summarize %q: %w", a.URL, err)
+		}
+		summaries = append(summaries, sum)
+	}
+
+	out := filepath.Join(workDir, "summaries.json")
+	if err := writeJSON(out, model.Summaries{Summaries: summaries}); err != nil {
+		return err
+	}
+	fmt.Printf("summarized %d articles to %s\n", len(summaries), out)
+	return nil
+}
+
+func runScriptPlan(ctx context.Context, workDir string, c llm.Client, cfg *config.Config, prompts map[string]string) error {
+	summariesPath := filepath.Join(workDir, "summaries.json")
+	data, err := os.ReadFile(summariesPath)
+	if err != nil {
+		return fmt.Errorf("read summaries.json: %w", err)
+	}
+	var sums model.Summaries
+	if err := json.Unmarshal(data, &sums); err != nil {
+		return fmt.Errorf("parse summaries.json: %w", err)
+	}
+
+	p := plan.NewLLMPlanner(c, prompts["plan"])
+	rundown, err := p.Plan(ctx, sums.Summaries, cfg.Show)
+	if err != nil {
+		return fmt.Errorf("plan: %w", err)
+	}
+
+	out := filepath.Join(workDir, "rundown.json")
+	if err := writeJSON(out, rundown); err != nil {
+		return err
+	}
+	fmt.Printf("planned %d corners to %s\n", len(rundown.Corners), out)
+	return nil
+}
+
+func runScriptWrite(ctx context.Context, workDir string, c llm.Client, cfg *config.Config, prompts map[string]string) error {
+	summariesPath := filepath.Join(workDir, "summaries.json")
+	summariesData, err := os.ReadFile(summariesPath)
+	if err != nil {
+		return fmt.Errorf("read summaries.json: %w", err)
+	}
+	var sums model.Summaries
+	if err := json.Unmarshal(summariesData, &sums); err != nil {
+		return fmt.Errorf("parse summaries.json: %w", err)
+	}
+
+	rundownPath := filepath.Join(workDir, "rundown.json")
+	rundownData, err := os.ReadFile(rundownPath)
+	if err != nil {
+		return fmt.Errorf("read rundown.json: %w", err)
+	}
+	var rundown model.Rundown
+	if err := json.Unmarshal(rundownData, &rundown); err != nil {
+		return fmt.Errorf("parse rundown.json: %w", err)
+	}
+
+	summaryByURL := make(map[string]model.Summary, len(sums.Summaries))
+	for _, s := range sums.Summaries {
+		summaryByURL[s.URL] = s
+	}
+
+	w := write.NewLLMWriter(c, prompts["write"])
+	var allLines []model.Line
+	for _, corner := range rundown.Corners {
+		relevant := make([]model.Summary, 0, len(corner.SummaryURLs))
+		for _, u := range corner.SummaryURLs {
+			if s, ok := summaryByURL[u]; ok {
+				relevant = append(relevant, s)
+			}
+		}
+		lines, err := w.Write(ctx, corner, relevant, cfg.Show)
+		if err != nil {
+			return fmt.Errorf("write corner %q: %w", corner.Title, err)
+		}
+		allLines = append(allLines, lines...)
+	}
+
+	out := filepath.Join(workDir, "lines.json")
+	if err := writeJSON(out, model.Lines{Lines: allLines}); err != nil {
+		return err
+	}
+	fmt.Printf("wrote %d lines to %s\n", len(allLines), out)
+	return nil
+}
+
+func runScriptDirect(ctx context.Context, workDir, out string, c llm.Client, cfg *config.Config, prompts map[string]string, seCatalog model.SECatalog) error {
+	linesPath := filepath.Join(workDir, "lines.json")
+	data, err := os.ReadFile(linesPath)
+	if err != nil {
+		return fmt.Errorf("read lines.json: %w", err)
+	}
+	var linesWrapper model.Lines
+	if err := json.Unmarshal(data, &linesWrapper); err != nil {
+		return fmt.Errorf("parse lines.json: %w", err)
+	}
+
+	d := direct.NewLLMDirector(c, prompts["direct"])
+	scr, err := d.Direct(ctx, linesWrapper.Lines, seCatalog)
+	if err != nil {
+		return fmt.Errorf("direct: %w", err)
+	}
+
+	if err := writeJSON(out, scr); err != nil {
+		return err
+	}
+	fmt.Printf("directed %d segments to %s\n", len(scr.Segments), out)
+	return nil
+}
+
+func loadPrompts(dir string) (map[string]string, error) {
+	names := []string{"summarize", "plan", "write", "direct"}
+	prompts := make(map[string]string, len(names))
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(dir, name+".md"))
+		if err != nil {
+			return nil, fmt.Errorf("read %s.md: %w", name, err)
+		}
+		prompts[name] = string(data)
+	}
+	return prompts, nil
+}
+
+func buildSECatalog(assets config.AssetsConfig) model.SECatalog {
+	names := make([]string, 0, len(assets.SE))
+	for name := range assets.SE {
+		names = append(names, name)
+	}
+	return model.SECatalog{Names: names}
+}
+
+func readArticles(path string) (model.Articles, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return model.Articles{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	var articles model.Articles
+	if err := json.Unmarshal(data, &articles); err != nil {
+		return model.Articles{}, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return articles, nil
+}
+
+func writeJSON(path string, v any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/canpok1/vox-radio/internal/assemble"
 	"github.com/canpok1/vox-radio/internal/collect"
@@ -394,10 +395,10 @@ func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, c
 	}
 
 	gen := script.NewLLMScriptGenerator(
-		summarize.NewLLMSummarizer(c, prompts["summarize"]),
-		plan.NewLLMPlanner(c, prompts["plan"]),
-		write.NewLLMWriter(c, prompts["write"]),
-		direct.NewLLMDirector(c, prompts["direct"]),
+		summarize.NewLLMSummarizer(c, prompts["summarize"], stepTemp(cfg, "summarize")),
+		plan.NewLLMPlanner(c, prompts["plan"], stepTemp(cfg, "plan")),
+		write.NewLLMWriter(c, prompts["write"], stepTemp(cfg, "write")),
+		direct.NewLLMDirector(c, prompts["direct"], stepTemp(cfg, "direct")),
 		seCatalog,
 		workDir,
 	)
@@ -419,7 +420,7 @@ func runScriptSummarize(ctx context.Context, in, workDir string, c llm.Client, c
 		return err
 	}
 
-	s := summarize.NewLLMSummarizer(c, prompts["summarize"])
+	s := summarize.NewLLMSummarizer(c, prompts["summarize"], stepTemp(cfg, "summarize"))
 	summaries := make([]model.Summary, 0, len(articles.Articles))
 	for _, a := range articles.Articles {
 		sum, err := s.Summarize(ctx, a)
@@ -448,7 +449,7 @@ func runScriptPlan(ctx context.Context, workDir string, c llm.Client, cfg *confi
 		return fmt.Errorf("parse summaries.json: %w", err)
 	}
 
-	p := plan.NewLLMPlanner(c, prompts["plan"])
+	p := plan.NewLLMPlanner(c, prompts["plan"], stepTemp(cfg, "plan"))
 	rundown, err := p.Plan(ctx, sums.Summaries, cfg.Show)
 	if err != nil {
 		return fmt.Errorf("plan: %w", err)
@@ -483,20 +484,12 @@ func runScriptWrite(ctx context.Context, workDir string, c llm.Client, cfg *conf
 		return fmt.Errorf("parse rundown.json: %w", err)
 	}
 
-	summaryByURL := make(map[string]model.Summary, len(sums.Summaries))
-	for _, s := range sums.Summaries {
-		summaryByURL[s.URL] = s
-	}
+	summaryByURL := script.SummaryByURL(sums.Summaries)
 
-	w := write.NewLLMWriter(c, prompts["write"])
+	w := write.NewLLMWriter(c, prompts["write"], stepTemp(cfg, "write"))
 	var allLines []model.Line
 	for _, corner := range rundown.Corners {
-		relevant := make([]model.Summary, 0, len(corner.SummaryURLs))
-		for _, u := range corner.SummaryURLs {
-			if s, ok := summaryByURL[u]; ok {
-				relevant = append(relevant, s)
-			}
-		}
+		relevant := script.CornerSummaries(corner, summaryByURL)
 		lines, err := w.Write(ctx, corner, relevant, cfg.Show)
 		if err != nil {
 			return fmt.Errorf("write corner %q: %w", corner.Title, err)
@@ -523,7 +516,7 @@ func runScriptDirect(ctx context.Context, workDir, out string, c llm.Client, cfg
 		return fmt.Errorf("parse lines.json: %w", err)
 	}
 
-	d := direct.NewLLMDirector(c, prompts["direct"])
+	d := direct.NewLLMDirector(c, prompts["direct"], stepTemp(cfg, "direct"))
 	scr, err := d.Direct(ctx, linesWrapper.Lines, seCatalog)
 	if err != nil {
 		return fmt.Errorf("direct: %w", err)
@@ -554,7 +547,15 @@ func buildSECatalog(assets config.AssetsConfig) model.SECatalog {
 	for name := range assets.SE {
 		names = append(names, name)
 	}
+	sort.Strings(names)
 	return model.SECatalog{Names: names}
+}
+
+func stepTemp(cfg *config.Config, name string) float64 {
+	if s, ok := cfg.LLM.Steps[name]; ok && s.Temperature != nil {
+		return *s.Temperature
+	}
+	return 0
 }
 
 func readArticles(path string) (model.Articles, error) {


### PR DESCRIPTION
## Summary

- `internal/script/{summarize,plan,write,direct}` に各ステップのLLM実装を追加
  - `LLMSummarizer` / `LLMPlanner` / `LLMWriter` / `LLMDirector` を実装
  - 各ステップはインラインJSONスキーマでLLMレスポンスを検証
  - per-step temperature対応（`llm.yaml` の `steps.<name>.temperature` を実際に使用）
- `internal/script` に `LLMScriptGenerator` を実装
  - 4ステップを直列実行し、中間ファイルを保存（`workDir` 指定時）
  - 総文字数の20%超過/不足時に最悪コーナーを1回再生成（局所修正）
  - `CornerSummaries` / `SummaryByURL` をエクスポートして main.go から再利用
- `main.go` に `script` サブコマンドを追加
  - フラグ: `--in` / `--out` / `--step` / `--config` / `--prompts`
  - `--step=summarize|plan|write|direct` で個別ステップを単独実行可能

## Test plan

- [x] `go test ./...` 全通過
- [x] `gofmt -l .` 出力なし
- [x] `golangci-lint run` 0 issues
- [x] 各ステップ（summarize/plan/write/direct）のユニットテスト（モックLLM使用）
- [x] `LLMScriptGenerator` のパイプラインテスト（happy path / エラーケース / 文字数再生成 / エッジケース）

Closes #14

---
🤖 Generated with [Claude Code](https://claude.ai/code)