### PR TITLE
feat: ghpages Hosting 実装と publish コマンドの ghpages 対応

### DIFF
--- a/docs/cli/vox-radio.md
+++ b/docs/cli/vox-radio.md
@@ -20,7 +20,7 @@ synthesizing voice clips, assembling audio, and publishing RSS feeds.
 * [vox-radio assemble](vox-radio_assemble.md)	 - Assemble WAV clips into an MP3 episode
 * [vox-radio collect](vox-radio_collect.md)	 - Collect articles from RSS feeds and URLs
 * [vox-radio prune](vox-radio_prune.md)	 - Remove old episodes, keeping only the most recent N
-* [vox-radio publish](vox-radio_publish.md)	 - Publish an episode to the local hosting directory
+* [vox-radio publish](vox-radio_publish.md)	 - Publish an episode to the hosting directory
 * [vox-radio script](vox-radio_script.md)	 - Generate a script from collected articles using LLM
 * [vox-radio synth](vox-radio_synth.md)	 - Synthesize voice clips from a script
 

--- a/docs/cli/vox-radio_publish.md
+++ b/docs/cli/vox-radio_publish.md
@@ -1,16 +1,21 @@
 ## vox-radio publish
 
-Publish an episode to the local hosting directory
+Publish an episode to the hosting directory
 
 ### Synopsis
 
 Copy the MP3 file into the hosting directory, update episodes.json,
 and regenerate feed.xml for RSS distribution.
 
+Hosting types:
+  local    Write files to a local directory (default).
+  ghpages  Write files to a local git working tree and push to gh-pages as an orphan commit.
+
 Example:
   vox-radio publish --in work/episode.mp3 --out-dir public
   vox-radio publish --in work/episode.mp3 --out-dir public --date 2026-01-01 --title "Episode title"
   vox-radio publish --in work/episode.mp3 --out-dir public --profile profiles/tech/profile.yaml
+  vox-radio publish --in work/episode.mp3 --out-dir public --hosting ghpages
 
 ```
 vox-radio publish [flags]
@@ -23,8 +28,9 @@ vox-radio publish [flags]
       --date string          episode date YYYY-MM-DD (default: today)
       --description string   episode description
   -h, --help                 help for publish
+      --hosting string       hosting type: local or ghpages (default "local")
       --in string            input mp3 path (required)
-      --out-dir string       output directory for local hosting (required)
+      --out-dir string       output directory for hosting (required)
       --profile string       profile YAML file path (default "profiles/test/profile.yaml")
       --title string         episode title (default: <date> <podcast.title>)
 ```

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -99,6 +99,15 @@ func TestPublishMissingOutDir(t *testing.T) {
 	}
 }
 
+func TestPublishInvalidHosting(t *testing.T) {
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"publish", "--in", "/tmp/ep.mp3", "--out-dir", "/tmp", "--hosting", "invalid"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid --hosting value")
+	}
+}
+
 func TestPruneMissingOutDir(t *testing.T) {
 	cmd := cli.NewRootCmd()
 	cmd.SetArgs([]string{"prune"})

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/publish"
+	"github.com/canpok1/vox-radio/internal/publish/hosting/ghpages"
 	"github.com/canpok1/vox-radio/internal/publish/hosting/local"
 	"github.com/spf13/cobra"
 )
