### PR TITLE
feat: CLIドキュメント反映漏れチェックを自動化する（確認エージェント＋ローカルスキル）

### DIFF
--- a/.claude/agents/cli-doc-checker.md
+++ b/.claude/agents/cli-doc-checker.md
@@ -1,0 +1,79 @@
+---
+name: cli-doc-checker
+description: CLIドキュメントの乖離を検出するread-onlyサブエージェント。main.go / internal/cli/** 変更時に呼び出し、Short/Long・docs/cli/・READMEの整合性を一覧報告する。修正は行わない。
+tools: Bash, Glob, Grep, Read
+---
+
+# CLIドキュメント整合性チェック
+
+`internal/cli` の実装と `docs/cli/`、README の CLI セクションの乖離を検出して一覧報告する。**修正は行わない。**
+
+## チェック手順
+
+### 1. Short / Long の存在確認
+
+`internal/cli/*.go` の各コマンドに `Short` と `Long` が設定されているか確認する。
+
+```bash
+grep -n "Short:\|Long:" internal/cli/*.go
+```
+
+`Short` または `Long` が空文字列・未設定のコマンドファイルを特定して報告する。
+
+### 2. docs/cli/ の鮮度チェック（作業ツリーを汚さない方式）
+
+現在の `docs/cli/` をバックアップし、`make docs` で再生成して差分を確認してから元に戻す。
+
+```bash
+TMPDIR=$(mktemp -d)
+cp docs/cli/* "$TMPDIR/"
+make docs 2>/dev/null
+DIFF=$(diff -rq "$TMPDIR/" docs/cli/ 2>&1)
+cp "$TMPDIR/"* docs/cli/
+rm -rf "$TMPDIR"
+echo "$DIFF"
+```
+
+差分がなければ「ドキュメント最新」と報告する。差分があればファイル名を列挙する。
+
+### 3. README の CLI セクション整合性確認
+
+`internal/cli/*.go` の全サブコマンドが README のコマンドテーブルに記載されているか確認する。
+
+```bash
+# 実装側コマンド名（vox-radio ルートコマンドを除く）
+grep -h 'Use:' internal/cli/*.go | grep -v '"vox-radio"' | grep -oE '"[a-z-]+"' | tr -d '"' | sort -u
+
+# README のコマンドテーブル記載コマンド名（行頭が "| `コマンド名`" の行のみを対象）
+grep -E '^\| `[a-z-]+`' README.md | sed 's/^| `\([a-z-]*\)`.*/\1/' | sort -u
+```
+
+実装にあって README に記載がないコマンドを「不足」として報告する。
+
+## 出力形式
+
+```
+## CLIドキュメント整合性チェック結果
+
+### 1. Short/Long 確認
+- [OK] 全コマンドに Short/Long が設定されている
+  または
+- [NG] 以下のファイルで Short/Long が未設定:
+  - internal/cli/xxx.go: コマンド名
+
+### 2. docs/cli/ 差分
+- [OK] 差分なし（最新）
+  または
+- [NG] 差分あり（make docs の再実行が必要）:
+  - docs/cli/vox-radio_xxx.md
+
+### 3. README CLI セクション
+- [OK] 全コマンドが記載されている
+  または
+- [NG] 不足コマンド: xxx, yyy
+
+### 総合判定
+- [乖離なし] ドキュメントは最新です
+  または
+- [乖離あり] 上記 NG 項目を修正してください
+```

--- a/.claude/agents/cli-doc-checker.md
+++ b/.claude/agents/cli-doc-checker.md
@@ -18,7 +18,7 @@ tools: Bash, Glob, Grep, Read
 grep -n "Short:\|Long:" internal/cli/*.go
 ```
 
-`Short` または `Long` が空文字列・未設定のコマンドファイルを特定して報告する。
+出力結果を目視して、`Short` または `Long` の行がないコマンドファイルを特定して報告する（このgrepはフィールドの存在確認であり、空文字列は別途 `grep -n 'Short:.*""'` で確認すること）。
 
 ### 2. docs/cli/ の鮮度チェック（作業ツリーを汚さない方式）
 
