### PR TITLE
refactor: ffprobeDuration/osFileSize を internal/mediainfo に集約する

### DIFF
--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/mediainfo"
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
@@ -36,8 +35,8 @@ func New(assetsConfig config.AssetsConfig, showConfig model.ShowConfig) *Assembl
 		AssetsConfig: assetsConfig,
 		ShowConfig:   showConfig,
 		runFFmpeg:    runFFmpegCmd,
-		getDuration:  ffprobeDuration,
-		getFileSize:  osFileSize,
+		getDuration:  mediainfo.Duration,
+		getFileSize:  mediainfo.FileSize,
 	}
 }
 
@@ -101,30 +100,4 @@ func runFFmpegCmd(ctx context.Context, args []string) error {
 	cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
-}
-
-func ffprobeDuration(path string) (float64, error) {
-	out, err := exec.Command("ffprobe",
-		"-v", "error",
-		"-show_entries", "format=duration",
-		"-of", "default=noprint_wrappers=1:nokey=1",
-		path,
-	).Output()
-	if err != nil {
-		return 0, fmt.Errorf("ffprobe: %w", err)
-	}
-	s := strings.TrimSpace(string(out))
-	dur, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse duration %q: %w", s, err)
-	}
-	return dur, nil
-}
-
-func osFileSize(path string) (int64, error) {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return 0, err
-	}
-	return fi.Size(), nil
 }

--- a/internal/mediainfo/mediainfo.go
+++ b/internal/mediainfo/mediainfo.go
@@ -1,0 +1,37 @@
+package mediainfo
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Duration returns the duration in seconds of the media file at path using ffprobe.
+func Duration(path string) (float64, error) {
+	out, err := exec.Command("ffprobe",
+		"-v", "error",
+		"-show_entries", "format=duration",
+		"-of", "default=noprint_wrappers=1:nokey=1",
+		path,
+	).Output()
+	if err != nil {
+		return 0, fmt.Errorf("ffprobe: %w", err)
+	}
+	s := strings.TrimSpace(string(out))
+	dur, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse duration %q: %w", s, err)
+	}
+	return dur, nil
+}
+
+// FileSize returns the size in bytes of the file at path.
+func FileSize(path string) (int64, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}

--- a/internal/mediainfo/mediainfo_test.go
+++ b/internal/mediainfo/mediainfo_test.go
@@ -1,0 +1,40 @@
+package mediainfo_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/mediainfo"
+)
+
+func TestFileSize_ReturnsCorrectSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	content := []byte("hello world")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	got, err := mediainfo.FileSize(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != int64(len(content)) {
+		t.Errorf("got %d, want %d", got, len(content))
+	}
+}
+
+func TestFileSize_NonExistentFile_ReturnsError(t *testing.T) {
+	_, err := mediainfo.FileSize("/nonexistent/path/to/file.mp3")
+	if err == nil {
+		t.Error("expected error for non-existent file, got nil")
+	}
+}
+
+func TestDuration_NonExistentFile_ReturnsError(t *testing.T) {
+	_, err := mediainfo.Duration("/nonexistent/path/to/file.mp3")
+	if err == nil {
+		t.Error("expected error for non-existent file, got nil")
+	}
+}

--- a/internal/mediainfo/mediainfo_test.go
+++ b/internal/mediainfo/mediainfo_test.go
@@ -2,6 +2,7 @@ package mediainfo_test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -29,6 +30,29 @@ func TestFileSize_NonExistentFile_ReturnsError(t *testing.T) {
 	_, err := mediainfo.FileSize("/nonexistent/path/to/file.mp3")
 	if err == nil {
 		t.Error("expected error for non-existent file, got nil")
+	}
+}
+
+func TestDuration_ReturnsPositiveDuration(t *testing.T) {
+	if _, err := exec.LookPath("ffprobe"); err != nil {
+		t.Skip("ffprobe not available")
+	}
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not available for test file generation")
+	}
+
+	dir := t.TempDir()
+	wavPath := filepath.Join(dir, "test.wav")
+	if err := exec.Command("ffmpeg", "-f", "lavfi", "-i", "sine=frequency=440:duration=1", wavPath).Run(); err != nil {
+		t.Fatalf("setup: generate test wav: %v", err)
+	}
+
+	got, err := mediainfo.Duration(wavPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got <= 0 {
+		t.Errorf("got non-positive duration: %f", got)
 	}
 }
 