@@ -18,34 +19,56 @@ func newPublishCmd() *cobra.Command {
 	var profilePath string
 	var outDir string
 	var baseURL string
+	var hostingType string
 
 	cmd := &cobra.Command{
 		Use:   "publish",
-		Short: "Publish an episode to the local hosting directory",
+		Short: "Publish an episode to the hosting directory",
 		Long: `Copy the MP3 file into the hosting directory, update episodes.json,
 and regenerate feed.xml for RSS distribution.
+
+Hosting types:
+  local    Write files to a local directory (default).
+  ghpages  Write files to a local git working tree and push to gh-pages as an orphan commit.
 
 Example:
   vox-radio publish --in work/episode.mp3 --out-dir public
   vox-radio publish --in work/episode.mp3 --out-dir public --date 2026-01-01 --title "Episode title"
-  vox-radio publish --in work/episode.mp3 --out-dir public --profile profiles/tech/profile.yaml`,
+  vox-radio publish --in work/episode.mp3 --out-dir public --profile profiles/tech/profile.yaml
+  vox-radio publish --in work/episode.mp3 --out-dir public --hosting ghpages`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			p, err := config.LoadProfile(profilePath)
 			if err != nil {
 				return fmt.Errorf("load profile: %w", err)
 			}
 
-			h := local.New(outDir, resolveSiteURL(baseURL, p.Podcast.SiteURL))
-			publisher := publish.New(h, p.Podcast)
-
+			siteURL := resolveSiteURL(baseURL, p.Podcast.SiteURL)
 			opts := publish.Options{
 				Date:        date,
 				Title:       titleFlag,
 				Description: descFlag,
 			}
 
-			if err := publisher.Run(context.Background(), in, opts); err != nil {
-				return err
+			ctx := context.Background()
+
+			switch hostingType {
+			case "local":
+				h := local.New(outDir, siteURL)
+				publisher := publish.New(h, p.Podcast)
+				if err := publisher.Run(ctx, in, opts); err != nil {
+					return err
+				}
+			case "ghpages":
+				h := ghpages.New(outDir, siteURL)
+				publisher := publish.New(h, p.Podcast)
+				if err := publisher.Run(ctx, in, opts); err != nil {
+					return err
+				}
+				if err := h.Push(ctx); err != nil {
+					return fmt.Errorf("push to gh-pages: %w", err)
+				}
+			default:
+				return fmt.Errorf("unknown hosting type %q: must be \"local\" or \"ghpages\"", hostingType)
 			}
 
 			effectiveDate := date
@@ -62,8 +85,9 @@ Example:
 	cmd.Flags().StringVar(&titleFlag, "title", "", "episode title (default: <date> <podcast.title>)")
 	cmd.Flags().StringVar(&descFlag, "description", "", "episode description")
 	cmd.Flags().StringVar(&profilePath, "profile", "profiles/test/profile.yaml", "profile YAML file path")
-	cmd.Flags().StringVar(&outDir, "out-dir", "", "output directory for local hosting (required)")
+	cmd.Flags().StringVar(&outDir, "out-dir", "", "output directory for hosting (required)")
 	cmd.Flags().StringVar(&baseURL, "base-url", "", "base URL for audio/feed URLs (default: site_url from profile)")
+	cmd.Flags().StringVar(&hostingType, "hosting", "local", "hosting type: local or ghpages")
 	_ = cmd.MarkFlagRequired("in")
 	_ = cmd.MarkFlagRequired("out-dir")
 

--- a/internal/cli/publish.go
+++ b/internal/cli/publish.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/publish"
+	"github.com/canpok1/vox-radio/internal/publish/hosting"
 	"github.com/canpok1/vox-radio/internal/publish/hosting/ghpages"
 	"github.com/canpok1/vox-radio/internal/publish/hosting/local"
 	"github.com/spf13/cobra"
@@ -49,26 +50,26 @@ Example:
 				Description: descFlag,
 			}
 
-			ctx := context.Background()
-
+			var h hosting.Hosting
 			switch hostingType {
 			case "local":
-				h := local.New(outDir, siteURL)
-				publisher := publish.New(h, p.Podcast)
-				if err := publisher.Run(ctx, in, opts); err != nil {
-					return err
-				}
+				h = local.New(outDir, siteURL)
 			case "ghpages":
-				h := ghpages.New(outDir, siteURL)
-				publisher := publish.New(h, p.Podcast)
-				if err := publisher.Run(ctx, in, opts); err != nil {
-					return err
-				}
-				if err := h.Push(ctx); err != nil {
-					return fmt.Errorf("push to gh-pages: %w", err)
-				}
+				h = ghpages.New(outDir, siteURL)
 			default:
 				return fmt.Errorf("unknown hosting type %q: must be \"local\" or \"ghpages\"", hostingType)
+			}
+
+			ctx := context.Background()
+			publisher := publish.New(h, p.Podcast)
+			if err := publisher.Run(ctx, in, opts); err != nil {
+				return err
+			}
+
+			if pusher, ok := h.(hosting.Pusher); ok {
+				if err := pusher.Push(ctx); err != nil {
+					return fmt.Errorf("push to gh-pages: %w", err)
+				}
 			}
 
 			effectiveDate := date

--- a/internal/publish/hosting/ghpages/ghpages.go
+++ b/internal/publish/hosting/ghpages/ghpages.go
@@ -1,0 +1,135 @@
+package ghpages
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+// Hosting implements hosting.Hosting using a local git working tree of the gh-pages branch.
+// Call Push to commit all staged files as a fresh orphan commit and force-push to origin.
+type Hosting struct {
+	dir     string
+	baseURL string
+}
+
+// New creates a Hosting that stages files in dir and constructs public URLs with the given baseURL prefix.
+// dir should be a local checkout of the gh-pages branch (or a git-initialized working tree).
+func New(dir, baseURL string) *Hosting {
+	return &Hosting{
+		dir:     dir,
+		baseURL: strings.TrimRight(baseURL, "/"),
+	}
+}
+
+// Push creates a fresh orphan commit from all files in dir and force-pushes to origin gh-pages.
+func (h *Hosting) Push(ctx context.Context) error {
+	type step struct {
+		name string
+		args []string
+	}
+
+	steps := []step{
+		{"config email", []string{"config", "user.email", "github-actions[bot]@users.noreply.github.com"}},
+		{"config name", []string{"config", "user.name", "github-actions[bot]"}},
+		{"checkout orphan", []string{"checkout", "--orphan", "gh-pages-deploy"}},
+		{"add all", []string{"add", "-A"}},
+		{"commit", []string{"commit", "-m", "Deploy to gh-pages"}},
+		{"push", []string{"push", "--force", "origin", "HEAD:gh-pages"}},
+	}
+
+	for _, s := range steps {
+		cmd := exec.CommandContext(ctx, "git", s.args...)
+		cmd.Dir = h.dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("git %s: %w\n%s", s.name, err, out)
+		}
+	}
+	return nil
+}
+
+func (h *Hosting) PutAudio(_ context.Context, name string, r io.Reader) (string, error) {
+	audioDir := filepath.Join(h.dir, "audio")
+	if err := os.MkdirAll(audioDir, 0o755); err != nil {
+		return "", fmt.Errorf("create audio dir: %w", err)
+	}
+
+	path := filepath.Join(audioDir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("create audio file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if _, err := io.Copy(f, r); err != nil {
+		return "", fmt.Errorf("write audio: %w", err)
+	}
+
+	return h.baseURL + "/audio/" + name, nil
+}
+
+func (h *Hosting) PutFeed(_ context.Context, feedXML []byte) (string, error) {
+	if err := os.MkdirAll(h.dir, 0o755); err != nil {
+		return "", fmt.Errorf("create dir: %w", err)
+	}
+
+	path := filepath.Join(h.dir, "feed.xml")
+	if err := os.WriteFile(path, feedXML, 0o644); err != nil {
+		return "", fmt.Errorf("write feed.xml: %w", err)
+	}
+
+	return h.baseURL + "/feed.xml", nil
+}
+
+func (h *Hosting) LoadEpisodes(_ context.Context) (model.Episodes, error) {
+	path := filepath.Join(h.dir, "episodes.json")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return model.Episodes{Episodes: make([]model.Episode, 0)}, nil
+	}
+	if err != nil {
+		return model.Episodes{}, fmt.Errorf("read episodes.json: %w", err)
+	}
+
+	var eps model.Episodes
+	if err := json.Unmarshal(data, &eps); err != nil {
+		return model.Episodes{}, fmt.Errorf("parse episodes.json: %w", err)
+	}
+	if eps.Episodes == nil {
+		eps.Episodes = make([]model.Episode, 0)
+	}
+	return eps, nil
+}
+
+func (h *Hosting) SaveEpisodes(_ context.Context, e model.Episodes) error {
+	if err := os.MkdirAll(h.dir, 0o755); err != nil {
+		return fmt.Errorf("create dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(e, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal episodes: %w", err)
+	}
+
+	path := filepath.Join(h.dir, "episodes.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write episodes.json: %w", err)
+	}
+	return nil
+}
+
+func (h *Hosting) DeleteAudio(_ context.Context, name string) error {
+	path := filepath.Join(h.dir, "audio", name)
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete audio %s: %w", name, err)
+	}
+	return nil
+}

--- a/internal/publish/hosting/ghpages/ghpages_test.go
+++ b/internal/publish/hosting/ghpages/ghpages_test.go
@@ -1,0 +1,313 @@
+package ghpages_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/publish/hosting/ghpages"
+)
+
+func TestHosting_PutAudio(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo")
+
+	content := []byte("fake mp3 data")
+	url, err := h.PutAudio(context.Background(), "episode_2026-05-30.mp3", bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("PutAudio: %v", err)
+	}
+
+	want := "https://owner.github.io/repo/audio/episode_2026-05-30.mp3"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "audio", "episode_2026-05-30.mp3"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Errorf("file content mismatch")
+	}
+}
+
+func TestHosting_PutAudio_TrailingSlash(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo/")
+
+	url, err := h.PutAudio(context.Background(), "ep.mp3", bytes.NewReader([]byte{}))
+	if err != nil {
+		t.Fatalf("PutAudio: %v", err)
+	}
+
+	if strings.Contains(url, "//audio/") {
+		t.Errorf("double slash in url: %q", url)
+	}
+	want := "https://owner.github.io/repo/audio/ep.mp3"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+}
+
+func TestHosting_PutFeed(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo")
+
+	feedXML := []byte(`<?xml version="1.0"?><rss></rss>`)
+	url, err := h.PutFeed(context.Background(), feedXML)
+	if err != nil {
+		t.Fatalf("PutFeed: %v", err)
+	}
+
+	want := "https://owner.github.io/repo/feed.xml"
+	if url != want {
+		t.Errorf("url = %q, want %q", url, want)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dir, "feed.xml"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if !bytes.Equal(got, feedXML) {
+		t.Errorf("feed.xml content mismatch")
+	}
+}
+
+func TestHosting_LoadEpisodes_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo")
+
+	eps, err := h.LoadEpisodes(context.Background())
+	if err != nil {
+		t.Fatalf("LoadEpisodes (not found): %v", err)
+	}
+	if len(eps.Episodes) != 0 {
+		t.Errorf("expected empty episodes, got %d", len(eps.Episodes))
+	}
+}
+
+func TestHosting_LoadEpisodes_Existing(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo")
+
+	data := `{"episodes":[{"guid":"ep1","title":"T","description":"D","pub_date":"2026-05-30T21:00:00Z","audio_url":"https://owner.github.io/repo/a.mp3","bytes":100,"duration":"00:01:00"}]}`
+	if err := os.WriteFile(filepath.Join(dir, "episodes.json"), []byte(data), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	eps, err := h.LoadEpisodes(context.Background())
+	if err != nil {
+		t.Fatalf("LoadEpisodes: %v", err)
+	}
+	if len(eps.Episodes) != 1 {
+		t.Fatalf("expected 1 episode, got %d", len(eps.Episodes))
+	}
+	if eps.Episodes[0].GUID != "ep1" {
+		t.Errorf("guid = %q, want ep1", eps.Episodes[0].GUID)
+	}
+}
+
+func TestHosting_SaveEpisodes(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo")
+
+	eps := model.Episodes{
+		Episodes: []model.Episode{
+			{
+				GUID:        "ep1",
+				Title:       "T",
+				Description: "D",
+				PubDate:     "2026-05-30T21:00:00Z",
+				AudioURL:    "https://owner.github.io/repo/a.mp3",
+				Bytes:       100,
+				Duration:    "00:01:00",
+			},
+		},
+	}
+	if err := h.SaveEpisodes(context.Background(), eps); err != nil {
+		t.Fatalf("SaveEpisodes: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "episodes.json"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), "ep1") {
+		t.Errorf("episodes.json does not contain ep1")
+	}
+}
+
+func TestHosting_SaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo")
+
+	original := model.Episodes{
+		Episodes: []model.Episode{
+			{
+				GUID:        "ep1",
+				Title:       "T",
+				Description: "D",
+				PubDate:     "2026-05-30T21:00:00Z",
+				AudioURL:    "https://owner.github.io/repo/a.mp3",
+				Bytes:       100,
+				Duration:    "00:01:00",
+			},
+		},
+	}
+	if err := h.SaveEpisodes(context.Background(), original); err != nil {
+		t.Fatalf("SaveEpisodes: %v", err)
+	}
+
+	loaded, err := h.LoadEpisodes(context.Background())
+	if err != nil {
+		t.Fatalf("LoadEpisodes: %v", err)
+	}
+	if len(loaded.Episodes) != 1 {
+		t.Fatalf("expected 1 episode, got %d", len(loaded.Episodes))
+	}
+	if loaded.Episodes[0].GUID != "ep1" {
+		t.Errorf("guid = %q, want ep1", loaded.Episodes[0].GUID)
+	}
+}
+
+func TestHosting_DeleteAudio(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo")
+
+	audioDir := filepath.Join(dir, "audio")
+	if err := os.MkdirAll(audioDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(audioDir, "ep.mp3"), []byte("data"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := h.DeleteAudio(context.Background(), "ep.mp3"); err != nil {
+		t.Fatalf("DeleteAudio: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(audioDir, "ep.mp3")); !os.IsNotExist(err) {
+		t.Error("file should be deleted")
+	}
+}
+
+func TestHosting_DeleteAudio_NonExistent(t *testing.T) {
+	dir := t.TempDir()
+	h := ghpages.New(dir, "https://owner.github.io/repo")
+
+	if err := h.DeleteAudio(context.Background(), "nonexistent.mp3"); err != nil {
+		t.Errorf("DeleteAudio (non-existent) should be no-op: %v", err)
+	}
+}
+
+func checkGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not in PATH")
+	}
+}
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func setupBareRemote(t *testing.T) string {
+	t.Helper()
+	remoteDir := t.TempDir()
+	gitRun(t, remoteDir, "init", "--bare")
+	return remoteDir
+}
+
+func setupWorkDir(t *testing.T, remoteDir string) string {
+	t.Helper()
+	workDir := t.TempDir()
+	gitRun(t, workDir, "init")
+	gitRun(t, workDir, "remote", "add", "origin", remoteDir)
+	return workDir
+}
+
+func TestHosting_Push(t *testing.T) {
+	checkGit(t)
+
+	remoteDir := setupBareRemote(t)
+	workDir := setupWorkDir(t, remoteDir)
+
+	h := ghpages.New(workDir, "https://owner.github.io/repo")
+
+	ctx := context.Background()
+	_, err := h.PutAudio(ctx, "ep.mp3", bytes.NewReader([]byte("audio data")))
+	if err != nil {
+		t.Fatalf("PutAudio: %v", err)
+	}
+	if err := h.SaveEpisodes(ctx, model.Episodes{
+		Episodes: []model.Episode{{GUID: "ep1", Title: "T", Description: "D", PubDate: "2026-05-30T21:00:00Z", AudioURL: "https://owner.github.io/repo/audio/ep.mp3", Bytes: 10, Duration: "00:00:01"}},
+	}); err != nil {
+		t.Fatalf("SaveEpisodes: %v", err)
+	}
+	if _, err := h.PutFeed(ctx, []byte(`<?xml version="1.0"?><rss></rss>`)); err != nil {
+		t.Fatalf("PutFeed: %v", err)
+	}
+
+	if err := h.Push(ctx); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	// Verify files are published to remote by cloning gh-pages branch
+	cloneDir := t.TempDir()
+	gitRun(t, cloneDir, "clone", "--branch", "gh-pages", remoteDir, ".")
+
+	for _, f := range []string{
+		filepath.Join("audio", "ep.mp3"),
+		"episodes.json",
+		"feed.xml",
+	} {
+		if _, err := os.Stat(filepath.Join(cloneDir, f)); err != nil {
+			t.Errorf("expected file %q in remote, got: %v", f, err)
+		}
+	}
+}
+
+func TestHosting_Push_Orphan(t *testing.T) {
+	checkGit(t)
+
+	remoteDir := setupBareRemote(t)
+	workDir := setupWorkDir(t, remoteDir)
+
+	h := ghpages.New(workDir, "https://owner.github.io/repo")
+
+	ctx := context.Background()
+	_, err := h.PutFeed(ctx, []byte(`<?xml version="1.0"?><rss></rss>`))
+	if err != nil {
+		t.Fatalf("PutFeed: %v", err)
+	}
+
+	// Push once
+	if err := h.Push(ctx); err != nil {
+		t.Fatalf("first Push: %v", err)
+	}
+
+	// Clone gh-pages and count commits — orphan should have exactly 1 commit
+	cloneDir := t.TempDir()
+	gitRun(t, cloneDir, "clone", "--branch", "gh-pages", remoteDir, ".")
+
+	cmd := exec.Command("git", "log", "--oneline")
+	cmd.Dir = cloneDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 commit (orphan), got %d: %s", len(lines), out)
+	}
+}

--- a/internal/publish/hosting/hosting.go
+++ b/internal/publish/hosting/hosting.go
@@ -14,3 +14,8 @@ type Hosting interface {
 	SaveEpisodes(ctx context.Context, e model.Episodes) error
 	DeleteAudio(ctx context.Context, name string) error
 }
+
+// Pusher is implemented by Hosting backends that require a post-publish push step.
+type Pusher interface {
+	Push(ctx context.Context) error
+}


### PR DESCRIPTION
## Summary

- `internal/publish/hosting/ghpages` パッケージを追加し、`Hosting` インターフェースの ghpages 実装を TDD で実装
- `PutAudio` / `PutFeed` / `LoadEpisodes` / `SaveEpisodes` / `DeleteAudio` — ローカルFS操作（local.Hosting と同様）
- `Push()` — orphan コミット＋force push で gh-pages ブランチへ公開
- `hosting.Pusher` インターフェースを追加し、CLI から実装型への直接依存を排除
- `vox-radio publish` コマンドに `--hosting local|ghpages` フラグを追加

## 変更ファイル

| ファイル | 変更内容 |
|---------|--------|
| `internal/publish/hosting/ghpages/ghpages.go` | ghpages Hosting 実装（新規） |
| `internal/publish/hosting/ghpages/ghpages_test.go` | テスト（新規）|
| `internal/publish/hosting/hosting.go` | `Pusher` インターフェース追加 |
| `internal/cli/publish.go` | `--hosting` フラグ追加・`Pusher` type assertion で push |
| `internal/cli/cli_test.go` | invalid hosting 値エラーテスト追加 |
| `docs/cli/vox-radio_publish.md` | CLIドキュメント自動再生成 |

## テスト計画

- [x] `go test ./...` — 全テスト PASS
- [x] `make lint` — 0 issues
- [x] `make fmt` — フォーマット済み
- [x] Push テストは tempdir の bare git リポジトリを remote として orphan commit を検証

Closes #15

---
🤖 Generated with [Claude Code](https://claude.ai/code)