@@ -27,11 +27,10 @@ grep -n "Short:\|Long:" internal/cli/*.go
 ```bash
 TMPDIR=$(mktemp -d)
 cp docs/cli/* "$TMPDIR/"
-make docs 2>/dev/null
-DIFF=$(diff -rq "$TMPDIR/" docs/cli/ 2>&1)
+make docs
+diff -rq "$TMPDIR/" docs/cli/
 cp "$TMPDIR/"* docs/cli/
 rm -rf "$TMPDIR"
-echo "$DIFF"
 ```
 
 差分がなければ「ドキュメント最新」と報告する。差分があればファイル名を列挙する。

--- a/.claude/agents/cli-doc-checker.md
+++ b/.claude/agents/cli-doc-checker.md
@@ -25,12 +25,12 @@ grep -n "Short:\|Long:" internal/cli/*.go
 現在の `docs/cli/` をバックアップし、`make docs` で再生成して差分を確認してから元に戻す。
 
 ```bash
-TMPDIR=$(mktemp -d)
-cp docs/cli/* "$TMPDIR/"
+BACKUP_DIR=$(mktemp -d)
+cp docs/cli/* "$BACKUP_DIR/"
 make docs
-diff -rq "$TMPDIR/" docs/cli/
-cp "$TMPDIR/"* docs/cli/
-rm -rf "$TMPDIR"
+diff -rq "$BACKUP_DIR/" docs/cli/
+cp "$BACKUP_DIR/"* docs/cli/
+rm -rf "$BACKUP_DIR"
 ```
 
 差分がなければ「ドキュメント最新」と報告する。差分があればファイル名を列挙する。

--- a/.claude/skills/cli-doc-review/SKILL.md
+++ b/.claude/skills/cli-doc-review/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: cli-doc-review
+description: main.go / internal/cli/** を変更したとき、CLIドキュメントの乖離を検出・修正するスキル。Short/Long文言・docs/cli/自動生成ドキュメント・READMEのCLIセクションを整合させてコミットする。
+allowed-tools: Bash, Read, Grep, Glob, Edit
+---
+
+## このスキルの起動タイミング
+
+- **手動実行**: ユーザーが `cli-doc-review` を明示的に呼んだとき。
+- **LLM 判断による自動起動**: `main.go` または `internal/cli/**` を変更した直後（CLIドキュメント反映ルールに従い漏れを防ぐ）。
+
+## 手順
+
+### ステップ1: 乖離を検出する
+
+以下のチェックを順に実施する。
+
+#### 1a. Short / Long の確認
+
+```bash
+grep -n "Short:\|Long:" internal/cli/*.go
+```
+
+`Short` または `Long` が空文字列・未設定のコマンドを特定する。
+
+#### 1b. docs/cli/ の鮮度チェック
+
+作業ツリーを汚さないよう `docs/cli/` をバックアップしてから再生成し、差分を確認して元に戻す。
+
+```bash
+TMPDIR=$(mktemp -d)
+cp docs/cli/* "$TMPDIR/"
+make docs 2>/dev/null
+diff -rq "$TMPDIR/" docs/cli/
+cp "$TMPDIR/"* docs/cli/
+rm -rf "$TMPDIR"
+```
+
+差分があれば対象ファイルを記録する。
+
+#### 1c. README の CLI セクション確認
+
+```bash
+# 実装側コマンド名（vox-radio ルートコマンドを除く）
+grep -h 'Use:' internal/cli/*.go | grep -v '"vox-radio"' | grep -oE '"[a-z-]+"' | tr -d '"' | sort -u
+
+# README のコマンドテーブル記載コマンド名（行頭が "| `コマンド名`" の行のみを対象）
+grep -E '^\| `[a-z-]+`' README.md | sed 's/^| `\([a-z-]*\)`.*/\1/' | sort -u
+```
+
+実装にあって README に記載がないコマンドを特定する。
+
+すべてのチェックで乖離がなければ「ドキュメント最新。修正不要。」と報告して終了する。
+
+---
+
+### ステップ2: docs/cli/ を再生成する
+
+ステップ1b で差分があった場合は `make docs` を実行してドキュメントを更新する。
+
+```bash
+make docs
+```
+
+---
+
+### ステップ3: Short / Long を修正する
+
+ステップ1a で未設定が見つかった場合、対象の `.go` ファイルを修正する。
+
+- `Short`: 動詞始まりの英語1行（例: `Collect articles from RSS feeds`）
+- `Long`: 詳細説明 + `Example:` セクション（他のコマンドを参考にする）
+
+修正後は再度 `make docs` を実行してドキュメントに反映させる。
+
+---
+
+### ステップ4: README を修正する
+
+ステップ1c で不足コマンドが見つかった場合、README のコマンドテーブルを更新する。
+
+- 追加コマンド: パイプライン順序（collect → script → synth → assemble → publish → prune / run）に合わせて行を挿入する
+- 削除コマンド: 対応行を削除する
+
+---
+
+### ステップ5: 修正をコミットする
+
+```bash
+git add docs/cli/ README.md internal/cli/
+git commit -m "docs: CLIドキュメントを更新する"
+```
+
+コミットメッセージは変更内容に応じて調整する（例: `docs: run コマンドを README に追記する`）。
+
+---
+
+### ステップ6: 再チェック
+
+ステップ1a〜1c を再度実行して乖離がなくなったことを確認する。
+
+乖離が残っている場合はステップ2〜5を繰り返す。

--- a/.claude/skills/cli-doc-review/SKILL.md
+++ b/.claude/skills/cli-doc-review/SKILL.md
@@ -21,7 +21,7 @@ allowed-tools: Bash, Read, Grep, Glob, Edit
 grep -n "Short:\|Long:" internal/cli/*.go
 ```
 
