### PR TITLE
feat: config再編 #1 — voicevox.url・キャラカタログ追加と--config廃止

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,10 @@ collect → script → synth → assemble → publish
 
 | 種別 | ファイル | 内容 |
 |------|---------|------|
-| 共通設定 (config) | `vox-radio.yaml`（リポジトリ直下） | LLM のみ（ジャンル非依存） |
+| 共通設定 (config) | `vox-radio.yaml`（カレントディレクトリ、自動読込） | LLM / VOICEVOX URL / キャラカタログ |
 | ジャンル別設定 (profile) | `profiles/<genre>/profile.yaml` | feeds / show / assets / podcast |
+
+`vox-radio.yaml` はカレントディレクトリから自動的に読み込まれます（`--config` フラグは不要）。
 
 プロファイルは `profiles/` ディレクトリに配置します。サンプルは `profiles/tech/`（技術ニュース用）と `profiles/test/`（動作確認用）です。詳細は [profiles/README.md](profiles/README.md) を参照してください。
 
@@ -71,7 +73,7 @@ vox-radio collect --out work/articles.json --profile profiles/tech/profile.yaml
 
 # 台本を生成
 vox-radio script --in work/articles.json --out work/script.json \
-    --config vox-radio.yaml --profile profiles/tech/profile.yaml
+    --profile profiles/tech/profile.yaml
 
 # 音声合成（設定不要）
 vox-radio synth --in work/script.json --out-dir work/clips

--- a/docs/cli/vox-radio_run.md
+++ b/docs/cli/vox-radio_run.md
@@ -9,6 +9,8 @@ Run collect → script → synth → assemble → publish → prune in one shot.
 Intermediate files are written to <out-dir>/intermediate/ and the final
 episode.mp3 is placed directly under <out-dir>/.
 
+vox-radio.yaml is automatically loaded from the current directory.
+
 Example:
   vox-radio run
   vox-radio run --out-dir output --profile profiles/tech/profile.yaml
@@ -22,7 +24,6 @@ vox-radio run [flags]
 
 ```
       --base-url string      base URL for audio/feed URLs (default: site_url from profile)
-      --config string        common config YAML file path (LLM settings) (default "vox-radio.yaml")
       --date string          episode date YYYY-MM-DD (default: today)
       --description string   episode description
   -h, --help                 help for run

--- a/docs/cli/vox-radio_script.md
+++ b/docs/cli/vox-radio_script.md
@@ -7,6 +7,8 @@ Generate a script from collected articles using LLM
 Run the multi-stage LLM pipeline (summarize → plan → write → direct) to
 produce script.json from articles.json.
 
+vox-radio.yaml is automatically loaded from the current directory.
+
 Use --step to run a single stage independently:
   summarize  Summarize each article (writes summaries.json)
   plan       Plan corners from summaries (writes rundown.json)
@@ -16,7 +18,7 @@ Use --step to run a single stage independently:
 Example:
   vox-radio script --in work/articles.json --out work/script.json
   vox-radio script --out work/script.json --step plan
-  vox-radio script --in work/articles.json --out work/script.json --config vox-radio.yaml --profile profiles/tech/profile.yaml
+  vox-radio script --in work/articles.json --out work/script.json --profile profiles/tech/profile.yaml
 
 ```
 vox-radio script [flags]