--- a/internal/publish/publish.go
+++ b/internal/publish/publish.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/mediainfo"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/publish/feed"
 	"github.com/canpok1/vox-radio/internal/publish/hosting"
@@ -35,8 +33,8 @@ func New(h hosting.Hosting, podcast config.PodcastConfig) *Publisher {
 	return &Publisher{
 		Hosting:     h,
 		Podcast:     podcast,
-		getDuration: ffprobeDuration,
-		getFileSize: osFileSize,
+		getDuration: mediainfo.Duration,
+		getFileSize: mediainfo.FileSize,
 	}
 }
 
@@ -122,30 +120,4 @@ func formatDuration(sec float64) string {
 	m := (total % 3600) / 60
 	s := total % 60
 	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
-}
-
-func ffprobeDuration(path string) (float64, error) {
-	out, err := exec.Command("ffprobe",
-		"-v", "error",
-		"-show_entries", "format=duration",
-		"-of", "default=noprint_wrappers=1:nokey=1",
-		path,
-	).Output()
-	if err != nil {
-		return 0, fmt.Errorf("ffprobe: %w", err)
-	}
-	s := strings.TrimSpace(string(out))
-	dur, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse duration %q: %w", s, err)
-	}
-	return dur, nil
-}
-
-func osFileSize(path string) (int64, error) {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return 0, err
-	}
-	return fi.Size(), nil
 }

--- a/internal/synth/synth.go
+++ b/internal/synth/synth.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strconv"
-	"strings"
 
+	"github.com/canpok1/vox-radio/internal/mediainfo"
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
@@ -25,7 +23,7 @@ func New(engineURL string, showConfig model.ShowConfig) *Synth {
 	return &Synth{
 		Client:      NewClient(engineURL),
 		ShowConfig:  showConfig,
-		getDuration: ffprobeDuration,
+		getDuration: mediainfo.Duration,
 	}
 }
 
@@ -102,22 +100,4 @@ func (s *Synth) resolveSpeakerID(role string) int {
 		return id
 	}
 	return s.ShowConfig.DefaultSpeaker
-}
-
-func ffprobeDuration(path string) (float64, error) {
-	out, err := exec.Command("ffprobe",
-		"-v", "error",
-		"-show_entries", "format=duration",
-		"-of", "default=noprint_wrappers=1:nokey=1",
-		path,
-	).Output()
-	if err != nil {
-		return 0, fmt.Errorf("ffprobe: %w", err)
-	}
-	s := strings.TrimSpace(string(out))
-	dur, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse duration %q: %w", s, err)
-	}
-	return dur, nil
 }


### PR DESCRIPTION
## Summary

- `internal/assemble`、`internal/publish`、`internal/synth` の3パッケージにコピー&ペーストで重複していた `ffprobeDuration` / `osFileSize` を `internal/mediainfo` パッケージに集約した
- `mediainfo.Duration(path string) (float64, error)` および `mediainfo.FileSize(path string) (int64, error)` として公開
- 各パッケージのコンストラクタでデフォルト値を `mediainfo.Duration` / `mediainfo.FileSize` に差し替え
- 既存テストのモックパターン（`getDuration` / `getFileSize` func フィールド）は変更なし（後方互換維持）
- `Duration` の正常系テストを追加（ffmpeg で WAV を生成し正の値を検証、ffprobe/ffmpeg 未インストール環境は `t.Skip`）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/mediainfo/mediainfo.go` | 新規作成: `Duration` / `FileSize` |
| `internal/mediainfo/mediainfo_test.go` | 新規作成: 全4テストケース |
| `internal/assemble/assemble.go` | ローカル実装削除 → `mediainfo` 参照 |
| `internal/publish/publish.go` | ローカル実装削除 → `mediainfo` 参照 |
| `internal/synth/synth.go` | ローカル実装削除 → `mediainfo` 参照 |

Closes #37

---
🤖 Generated with [Claude Code](https://claude.ai/code)