-`Short` または `Long` が空文字列・未設定のコマンドを特定する。
+出力結果を目視して、`Short` または `Long` の行がないコマンドを特定する（空文字列は別途 `grep -n 'Short:.*""'` で確認すること）。
 
 #### 1b. docs/cli/ の鮮度チェック
 
@@ -30,7 +30,7 @@ grep -n "Short:\|Long:" internal/cli/*.go
 ```bash
 TMPDIR=$(mktemp -d)
 cp docs/cli/* "$TMPDIR/"
-make docs 2>/dev/null
+make docs
 diff -rq "$TMPDIR/" docs/cli/
 cp "$TMPDIR/"* docs/cli/
 rm -rf "$TMPDIR"
@@ -86,8 +86,12 @@ make docs
 
 ### ステップ5: 修正をコミットする
 
+変更したファイルのみをステージングする（Short/Long を修正した場合のみ `internal/cli/` を追加する）。
+
 ```bash
-git add docs/cli/ README.md internal/cli/
+git add docs/cli/ README.md
+# Short/Long を修正した場合はさらに追加
+# git add internal/cli/<変更したファイル>
 git commit -m "docs: CLIドキュメントを更新する"
 ```
 

--- a/.claude/skills/cli-doc-review/SKILL.md
+++ b/.claude/skills/cli-doc-review/SKILL.md
@@ -28,12 +28,12 @@ grep -n "Short:\|Long:" internal/cli/*.go
 作業ツリーを汚さないよう `docs/cli/` をバックアップしてから再生成し、差分を確認して元に戻す。
 
 ```bash
-TMPDIR=$(mktemp -d)
-cp docs/cli/* "$TMPDIR/"
+BACKUP_DIR=$(mktemp -d)
+cp docs/cli/* "$BACKUP_DIR/"
 make docs
-diff -rq "$TMPDIR/" docs/cli/
-cp "$TMPDIR/"* docs/cli/
-rm -rf "$TMPDIR"
+diff -rq "$BACKUP_DIR/" docs/cli/
+cp "$BACKUP_DIR/"* docs/cli/
+rm -rf "$BACKUP_DIR"
 ```
 
 差分があれば対象ファイルを記録する。

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ collect → script → synth → assemble → publish
 | `assemble` | 音声クリップとイントロ・アウトロを ffmpeg で結合し MP3 エピソードを生成する |
 | `publish` | MP3 をホスティングディレクトリへコピーし、`episodes.json` と `feed.xml` を更新する |
 | `prune` | 直近 N 件を残して古いエピソードを削除し、`episodes.json` と `feed.xml` を更新する |
+| `run` | collect → script → synth → assemble → publish の全パイプラインを一括実行する |
 
 ### 設定ファイル
 


### PR DESCRIPTION
## Summary

- `.claude/agents/cli-doc-checker.md` を新設
  - `internal/cli` の Short/Long 確認・`docs/cli/` 鮮度チェック・README 整合性の3項目を一覧報告する read-only サブエージェント
  - バックアップ→再生成→diff→リストア方式で作業ツリーを汚さずに鮮度チェックを実施
- `.claude/skills/cli-doc-review/SKILL.md` を新設
  - `main.go` / `internal/cli/**` 変更時に自動起動し、乖離を検出・修正してコミットするスキル
- README のコマンドテーブルに `run` コマンドを追記（既存の記載漏れを修正）

## Test plan

- [ ] `cli-doc-review` スキル実行で `cli-doc-checker` が乖離なしと報告することを確認
- [ ] `internal/cli/` のコマンドを1つ変更して `docs/cli/` を更新しない状態で `cli-doc-checker` が差分を検出することを確認
- [ ] README コマンドテーブルからコマンドを1行削除した状態で `cli-doc-checker` が不足コマンドを報告することを確認

Closes #35

---
🤖 Generated with [Claude Code](https://claude.ai/code)