### PR TITLE
docs: worktree 作業ルールを新設（編集前確認・PR マージ方法）

### DIFF
--- a/.claude/rules/worktree.md
+++ b/.claude/rules/worktree.md
@@ -1,0 +1,25 @@
+# worktree 作業ルール
+
+## ファイル編集前の確認
+
+worktree 環境でファイルを編集する前に、必ず以下を実行してカレントディレクトリとブランチを確認すること。
+
+```bash
+pwd
+git status
+```
+
+- worktree と main リポジトリのパスを混同しないよう、編集先が意図したブランチであることを確認してから作業を始める。
+
+## PR マージ方法
+
+worktree 環境では `gh pr merge` が失敗するため、代わりに GitHub API を直接呼び出してマージすること。
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr_number}/merge \
+  --method PUT \
+  --field merge_method=squash \
+  --field commit_title="{タイトル}"
+```
+
+- `gh pr merge` は main チェックアウト済み worktree 環境では動作しない。


### PR DESCRIPTION
## Summary

- `.claude/rules/worktree.md` を新規作成し、worktree 環境での作業手順を明文化した
- ファイル編集前に `pwd` / `git status` でカレントディレクトリとブランチを確認するルールを追加
- PR マージは `gh pr merge` ではなく `gh api` を使うルールを追加

Closes #26

---
🤖 Generated with [Claude Code](https://claude.ai/code)