@@ -25,7 +27,6 @@ vox-radio script [flags]
 ### Options
 
 ```
-      --config string    common config YAML file path (LLM settings) (default "vox-radio.yaml")
   -h, --help             help for script
       --in string        input articles.json path (required for full pipeline or summarize step)
       --out string       output script.json path (required)

--- a/docs/cli/vox-radio_synth.md
+++ b/docs/cli/vox-radio_synth.md
@@ -7,8 +7,8 @@ Synthesize voice clips from a script
 Read script.json and call VOICEVOX to synthesize each line into WAV clips.
 The output directory will contain per-line WAV files and a clips.json manifest.
 
-Environment:
-  VOICEVOX_ENGINE_URL  URL of the VOICEVOX engine (default: http://localhost:50021)
+vox-radio.yaml is automatically loaded from the current directory.
+The voicevox.url field specifies the VOICEVOX engine URL (default: http://localhost:50021).
 
 Example:
   vox-radio synth --in work/script.json --out-dir work/clips

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -23,7 +23,6 @@ import (
 
 func newRunCmd() *cobra.Command {
 	var outDir string
-	var configPath string
 	var profilePath string
 	var promptsDir string
 	var date string
@@ -40,12 +39,14 @@ func newRunCmd() *cobra.Command {
 Intermediate files are written to <out-dir>/intermediate/ and the final
 episode.mp3 is placed directly under <out-dir>/.
 
+vox-radio.yaml is automatically loaded from the current directory.
+
 Example:
   vox-radio run
   vox-radio run --out-dir output --profile profiles/tech/profile.yaml
   vox-radio run --hosting ghpages --date 2026-01-01`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.LoadConfig(configPath)
+			cfg, err := config.LoadConfig("vox-radio.yaml")
 			if err != nil {
 				return fmt.Errorf("load config: %w", err)
 			}
@@ -81,7 +82,7 @@ Example:
 				intermediateDir,
 			)
 
-			engineURL := os.Getenv("VOICEVOX_ENGINE_URL")
+			engineURL := cfg.Voicevox.URL
 			if engineURL == "" {
 				engineURL = "http://localhost:50021"
 			}
@@ -98,7 +99,7 @@ Example:
 				Profile:   p,
 				Collector: collect.New(nil),
 				Scripter:  scripter,
-				Synther:   synth.New(engineURL, p.Show),
+				Synther:   synth.New(engineURL, p.Show, cfg),
 				Assembler: assemble.New(p.Assets, p.Show),
 				Publisher: publish.New(h, p.Podcast),
 				Pruner:    publish.NewPruner(h, keep),
@@ -123,7 +124,6 @@ Example:
 	}
 
 	cmd.Flags().StringVar(&outDir, "out-dir", "output", "output directory (episode.mp3 placed here, intermediate files in <out-dir>/intermediate/)")
-	cmd.Flags().StringVar(&configPath, "config", "vox-radio.yaml", "common config YAML file path (LLM settings)")
 	cmd.Flags().StringVar(&profilePath, "profile", "profiles/test/profile.yaml", "profile YAML file path")
 	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "directory containing prompt templates")
 	cmd.Flags().StringVar(&date, "date", "", "episode date YYYY-MM-DD (default: today)")

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -23,7 +23,6 @@ func newScriptCmd() *cobra.Command {
 	var in string
 	var out string
 	var step string
-	var configPath string
 	var profilePath string
 	var promptsDir string
 
@@ -32,6 +31,8 @@ func newScriptCmd() *cobra.Command {
 		Short: "Generate a script from collected articles using LLM",
 		Long: `Run the multi-stage LLM pipeline (summarize → plan → write → direct) to
 produce script.json from articles.json.
+
+vox-radio.yaml is automatically loaded from the current directory.
 
 Use --step to run a single stage independently:
   summarize  Summarize each article (writes summaries.json)
@@ -42,9 +43,9 @@ Use --step to run a single stage independently:
 Example:
   vox-radio script --in work/articles.json --out work/script.json
   vox-radio script --out work/script.json --step plan
-  vox-radio script --in work/articles.json --out work/script.json --config vox-radio.yaml --profile profiles/tech/profile.yaml`,
+  vox-radio script --in work/articles.json --out work/script.json --profile profiles/tech/profile.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cfg, err := config.LoadConfig(configPath)
+			cfg, err := config.LoadConfig("vox-radio.yaml")
 			if err != nil {
 				return fmt.Errorf("load config: %w", err)
 			}
@@ -95,7 +96,6 @@ Example:
 	cmd.Flags().StringVar(&in, "in", "", "input articles.json path (required for full pipeline or summarize step)")
 	cmd.Flags().StringVar(&out, "out", "", "output script.json path (required)")
 	cmd.Flags().StringVar(&step, "step", "", "run a single step: summarize|plan|write|direct")
-	cmd.Flags().StringVar(&configPath, "config", "vox-radio.yaml", "common config YAML file path (LLM settings)")
 	cmd.Flags().StringVar(&profilePath, "profile", "profiles/test/profile.yaml", "profile YAML file path")
 	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "directory containing prompt templates")
 	_ = cmd.MarkFlagRequired("out")

--- a/internal/cli/synth.go
+++ b/internal/cli/synth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/synth"
 	"github.com/spf13/cobra"
@@ -21,12 +22,17 @@ func newSynthCmd() *cobra.Command {
 		Long: `Read script.json and call VOICEVOX to synthesize each line into WAV clips.
 The output directory will contain per-line WAV files and a clips.json manifest.
 
-Environment:
-  VOICEVOX_ENGINE_URL  URL of the VOICEVOX engine (default: http://localhost:50021)
+vox-radio.yaml is automatically loaded from the current directory.
+The voicevox.url field specifies the VOICEVOX engine URL (default: http://localhost:50021).
 
 Example:
   vox-radio synth --in work/script.json --out-dir work/clips`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.LoadConfig("vox-radio.yaml")
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
 			data, err := os.ReadFile(in)
 			if err != nil {
 				return fmt.Errorf("read script: %w", err)
@@ -41,12 +47,12 @@ Example:
 				Speakers:       map[string]int{},
 			}
 
-			engineURL := os.Getenv("VOICEVOX_ENGINE_URL")
+			engineURL := cfg.Voicevox.URL
 			if engineURL == "" {
 				engineURL = "http://localhost:50021"
 			}
 
-			s := synth.New(engineURL, showConfig)
+			s := synth.New(engineURL, showConfig, cfg)
 			meta, err := s.Run(context.Background(), scr, outDir)
 			if err != nil {
 				return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -68,10 +69,25 @@ type PodcastConfig struct {
 	MaxItems      int    `yaml:"max_items"`
 }
 
-// Config holds genre-independent common settings (LLM only).
+type VoicevoxConfig struct {
+	URL string `yaml:"url"`
+}
+
+type CharacterConfig struct {
+	Name         string         `yaml:"name"`
+	Pronoun      string         `yaml:"pronoun"`
+	SpeechSuffix []string       `yaml:"speech_suffix"`
+	Personality  []string       `yaml:"personality"`
+	DefaultStyle string         `yaml:"default_style"`
+	Styles       map[string]int `yaml:"styles"`
+}
+
+// Config holds genre-independent common settings.
 // It is loaded from vox-radio.yaml at the repository root.
 type Config struct {
-	LLM LLMConfig `yaml:"llm"`
+	LLM        LLMConfig                  `yaml:"llm"`
+	Voicevox   VoicevoxConfig             `yaml:"voicevox"`
+	Characters map[string]CharacterConfig `yaml:"characters"`
 }
 
 // Profile holds genre-specific settings (feeds, show, assets, podcast).
@@ -90,7 +106,21 @@ func LoadConfig(path string) (*Config, error) {
 	if err := loadYAML(path, cfg); err != nil {
 		return nil, err
 	}
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
 	return cfg, nil
+}
+
+func validateConfig(cfg *Config) error {
+	for id, ch := range cfg.Characters {
+		if ch.DefaultStyle != "" {
+			if _, ok := ch.Styles[ch.DefaultStyle]; !ok {
+				return fmt.Errorf("characters[%q].default_style %q not found in styles", id, ch.DefaultStyle)
+			}
+		}
+	}
+	return nil
 }
 
 // LoadProfile loads genre-specific settings from the given YAML file path.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -151,3 +151,56 @@ func TestLoadProfile_MissingFile(t *testing.T) {
 		t.Error("expected error for missing file")
 	}
 }
+
+func TestLoadConfig_Voicevox(t *testing.T) {
+	cfg, err := config.LoadConfig("testdata/config.yaml")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.Voicevox.URL == "" {
+		t.Error("Voicevox.URL must not be empty")
+	}
+}
+
+func TestLoadConfig_Characters(t *testing.T) {
+	cfg, err := config.LoadConfig("testdata/config.yaml")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if len(cfg.Characters) == 0 {
+		t.Error("Characters must not be empty")
+	}
+
+	ch, ok := cfg.Characters["zundamon"]
+	if !ok {
+		t.Fatal("Characters[\"zundamon\"] not found")
+	}
+	if ch.Name == "" {
+		t.Error("CharacterConfig.Name must not be empty")
+	}
+	if ch.Pronoun == "" {
+		t.Error("CharacterConfig.Pronoun must not be empty")
+	}
+	if len(ch.SpeechSuffix) == 0 {
+		t.Error("CharacterConfig.SpeechSuffix must not be empty")
+	}
+	if len(ch.Personality) == 0 {
+		t.Error("CharacterConfig.Personality must not be empty")
+	}
+	if ch.DefaultStyle == "" {
+		t.Error("CharacterConfig.DefaultStyle must not be empty")
+	}
+	if len(ch.Styles) == 0 {
+		t.Error("CharacterConfig.Styles must not be empty")
+	}
+	if _, ok := ch.Styles[ch.DefaultStyle]; !ok {
+		t.Errorf("DefaultStyle %q not found in Styles", ch.DefaultStyle)
+	}
+}
+
+func TestLoadConfig_ValidationError_DefaultStyleNotInStyles(t *testing.T) {
+	_, err := config.LoadConfig("testdata/config_invalid_default_style.yaml")
+	if err == nil {
+		t.Error("expected error when default_style is not in styles")
+	}
+}

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -9,3 +9,18 @@ llm:
     plan:      { temperature: 0.4 }
     write:     { temperature: 0.8 }
     direct:    { temperature: 0.2 }
+
+voicevox:
+  url: http://localhost:50021
+
+characters:
+  zundamon:
+    name: ずんだもん
+    pronoun: ボク
+    speech_suffix: ["〜のだ", "〜なのだ"]
+    personality: ["元気", "明るい", "素直", "前向き"]
+    default_style: ノーマル
+    styles:
+      ノーマル: 3
+      あまあま: 1
+      なみだめ: 76

--- a/internal/config/testdata/config_invalid_default_style.yaml
+++ b/internal/config/testdata/config_invalid_default_style.yaml
@@ -1,0 +1,21 @@
+llm:
+  base_url: https://example.com
+  api_key_env: TEST_KEY
+  model: test-model
+  temperature: 0.7
+  max_retries: 3
+  steps:
+    summarize: { temperature: 0.2 }
+
+voicevox:
+  url: http://localhost:50021
+
+characters:
+  zundamon:
+    name: ずんだもん
+    pronoun: ボク
+    speech_suffix: ["〜のだ"]
+    personality: ["元気"]
+    default_style: 存在しないスタイル
+    styles:
+      ノーマル: 3

--- a/internal/synth/synth.go
+++ b/internal/synth/synth.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/mediainfo"
 	"github.com/canpok1/vox-radio/internal/model"
 )
@@ -15,14 +16,17 @@ import (
 type Synth struct {
 	Client      VoicevoxClient
 	ShowConfig  model.ShowConfig
+	Config      *config.Config
 	getDuration func(path string) (float64, error)
 }
 
-// New creates a new Synth with an HTTP VOICEVOX client
-func New(engineURL string, showConfig model.ShowConfig) *Synth {
+// New creates a new Synth with an HTTP VOICEVOX client.
+// cfg carries the character catalog for future speaker resolution (#2).
+func New(engineURL string, showConfig model.ShowConfig, cfg *config.Config) *Synth {
 	return &Synth{
 		Client:      NewClient(engineURL),
 		ShowConfig:  showConfig,
+		Config:      cfg,
 		getDuration: mediainfo.Duration,
 	}
 }

--- a/internal/synth/synth_test.go
+++ b/internal/synth/synth_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
@@ -211,6 +212,22 @@ func TestSynth_Run_UsesSpeakerFromShowConfig(t *testing.T) {
 		if gotSpeakers[i] != want[i] {
 			t.Errorf("speaker[%d]: got %d, want %d", i, gotSpeakers[i], want[i])
 		}
+	}
+}
+
+func TestNew_StoresConfig(t *testing.T) {
+	cfg := &config.Config{
+		Voicevox: config.VoicevoxConfig{URL: "http://localhost:50021"},
+		Characters: map[string]config.CharacterConfig{
+			"zundamon": {Name: "ずんだもん", DefaultStyle: "ノーマル", Styles: map[string]int{"ノーマル": 3}},
+		},
+	}
+	showConfig := model.ShowConfig{DefaultSpeaker: 3, Speakers: map[string]int{}}
+
+	s := New("http://localhost:50021", showConfig, cfg)
+
+	if s.Config != cfg {
+		t.Error("New should store the config in Synth.Config")
 	}
 }
 

--- a/vox-radio.yaml
+++ b/vox-radio.yaml
@@ -9,3 +9,36 @@ llm:
     plan:      { temperature: 0.4 }
     write:     { temperature: 0.8 }
     direct:    { temperature: 0.2 }
+
+voicevox:
+  url: http://localhost:50021
+
+characters:
+  zundamon:
+    name: ずんだもん
+    pronoun: ボク
+    speech_suffix: ["〜のだ", "〜なのだ"]
+    personality: ["元気", "明るい", "素直", "前向き"]
+    default_style: ノーマル
+    styles:
+      ノーマル: 3
+      あまあま: 1
+      なみだめ: 76
+  zundako:
+    name: ずん子
+    pronoun: 私
+    speech_suffix: ["〜ですわ", "〜ですの"]
+    personality: ["知的", "冷静", "丁寧", "分析的"]
+    default_style: ノーマル
+    styles:
+      ノーマル: 22
+  metan:
+    name: 四国めたん
+    pronoun: うち
+    speech_suffix: ["〜やん", "〜やで"]
+    personality: ["活発", "関西弁", "陽気", "世話好き"]
+    default_style: ノーマル
+    styles:
+      ノーマル: 2
+      あまあま: 0
+      ツンツン: 6


### PR DESCRIPTION
## Summary

- `vox-radio.yaml` に `voicevox.url` と `characters`（キャラカタログ）を追加
- `--config` フラグを廃止し、全コマンドで `vox-radio.yaml` を固定パスから自動読込
- VOICEVOX エンジン URL を環境変数 `VOICEVOX_ENGINE_URL` から `cfg.Voicevox.URL` へ移行
- `synth.New` に `*config.Config` を追加してキャラカタログを受け渡し可能に（実際の解決は #2）
- `default_style` が `styles` に存在しない場合のバリデーションを追加

## Changes

### config
- `VoicevoxConfig { URL string }` / `CharacterConfig { Name, Pronoun, SpeechSuffix, Personality, DefaultStyle, Styles }` を追加
- `Config` に `Voicevox` / `Characters` フィールドを追加
- `validateConfig`: `default_style` が `styles` に存在するかチェック

### synth
- `Synth` に `Config *config.Config` フィールドを追加
- `synth.New(engineURL, showConfig, cfg)` に第3引数 `cfg` を追加

### CLI
- `run` / `script` / `synth` から `--config` フラグを廃止
- `synth` コマンドに `config.LoadConfig("vox-radio.yaml")` を追加
- VOICEVOX URL ソースを `cfg.Voicevox.URL`（フォールバック: `http://localhost:50021`）に変更

### Docs / Config
- `vox-radio.yaml` に voicevox + characters（ずんだもん・ずん子・めたん）追加
- `make docs` で `docs/cli/` を再生成（`--config` 記述を削除）
- `README.md` の設定説明・実行例を更新

Closes #46

---
🤖 Generated with [Claude Code](https://claude.ai/code)