### PR TITLE
feat: feeds/articles を corner.source へ移動しcollectをコーナー単位収集に変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ collect → script → synth → assemble → publish
 
 | コマンド | 概要 |
 |----------|------|
-| `collect` | RSS フィードや URL から記事を収集し `articles.json` を生成する |
+| `collect` | `corners[].source` に定義したフィード・URL からコーナーごとに記事を収集し `articles.json` を生成する |
 | `script` | 記事を LLM に渡して台本 `script.json` を生成する（summarize → write → direct の多段パイプライン） |
 | `synth` | `script.json` をもとに VOICEVOX で音声クリップを合成する |
 | `assemble` | 音声クリップとイントロ・アウトロを ffmpeg で結合し MP3 エピソードを生成する |
@@ -59,7 +59,7 @@ collect → script → synth → assemble → publish
 | 種別 | ファイル | 内容 |
 |------|---------|------|
 | 共通設定 (config) | `vox-radio.yaml`（カレントディレクトリ、自動読込） | LLM / VOICEVOX URL / キャラカタログ |
-| ジャンル別設定 (profile) | `profiles/<genre>/profile.yaml` | feeds / program / corners / assets |
+| ジャンル別設定 (profile) | `profiles/<genre>/profile.yaml` | program / corners（各コーナーの source でデータソース指定） / assets |
 
 `vox-radio.yaml` はカレントディレクトリから自動的に読み込まれます（`--config` フラグは不要）。
 

--- a/docs/cli/vox-radio.md
+++ b/docs/cli/vox-radio.md
@@ -18,7 +18,7 @@ synthesizing voice clips, assembling audio, and publishing RSS feeds.
 ### SEE ALSO
 
 * [vox-radio assemble](vox-radio_assemble.md)	 - Assemble WAV clips into an MP3 episode
-* [vox-radio collect](vox-radio_collect.md)	 - Collect articles from RSS feeds and URLs
+* [vox-radio collect](vox-radio_collect.md)	 - Collect articles from RSS feeds and URLs per corner
 * [vox-radio prune](vox-radio_prune.md)	 - Remove old episodes, keeping only the most recent N
 * [vox-radio publish](vox-radio_publish.md)	 - Publish an episode to the hosting directory
 * [vox-radio run](vox-radio_run.md)	 - Run the full podcast production pipeline

--- a/docs/cli/vox-radio_collect.md
+++ b/docs/cli/vox-radio_collect.md
@@ -1,11 +1,13 @@
 ## vox-radio collect
 
-Collect articles from RSS feeds and URLs
+Collect articles from RSS feeds and URLs per corner
 
 ### Synopsis
 
-Collect articles from RSS feeds and web URLs defined in the profile,
+Collect articles from RSS feeds and web URLs defined in corners[].source,
 extract their body text, and write the result to articles.json.
+
+Corners without a source field are skipped.
 
 Example:
   vox-radio collect --out work/articles.json

--- a/docs/cli/vox-radio_script.md
+++ b/docs/cli/vox-radio_script.md
@@ -11,7 +11,7 @@ vox-radio.yaml is automatically loaded from the current directory.
 Corner definitions come from the profile (no plan step).
 
 Use --step to run a single stage independently:
-  summarize  Summarize each article (writes summaries.json)
+  summarize  Summarize each article per corner (writes summaries.json)
   write      Write lines per corner (writes lines.json)
   direct     Assign SE/speakers to lines (writes script.json)
 

--- a/internal/cli/collect.go
+++ b/internal/cli/collect.go
@@ -15,9 +15,11 @@ func newCollectCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "collect",
-		Short: "Collect articles from RSS feeds and URLs",
-		Long: `Collect articles from RSS feeds and web URLs defined in the profile,
+		Short: "Collect articles from RSS feeds and URLs per corner",
+		Long: `Collect articles from RSS feeds and web URLs defined in corners[].source,
 extract their body text, and write the result to articles.json.
+
+Corners without a source field are skipped.
 
 Example:
   vox-radio collect --out work/articles.json
@@ -29,10 +31,7 @@ Example:
 			}
 
 			c := collect.New(nil)
-			articles, err := c.Run(context.Background(), config.FeedsConfig{
-				Feeds:    p.Feeds,
-				Articles: p.Articles,
-			})
+			articles, err := c.RunAll(context.Background(), p.Corners)
 			if err != nil {
 				return err
 			}
@@ -41,7 +40,11 @@ Example:
 				return err
 			}
 
-			fmt.Printf("collected %d articles to %s\n", len(articles.Articles), out)
+			total := 0
+			for _, ca := range articles.Corners {
+				total += len(ca.Articles)
+			}
+			fmt.Printf("collected %d articles across %d corners to %s\n", total, len(articles.Corners), out)
 			return nil
 		},
 	}

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -167,16 +167,12 @@ func runScriptWrite(ctx context.Context, workDir string, c llm.Client, llmCfg co
 		return fmt.Errorf("parse summaries.json: %w", err)
 	}
 
-	cornerSumsMap := make(map[string][]model.Summary, len(sums.Corners))
-	for _, cs := range sums.Corners {
-		cornerSumsMap[cs.CornerTitle] = cs.Summaries
-	}
+	cornerSumsMap := sums.CornerMap()
 
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(llmCfg, "write"))
 	allLines := make([]model.Line, 0)
 	for _, corner := range p.Corners {
-		cornerSums := cornerSumsMap[corner.Title]
-		lines, err := w.Write(ctx, corner, cornerSums, chars)
+		lines, err := w.Write(ctx, corner, cornerSumsMap[corner.Title], chars)
 		if err != nil {
 			return fmt.Errorf("write corner %q: %w", corner.Title, err)
 		}

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -35,7 +35,7 @@ vox-radio.yaml is automatically loaded from the current directory.
 Corner definitions come from the profile (no plan step).
 
 Use --step to run a single stage independently:
-  summarize  Summarize each article (writes summaries.json)
+  summarize  Summarize each article per corner (writes summaries.json)
   write      Write lines per corner (writes lines.json)
   direct     Assign SE/speakers to lines (writes script.json)
 
@@ -112,7 +112,7 @@ func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, l
 		workDir,
 	)
 
-	scr, err := gen.Generate(ctx, articles.Articles, p.Corners, chars)
+	scr, err := gen.Generate(ctx, articles, p.Corners, chars)
 	if err != nil {
 		return fmt.Errorf("generate: %w", err)
 	}
@@ -130,20 +130,29 @@ func runScriptSummarize(ctx context.Context, in, workDir string, c llm.Client, l
 	}
 
 	s := summarize.NewLLMSummarizer(c, prompts["summarize"], stepTemp(llmCfg, "summarize"))
-	summaries := make([]model.Summary, 0, len(articles.Articles))
-	for _, a := range articles.Articles {
-		sum, err := s.Summarize(ctx, a)
-		if err != nil {
-			return fmt.Errorf("summarize %q: %w", a.URL, err)
+	cornerSummaries := make([]model.CornerSummaries, 0, len(articles.Corners))
+	totalCount := 0
+	for _, ca := range articles.Corners {
+		sums := make([]model.Summary, 0, len(ca.Articles))
+		for _, a := range ca.Articles {
+			sum, err := s.Summarize(ctx, a)
+			if err != nil {
+				return fmt.Errorf("summarize %q: %w", a.URL, err)
+			}
+			sums = append(sums, sum)
 		}
-		summaries = append(summaries, sum)
+		cornerSummaries = append(cornerSummaries, model.CornerSummaries{
+			CornerTitle: ca.CornerTitle,
+			Summaries:   sums,
+		})
+		totalCount += len(sums)
 	}
 
 	outPath := filepath.Join(workDir, "summaries.json")
-	if err := writeJSON(outPath, model.Summaries{Summaries: summaries}); err != nil {
+	if err := writeJSON(outPath, model.Summaries{Corners: cornerSummaries}); err != nil {
 		return err
 	}
-	fmt.Printf("summarized %d articles to %s\n", len(summaries), outPath)
+	fmt.Printf("summarized %d articles to %s\n", totalCount, outPath)
 	return nil
 }
 
@@ -158,10 +167,16 @@ func runScriptWrite(ctx context.Context, workDir string, c llm.Client, llmCfg co
 		return fmt.Errorf("parse summaries.json: %w", err)
 	}
 
+	cornerSumsMap := make(map[string][]model.Summary, len(sums.Corners))
+	for _, cs := range sums.Corners {
+		cornerSumsMap[cs.CornerTitle] = cs.Summaries
+	}
+
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(llmCfg, "write"))
 	allLines := make([]model.Line, 0)
 	for _, corner := range p.Corners {
-		lines, err := w.Write(ctx, corner, sums.Summaries, chars)
+		cornerSums := cornerSumsMap[corner.Title]
+		lines, err := w.Write(ctx, corner, cornerSums, chars)
 		if err != nil {
 			return fmt.Errorf("write corner %q: %w", corner.Title, err)
 		}

--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -23,13 +23,13 @@ func New(client *http.Client) *Collector {
 }
 
 // Run collects articles from all feeds and individual URLs in cfg.
-func (c *Collector) Run(ctx context.Context, cfg config.FeedsConfig) (model.Articles, error) {
+func (c *Collector) Run(ctx context.Context, cfg config.FeedsConfig) ([]model.Article, error) {
 	articles := make([]model.Article, 0)
 
 	for _, feed := range cfg.Feeds {
 		items, err := c.fetchFeed(ctx, feed.URL, feed.MaxItems)
 		if err != nil {
-			return model.Articles{}, fmt.Errorf("fetch feed %s: %w", feed.URL, err)
+			return nil, fmt.Errorf("fetch feed %s: %w", feed.URL, err)
 		}
 		articles = append(articles, items...)
 	}
@@ -37,10 +37,34 @@ func (c *Collector) Run(ctx context.Context, cfg config.FeedsConfig) (model.Arti
 	for _, u := range cfg.Articles {
 		article, err := c.fetchArticle(ctx, u)
 		if err != nil {
-			return model.Articles{}, fmt.Errorf("fetch article %s: %w", u, err)
+			return nil, fmt.Errorf("fetch article %s: %w", u, err)
 		}
 		articles = append(articles, *article)
 	}
 
-	return model.Articles{Articles: articles}, nil
+	return articles, nil
+}
+
+// RunAll collects articles per corner, skipping corners with no source.
+func (c *Collector) RunAll(ctx context.Context, corners []config.CornerConfig) (model.Articles, error) {
+	result := make([]model.CornerArticles, 0, len(corners))
+
+	for _, corner := range corners {
+		if corner.Source == nil {
+			continue
+		}
+		articles, err := c.Run(ctx, config.FeedsConfig{
+			Feeds:    corner.Source.Feeds,
+			Articles: corner.Source.Articles,
+		})
+		if err != nil {
+			return model.Articles{}, fmt.Errorf("collect corner %q: %w", corner.Title, err)
+		}
+		result = append(result, model.CornerArticles{
+			CornerTitle: corner.Title,
+			Articles:    articles,
+		})
+	}
+
+	return model.Articles{Corners: result}, nil
 }

--- a/internal/collect/collect_test.go
+++ b/internal/collect/collect_test.go
@@ -72,8 +72,8 @@ func TestCollector_Run_RSSAppliesMaxItems(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(result.Articles) != 2 {
-		t.Errorf("articles count: got %d, want 2", len(result.Articles))
+	if len(result) != 2 {
+		t.Errorf("articles count: got %d, want 2", len(result))
 	}
 }
 
@@ -97,10 +97,10 @@ func TestCollector_Run_RSSParsesFields(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(result.Articles) == 0 {
+	if len(result) == 0 {
 		t.Fatal("no articles returned")
 	}
-	art := result.Articles[0]
+	art := result[0]
 	if art.Title != "AIチップの最新動向" {
 		t.Errorf("title: got %q, want %q", art.Title, "AIチップの最新動向")
 	}
@@ -130,10 +130,10 @@ func TestCollector_Run_ArticleExtractsBody(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(result.Articles) != 1 {
-		t.Fatalf("articles count: got %d, want 1", len(result.Articles))
+	if len(result) != 1 {
+		t.Fatalf("articles count: got %d, want 1", len(result))
 	}
-	art := result.Articles[0]
+	art := result[0]
 	if art.Title != "テスト記事タイトル" {
 		t.Errorf("title: got %q, want %q", art.Title, "テスト記事タイトル")
 	}
@@ -142,6 +142,79 @@ func TestCollector_Run_ArticleExtractsBody(t *testing.T) {
 	}
 	if strings.Contains(art.Body, "ナビゲーション") {
 		t.Errorf("body should not contain nav text, got: %q", art.Body)
+	}
+}
+
+func TestCollector_RunAll_SkipsSourcelessCorners(t *testing.T) {
+	corners := []config.CornerConfig{
+		{Title: "ソースなし", Content: "挨拶のみ"},
+		{Title: "ソースあり", Content: "ニュース", Source: &config.SourceConfig{}},
+	}
+
+	c := collect.New(nil)
+	result, err := c.RunAll(context.Background(), corners)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Corners) != 1 {
+		t.Fatalf("corners count: got %d, want 1 (source-less skipped)", len(result.Corners))
+	}
+	if result.Corners[0].CornerTitle != "ソースあり" {
+		t.Errorf("corner title: got %q, want %q", result.Corners[0].CornerTitle, "ソースあり")
+	}
+}
+
+func TestCollector_RunAll_CollectsPerCorner(t *testing.T) {
+	rssData := loadTestdata(t, "feed.xml")
+	htmlData := loadTestdata(t, "article.html")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".xml") {
+			w.Header().Set("Content-Type", "application/rss+xml")
+			_, _ = w.Write(rssData)
+		} else {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write(htmlData)
+		}
+	}))
+	defer server.Close()
+
+	corners := []config.CornerConfig{
+		{
+			Title: "コーナーA",
+			Source: &config.SourceConfig{
+				Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 1}},
+			},
+		},
+		{
+			Title: "コーナーB",
+			Source: &config.SourceConfig{
+				Articles: []string{server.URL + "/article.html"},
+			},
+		},
+	}
+
+	c := collect.New(server.Client())
+	result, err := c.RunAll(context.Background(), corners)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Corners) != 2 {
+		t.Fatalf("corners count: got %d, want 2", len(result.Corners))
+	}
+	if result.Corners[0].CornerTitle != "コーナーA" {
+		t.Errorf("corners[0].title: got %q, want %q", result.Corners[0].CornerTitle, "コーナーA")
+	}
+	if len(result.Corners[0].Articles) != 1 {
+		t.Errorf("corners[0].articles count: got %d, want 1", len(result.Corners[0].Articles))
+	}
+	if result.Corners[1].CornerTitle != "コーナーB" {
+		t.Errorf("corners[1].title: got %q, want %q", result.Corners[1].CornerTitle, "コーナーB")
+	}
+	if len(result.Corners[1].Articles) != 1 {
+		t.Errorf("corners[1].articles count: got %d, want 1", len(result.Corners[1].Articles))
 	}
 }
 
@@ -173,7 +246,7 @@ func TestCollector_Run_CombinesFeedsAndArticles(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(result.Articles) != 2 {
-		t.Errorf("articles count: got %d, want 2 (1 RSS + 1 individual)", len(result.Articles))
+	if len(result) != 2 {
+		t.Errorf("articles count: got %d, want 2 (1 RSS + 1 individual)", len(result))
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,12 @@ type ProgramConfig struct {
 	SegmentPauseSec float64 `yaml:"segment_pause_sec"`
 }
 
+// SourceConfig defines the data sources for a corner (feeds and individual article URLs).
+type SourceConfig struct {
+	Feeds    []FeedEntry `yaml:"feeds"`
+	Articles []string    `yaml:"articles"`
+}
+
 // CornerConfig defines a fixed corner in the program structure.
 // target_chars is provisional; will be replaced by target_duration_sec in #4.
 type CornerConfig struct {
@@ -76,6 +82,7 @@ type CornerConfig struct {
 	Content     string            `yaml:"content"`
 	Cast        map[string]string `yaml:"cast"`
 	TargetChars int               `yaml:"target_chars"`
+	Source      *SourceConfig     `yaml:"source,omitempty"`
 }
 
 type VoicevoxConfig struct {
@@ -108,14 +115,13 @@ type Config struct {
 	Characters map[string]CharacterConfig `yaml:"characters"`
 }
 
-// Profile holds genre-specific settings (feeds, program, corners, assets).
+// Profile holds genre-specific settings (program, corners, assets).
 // It is loaded from profiles/<genre>/profile.yaml.
+// Data sources (feeds, articles) are defined per-corner in corners[].source.
 type Profile struct {
-	Program  ProgramConfig  `yaml:"program"`
-	Corners  []CornerConfig `yaml:"corners"`
-	Feeds    []FeedEntry    `yaml:"feeds"`
-	Articles []string       `yaml:"articles"`
-	Assets   AssetsConfig   `yaml:"assets"`
+	Program ProgramConfig  `yaml:"program"`
+	Corners []CornerConfig `yaml:"corners"`
+	Assets  AssetsConfig   `yaml:"assets"`
 }
 
 // LoadConfig loads common settings from the given YAML file path.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -76,15 +76,25 @@ func TestLoadProfile(t *testing.T) {
 		}
 	})
 
-	t.Run("Feeds", func(t *testing.T) {
-		if len(profile.Feeds) == 0 {
-			t.Error("Feeds must not be empty")
+	t.Run("CornerSource", func(t *testing.T) {
+		var sourceCorner *config.CornerConfig
+		for i := range profile.Corners {
+			if profile.Corners[i].Source != nil {
+				sourceCorner = &profile.Corners[i]
+				break
+			}
 		}
-		if profile.Feeds[0].URL == "" {
-			t.Error("Feeds[0].URL must not be empty")
+		if sourceCorner == nil {
+			t.Fatal("no corner with source found")
 		}
-		if len(profile.Articles) == 0 {
-			t.Error("Articles must not be empty")
+		if len(sourceCorner.Source.Feeds) == 0 {
+			t.Error("Source.Feeds must not be empty")
+		}
+		if sourceCorner.Source.Feeds[0].URL == "" {
+			t.Error("Source.Feeds[0].URL must not be empty")
+		}
+		if len(sourceCorner.Source.Articles) == 0 {
+			t.Error("Source.Articles must not be empty")
 		}
 	})
 

--- a/internal/config/testdata/profile.yaml
+++ b/internal/config/testdata/profile.yaml
@@ -21,12 +21,13 @@ corners:
     cast:
       zundamon: "司会"
     target_chars: 200
+    source:
+      feeds:
+        - url: https://example.com/rss.xml
+          max_items: 3
+      articles:
+        - https://example.com/articles/1
 
-feeds:
-  - url: https://example.com/rss.xml
-    max_items: 3
-articles:
-  - https://example.com/articles/1
 assets:
   jingle:
     opening: { file: assets/jingle/opening.mp3, fade_in: 0.5, fade_out: 0.5 }

--- a/internal/model/article.go
+++ b/internal/model/article.go
@@ -14,3 +14,12 @@ type CornerArticles struct {
 type Articles struct {
 	Corners []CornerArticles `json:"corners"`
 }
+
+// CornerMap returns a map from corner title to its articles.
+func (a Articles) CornerMap() map[string][]Article {
+	m := make(map[string][]Article, len(a.Corners))
+	for _, ca := range a.Corners {
+		m[ca.CornerTitle] = ca.Articles
+	}
+	return m
+}

--- a/internal/model/article.go
+++ b/internal/model/article.go
@@ -6,6 +6,11 @@ type Article struct {
 	Body  string `json:"body"`
 }
 
+type CornerArticles struct {
+	CornerTitle string    `json:"corner_title"`
+	Articles    []Article `json:"articles"`
+}
+
 type Articles struct {
-	Articles []Article `json:"articles"`
+	Corners []CornerArticles `json:"corners"`
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -48,10 +48,17 @@ func TestArticles_RoundTrip(t *testing.T) {
 
 func TestArticles_Fields(t *testing.T) {
 	v := unmarshalFixture[model.Articles](t, "articles.json")
-	if len(v.Articles) == 0 {
-		t.Error("expected at least one article")
+	if len(v.Corners) == 0 {
+		t.Error("expected at least one corner")
 	}
-	a := v.Articles[0]
+	ca := v.Corners[0]
+	if ca.CornerTitle == "" {
+		t.Error("CornerTitle must not be empty")
+	}
+	if len(ca.Articles) == 0 {
+		t.Error("expected at least one article in corner")
+	}
+	a := ca.Articles[0]
 	if a.URL == "" {
 		t.Error("URL must not be empty")
 	}
@@ -69,10 +76,17 @@ func TestSummaries_RoundTrip(t *testing.T) {
 
 func TestSummaries_Fields(t *testing.T) {
 	v := unmarshalFixture[model.Summaries](t, "summaries.json")
-	if len(v.Summaries) == 0 {
-		t.Error("expected at least one summary")
+	if len(v.Corners) == 0 {
+		t.Error("expected at least one corner")
 	}
-	s := v.Summaries[0]
+	cs := v.Corners[0]
+	if cs.CornerTitle == "" {
+		t.Error("CornerTitle must not be empty")
+	}
+	if len(cs.Summaries) == 0 {
+		t.Error("expected at least one summary in corner")
+	}
+	s := cs.Summaries[0]
 	if s.URL == "" {
 		t.Error("URL must not be empty")
 	}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -70,6 +70,39 @@ func TestArticles_Fields(t *testing.T) {
 	}
 }
 
+func TestArticles_CornerMap(t *testing.T) {
+	art1 := model.Article{URL: "https://example.com/1", Title: "T1", Body: "B1"}
+	art2 := model.Article{URL: "https://example.com/2", Title: "T2", Body: "B2"}
+	a := model.Articles{
+		Corners: []model.CornerArticles{
+			{CornerTitle: "ニュース", Articles: []model.Article{art1}},
+			{CornerTitle: "エンディング", Articles: []model.Article{art2}},
+		},
+	}
+
+	m := a.CornerMap()
+
+	if len(m) != 2 {
+		t.Fatalf("map length: got %d, want 2", len(m))
+	}
+	if arts := m["ニュース"]; len(arts) != 1 || arts[0].URL != art1.URL {
+		t.Errorf("CornerMap[\"ニュース\"]: got %v, want [%v]", arts, art1)
+	}
+	if arts := m["エンディング"]; len(arts) != 1 || arts[0].URL != art2.URL {
+		t.Errorf("CornerMap[\"エンディング\"]: got %v, want [%v]", arts, art2)
+	}
+	if _, ok := m["存在しないコーナー"]; ok {
+		t.Error("missing key should not exist in map")
+	}
+}
+
+func TestArticles_CornerMap_Empty(t *testing.T) {
+	m := model.Articles{}.CornerMap()
+	if len(m) != 0 {
+		t.Errorf("empty Articles.CornerMap() should return empty map, got %d entries", len(m))
+	}
+}
+
 func TestSummaries_RoundTrip(t *testing.T) {
 	roundTrip[model.Summaries](t, loadFixture(t, "summaries.json"))
 }
@@ -95,6 +128,36 @@ func TestSummaries_Fields(t *testing.T) {
 	}
 	if len(s.Points) == 0 {
 		t.Error("Points must not be empty")
+	}
+}
+
+func TestSummaries_CornerMap(t *testing.T) {
+	sum1 := model.Summary{URL: "https://example.com/1", Summary: "S1", Points: []string{"p1"}}
+	sum2 := model.Summary{URL: "https://example.com/2", Summary: "S2", Points: []string{"p2"}}
+	s := model.Summaries{
+		Corners: []model.CornerSummaries{
+			{CornerTitle: "ニュース", Summaries: []model.Summary{sum1}},
+			{CornerTitle: "エンディング", Summaries: []model.Summary{sum2}},
+		},
+	}
+
+	m := s.CornerMap()
+
+	if len(m) != 2 {
+		t.Fatalf("map length: got %d, want 2", len(m))
+	}
+	if sums := m["ニュース"]; len(sums) != 1 || sums[0].URL != sum1.URL {
+		t.Errorf("CornerMap[\"ニュース\"]: got %v, want [%v]", sums, sum1)
+	}
+	if sums := m["エンディング"]; len(sums) != 1 || sums[0].URL != sum2.URL {
+		t.Errorf("CornerMap[\"エンディング\"]: got %v, want [%v]", sums, sum2)
+	}
+}
+
+func TestSummaries_CornerMap_Empty(t *testing.T) {
+	m := model.Summaries{}.CornerMap()
+	if len(m) != 0 {
+		t.Errorf("empty Summaries.CornerMap() should return empty map, got %d entries", len(m))
 	}
 }
 

--- a/internal/model/summary.go
+++ b/internal/model/summary.go
@@ -6,6 +6,11 @@ type Summary struct {
 	Points  []string `json:"points"`
 }
 
+type CornerSummaries struct {
+	CornerTitle string    `json:"corner_title"`
+	Summaries   []Summary `json:"summaries"`
+}
+
 type Summaries struct {
-	Summaries []Summary `json:"summaries"`
+	Corners []CornerSummaries `json:"corners"`
 }

--- a/internal/model/summary.go
+++ b/internal/model/summary.go
@@ -14,3 +14,12 @@ type CornerSummaries struct {
 type Summaries struct {
 	Corners []CornerSummaries `json:"corners"`
 }
+
+// CornerMap returns a map from corner title to its summaries.
+func (s Summaries) CornerMap() map[string][]Summary {
+	m := make(map[string][]Summary, len(s.Corners))
+	for _, cs := range s.Corners {
+		m[cs.CornerTitle] = cs.Summaries
+	}
+	return m
+}

--- a/internal/model/testdata/articles.json
+++ b/internal/model/testdata/articles.json
@@ -1,14 +1,19 @@
 {
-  "articles": [
+  "corners": [
     {
-      "url": "https://example.com/article/1",
-      "title": "AIチップの最新動向",
-      "body": "新型AIチップが発表された。従来比2倍の性能を実現する。"
-    },
-    {
-      "url": "https://example.com/article/2",
-      "title": "オープンソース活動の活発化",
-      "body": "オープンソースプロジェクトへの参加者が増加している。"
+      "corner_title": "今日のテックニュース",
+      "articles": [
+        {
+          "url": "https://example.com/article/1",
+          "title": "AIチップの最新動向",
+          "body": "新型AIチップが発表された。従来比2倍の性能を実現する。"
+        },
+        {
+          "url": "https://example.com/article/2",
+          "title": "オープンソース活動の活発化",
+          "body": "オープンソースプロジェクトへの参加者が増加している。"
+        }
+      ]
     }
   ]
 }

--- a/internal/model/testdata/summaries.json
+++ b/internal/model/testdata/summaries.json
@@ -1,20 +1,25 @@
 {
-  "summaries": [
+  "corners": [
     {
-      "url": "https://example.com/article/1",
-      "summary": "新型AIチップが従来比2倍の性能を実現",
-      "points": [
-        "従来比2倍の性能",
-        "電力効率も向上",
-        "2027年量産予定"
-      ]
-    },
-    {
-      "url": "https://example.com/article/2",
-      "summary": "オープンソース参加者が増加傾向",
-      "points": [
-        "参加者数が前年比30%増",
-        "企業からの貢献も増加"
+      "corner_title": "今日のテックニュース",
+      "summaries": [
+        {
+          "url": "https://example.com/article/1",
+          "summary": "新型AIチップが従来比2倍の性能を実現",
+          "points": [
+            "従来比2倍の性能",
+            "電力効率も向上",
+            "2027年量産予定"
+          ]
+        },
+        {
+          "url": "https://example.com/article/2",
+          "summary": "オープンソース参加者が増加傾向",
+          "points": [
+            "参加者数が前年比30%増",
+            "企業からの貢献も増加"
+          ]
+        }
       ]
     }
   ]

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -11,14 +11,14 @@ import (
 	"github.com/canpok1/vox-radio/internal/publish"
 )
 
-// Collector gathers articles from configured feeds.
+// Collector gathers articles per corner from configured sources.
 type Collector interface {
-	Run(ctx context.Context, cfg config.FeedsConfig) (model.Articles, error)
+	RunAll(ctx context.Context, corners []config.CornerConfig) (model.Articles, error)
 }
 
-// Scripter generates a radio script from articles.
+// Scripter generates a radio script from corner-attributed articles.
 type Scripter interface {
-	Generate(ctx context.Context, articles []model.Article, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error)
+	Generate(ctx context.Context, articles model.Articles, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error)
 }
 
 // Synther synthesizes voice clips from a script.
@@ -67,10 +67,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("create output dirs: %w", err)
 	}
 
-	articles, err := r.Collector.Run(ctx, config.FeedsConfig{
-		Feeds:    r.Profile.Feeds,
-		Articles: r.Profile.Articles,
-	})
+	articles, err := r.Collector.RunAll(ctx, r.Profile.Corners)
 	if err != nil {
 		return fmt.Errorf("collect: %w", err)
 	}
@@ -83,7 +80,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		chars = r.Config.Characters
 	}
 
-	scr, err := r.Scripter.Generate(ctx, articles.Articles, r.Profile.Corners, chars)
+	scr, err := r.Scripter.Generate(ctx, articles, r.Profile.Corners, chars)
 	if err != nil {
 		return fmt.Errorf("script: %w", err)
 	}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -22,21 +22,21 @@ type stubCollector struct {
 	called   bool
 }
 
-func (s *stubCollector) Run(_ context.Context, _ config.FeedsConfig) (model.Articles, error) {
+func (s *stubCollector) RunAll(_ context.Context, _ []config.CornerConfig) (model.Articles, error) {
 	s.called = true
 	return s.articles, s.err
 }
 
 type stubScripter struct {
-	script   model.Script
-	err      error
-	called   bool
-	gotSlice []model.Article
+	script      model.Script
+	err         error
+	called      bool
+	gotArticles model.Articles
 }
 
-func (s *stubScripter) Generate(_ context.Context, articles []model.Article, _ []config.CornerConfig, _ map[string]config.CharacterConfig) (model.Script, error) {
+func (s *stubScripter) Generate(_ context.Context, articles model.Articles, _ []config.CornerConfig, _ map[string]config.CharacterConfig) (model.Script, error) {
 	s.called = true
-	s.gotSlice = articles
+	s.gotArticles = articles
 	return s.script, s.err
 }
 
@@ -103,7 +103,7 @@ type stubs struct {
 
 func defaultStubs() stubs {
 	return stubs{
-		col: &stubCollector{articles: model.Articles{Articles: make([]model.Article, 0)}},
+		col: &stubCollector{articles: model.Articles{Corners: make([]model.CornerArticles, 0)}},
 		scr: &stubScripter{script: model.Script{Segments: make([]model.ScriptSegment, 0)}},
 		syn: &stubSynther{clips: &model.ClipsMeta{Clips: make([]model.ClipMeta, 0)}},
 		asm: &stubAssembler{result: &assemble.Result{}},
@@ -135,7 +135,7 @@ func TestRunner_Run_CallsAllSteps(t *testing.T) {
 	}
 
 	if !s.col.called {
-		t.Error("Collector.Run not called")
+		t.Error("Collector.RunAll not called")
 	}
 	if !s.scr.called {
 		t.Error("Scripter.Generate not called")
@@ -194,14 +194,22 @@ func TestRunner_Run_PassesArticlesToScripter(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
 	article := model.Article{URL: "http://example.com", Title: "Test", Body: "body"}
-	s.col.articles = model.Articles{Articles: []model.Article{article}}
+	s.col.articles = model.Articles{
+		Corners: []model.CornerArticles{
+			{CornerTitle: "テストコーナー", Articles: []model.Article{article}},
+		},
+	}
 
 	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(s.scr.gotSlice) != 1 || s.scr.gotSlice[0].URL != article.URL {
-		t.Errorf("Scripter.Generate received %v, want [%v]", s.scr.gotSlice, article)
+	if len(s.scr.gotArticles.Corners) != 1 {
+		t.Fatalf("Scripter.Generate received %d corners, want 1", len(s.scr.gotArticles.Corners))
+	}
+	got := s.scr.gotArticles.Corners[0]
+	if len(got.Articles) != 1 || got.Articles[0].URL != article.URL {
+		t.Errorf("Scripter.Generate corner articles = %v, want [%v]", got.Articles, article)
 	}
 }
 

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -18,7 +18,7 @@ import (
 const regenThreshold = 0.20
 
 type ScriptGenerator interface {
-	Generate(ctx context.Context, articles []model.Article, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error)
+	Generate(ctx context.Context, articles model.Articles, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error)
 }
 
 type LLMScriptGenerator struct {
@@ -45,20 +45,30 @@ func NewLLMScriptGenerator(
 	}
 }
 
-func (g *LLMScriptGenerator) Generate(ctx context.Context, articles []model.Article, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error) {
-	summaries, err := g.summarizeAll(ctx, articles)
-	if err != nil {
-		return model.Script{}, err
+func (g *LLMScriptGenerator) Generate(ctx context.Context, articles model.Articles, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error) {
+	cornerArticlesMap := buildCornerArticlesMap(articles)
+
+	cornerSummaries := make([]model.CornerSummaries, 0, len(corners))
+	for _, corner := range corners {
+		arts := cornerArticlesMap[corner.Title]
+		sums, err := g.summarizeAll(ctx, arts)
+		if err != nil {
+			return model.Script{}, err
+		}
+		cornerSummaries = append(cornerSummaries, model.CornerSummaries{
+			CornerTitle: corner.Title,
+			Summaries:   sums,
+		})
 	}
-	if err := g.saveIntermediate("summaries.json", model.Summaries{Summaries: summaries}); err != nil {
+	if err := g.saveIntermediate("summaries.json", model.Summaries{Corners: cornerSummaries}); err != nil {
 		return model.Script{}, err
 	}
 
-	cornerLines, err := g.writeAll(ctx, corners, summaries, chars)
+	cornerLines, err := g.writeAll(ctx, corners, cornerSummaries, chars)
 	if err != nil {
 		return model.Script{}, err
 	}
-	cornerLines = g.regenIfNeeded(ctx, cornerLines, corners, summaries, chars)
+	cornerLines = g.regenIfNeeded(ctx, cornerLines, corners, cornerSummaries, chars)
 	allLines := flatten(cornerLines)
 	if err := g.saveIntermediate("lines.json", model.Lines{Lines: allLines}); err != nil {
 		return model.Script{}, err
@@ -70,6 +80,14 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, articles []model.Arti
 	}
 
 	return scr, nil
+}
+
+func buildCornerArticlesMap(articles model.Articles) map[string][]model.Article {
+	m := make(map[string][]model.Article, len(articles.Corners))
+	for _, ca := range articles.Corners {
+		m[ca.CornerTitle] = ca.Articles
+	}
+	return m
 }
 
 func (g *LLMScriptGenerator) summarizeAll(ctx context.Context, articles []model.Article) ([]model.Summary, error) {
@@ -84,10 +102,12 @@ func (g *LLMScriptGenerator) summarizeAll(ctx context.Context, articles []model.
 	return summaries, nil
 }
 
-func (g *LLMScriptGenerator) writeAll(ctx context.Context, corners []config.CornerConfig, summaries []model.Summary, chars map[string]config.CharacterConfig) ([][]model.Line, error) {
+func (g *LLMScriptGenerator) writeAll(ctx context.Context, corners []config.CornerConfig, cornerSummaries []model.CornerSummaries, chars map[string]config.CharacterConfig) ([][]model.Line, error) {
+	cornerSumsMap := buildCornerSumsMap(cornerSummaries)
 	result := make([][]model.Line, len(corners))
 	for i, corner := range corners {
-		lines, err := g.writer.Write(ctx, corner, summaries, chars)
+		sums := cornerSumsMap[corner.Title]
+		lines, err := g.writer.Write(ctx, corner, sums, chars)
 		if err != nil {
 			return nil, fmt.Errorf("write corner %q: %w", corner.Title, err)
 		}
@@ -96,7 +116,15 @@ func (g *LLMScriptGenerator) writeAll(ctx context.Context, corners []config.Corn
 	return result, nil
 }
 
-func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]model.Line, corners []config.CornerConfig, summaries []model.Summary, chars map[string]config.CharacterConfig) [][]model.Line {
+func buildCornerSumsMap(cornerSummaries []model.CornerSummaries) map[string][]model.Summary {
+	m := make(map[string][]model.Summary, len(cornerSummaries))
+	for _, cs := range cornerSummaries {
+		m[cs.CornerTitle] = cs.Summaries
+	}
+	return m
+}
+
+func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]model.Line, corners []config.CornerConfig, cornerSummaries []model.CornerSummaries, chars map[string]config.CharacterConfig) [][]model.Line {
 	if len(corners) == 0 {
 		return cornerLines
 	}
@@ -117,6 +145,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 		return cornerLines
 	}
 
+	cornerSumsMap := buildCornerSumsMap(cornerSummaries)
 	worstIdx := 0
 	worstDev := 0.0
 	for i, corner := range corners {
@@ -135,7 +164,8 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 	}
 
 	corner := corners[worstIdx]
-	if newLines, err := g.writer.Write(ctx, corner, summaries, chars); err == nil {
+	sums := cornerSumsMap[corner.Title]
+	if newLines, err := g.writer.Write(ctx, corner, sums, chars); err == nil {
 		cornerLines[worstIdx] = newLines
 	}
 	return cornerLines

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -46,7 +46,7 @@ func NewLLMScriptGenerator(
 }
 
 func (g *LLMScriptGenerator) Generate(ctx context.Context, articles model.Articles, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error) {
-	cornerArticlesMap := buildCornerArticlesMap(articles)
+	cornerArticlesMap := articles.CornerMap()
 
 	cornerSummaries := make([]model.CornerSummaries, 0, len(corners))
 	for _, corner := range corners {
@@ -60,15 +60,16 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, articles model.Articl
 			Summaries:   sums,
 		})
 	}
-	if err := g.saveIntermediate("summaries.json", model.Summaries{Corners: cornerSummaries}); err != nil {
+	sumsModel := model.Summaries{Corners: cornerSummaries}
+	if err := g.saveIntermediate("summaries.json", sumsModel); err != nil {
 		return model.Script{}, err
 	}
 
-	cornerLines, err := g.writeAll(ctx, corners, cornerSummaries, chars)
+	cornerLines, err := g.writeAll(ctx, corners, sumsModel, chars)
 	if err != nil {
 		return model.Script{}, err
 	}
-	cornerLines = g.regenIfNeeded(ctx, cornerLines, corners, cornerSummaries, chars)
+	cornerLines = g.regenIfNeeded(ctx, cornerLines, corners, sumsModel, chars)
 	allLines := flatten(cornerLines)
 	if err := g.saveIntermediate("lines.json", model.Lines{Lines: allLines}); err != nil {
 		return model.Script{}, err
@@ -80,14 +81,6 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, articles model.Articl
 	}
 
 	return scr, nil
-}
-
-func buildCornerArticlesMap(articles model.Articles) map[string][]model.Article {
-	m := make(map[string][]model.Article, len(articles.Corners))
-	for _, ca := range articles.Corners {
-		m[ca.CornerTitle] = ca.Articles
-	}
-	return m
 }
 
 func (g *LLMScriptGenerator) summarizeAll(ctx context.Context, articles []model.Article) ([]model.Summary, error) {
@@ -102,12 +95,11 @@ func (g *LLMScriptGenerator) summarizeAll(ctx context.Context, articles []model.
 	return summaries, nil
 }
 
-func (g *LLMScriptGenerator) writeAll(ctx context.Context, corners []config.CornerConfig, cornerSummaries []model.CornerSummaries, chars map[string]config.CharacterConfig) ([][]model.Line, error) {
-	cornerSumsMap := buildCornerSumsMap(cornerSummaries)
+func (g *LLMScriptGenerator) writeAll(ctx context.Context, corners []config.CornerConfig, sums model.Summaries, chars map[string]config.CharacterConfig) ([][]model.Line, error) {
+	cornerSumsMap := sums.CornerMap()
 	result := make([][]model.Line, len(corners))
 	for i, corner := range corners {
-		sums := cornerSumsMap[corner.Title]
-		lines, err := g.writer.Write(ctx, corner, sums, chars)
+		lines, err := g.writer.Write(ctx, corner, cornerSumsMap[corner.Title], chars)
 		if err != nil {
 			return nil, fmt.Errorf("write corner %q: %w", corner.Title, err)
 		}
@@ -116,15 +108,7 @@ func (g *LLMScriptGenerator) writeAll(ctx context.Context, corners []config.Corn
 	return result, nil
 }
 
-func buildCornerSumsMap(cornerSummaries []model.CornerSummaries) map[string][]model.Summary {
-	m := make(map[string][]model.Summary, len(cornerSummaries))
-	for _, cs := range cornerSummaries {
-		m[cs.CornerTitle] = cs.Summaries
-	}
-	return m
-}
-
-func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]model.Line, corners []config.CornerConfig, cornerSummaries []model.CornerSummaries, chars map[string]config.CharacterConfig) [][]model.Line {
+func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]model.Line, corners []config.CornerConfig, sums model.Summaries, chars map[string]config.CharacterConfig) [][]model.Line {
 	if len(corners) == 0 {
 		return cornerLines
 	}
@@ -145,7 +129,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 		return cornerLines
 	}
 
-	cornerSumsMap := buildCornerSumsMap(cornerSummaries)
+	cornerSumsMap := sums.CornerMap()
 	worstIdx := 0
 	worstDev := 0.0
 	for i, corner := range corners {
@@ -164,8 +148,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 	}
 
 	corner := corners[worstIdx]
-	sums := cornerSumsMap[corner.Title]
-	if newLines, err := g.writer.Write(ctx, corner, sums, chars); err == nil {
+	if newLines, err := g.writer.Write(ctx, corner, cornerSumsMap[corner.Title], chars); err == nil {
 		cornerLines[worstIdx] = newLines
 	}
 	return cornerLines

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -60,16 +60,16 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, articles model.Articl
 			Summaries:   sums,
 		})
 	}
-	sumsModel := model.Summaries{Corners: cornerSummaries}
-	if err := g.saveIntermediate("summaries.json", sumsModel); err != nil {
+	allSummaries := model.Summaries{Corners: cornerSummaries}
+	if err := g.saveIntermediate("summaries.json", allSummaries); err != nil {
 		return model.Script{}, err
 	}
 
-	cornerLines, err := g.writeAll(ctx, corners, sumsModel, chars)
+	cornerLines, err := g.writeAll(ctx, corners, allSummaries, chars)
 	if err != nil {
 		return model.Script{}, err
 	}
-	cornerLines = g.regenIfNeeded(ctx, cornerLines, corners, sumsModel, chars)
+	cornerLines = g.regenIfNeeded(ctx, cornerLines, corners, allSummaries, chars)
 	allLines := flatten(cornerLines)
 	if err := g.saveIntermediate("lines.json", model.Lines{Lines: allLines}); err != nil {
 		return model.Script{}, err

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -73,10 +73,19 @@ var testCorners = []config.CornerConfig{
 	{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 100},
 }
 
-func TestLLMScriptGenerator_Generate_HappyPath(t *testing.T) {
-	articles := []model.Article{
-		{URL: "https://example.com/1", Title: "AI", Body: "本文"},
+// corneredArticles wraps articles into a model.Articles attributed to the given corner title.
+func corneredArticles(cornerTitle string, arts ...model.Article) model.Articles {
+	return model.Articles{
+		Corners: []model.CornerArticles{
+			{CornerTitle: cornerTitle, Articles: arts},
+		},
 	}
+}
+
+func TestLLMScriptGenerator_Generate_HappyPath(t *testing.T) {
+	articles := corneredArticles("AIコーナー",
+		model.Article{URL: "https://example.com/1", Title: "AI", Body: "本文"},
+	)
 	lines := []model.Line{
 		{SpeakerRole: "zundamon", Text: "テスト"},
 	}
@@ -107,7 +116,7 @@ func TestLLMScriptGenerator_Generate_SummarizeError(t *testing.T) {
 		"",
 	)
 
-	_, err := gen.Generate(context.Background(), []model.Article{{URL: "u"}}, testCorners, testChars)
+	_, err := gen.Generate(context.Background(), corneredArticles("AIコーナー", model.Article{URL: "u"}), testCorners, testChars)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -122,7 +131,7 @@ func TestLLMScriptGenerator_Generate_WriteError(t *testing.T) {
 		"",
 	)
 
-	_, err := gen.Generate(context.Background(), []model.Article{{URL: "u"}}, testCorners, testChars)
+	_, err := gen.Generate(context.Background(), corneredArticles("AIコーナー", model.Article{URL: "u"}), testCorners, testChars)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -131,10 +140,10 @@ func TestLLMScriptGenerator_Generate_WriteError(t *testing.T) {
 func TestLLMScriptGenerator_Generate_CharCountRegen(t *testing.T) {
 	// TargetChars=100, but writer first returns 1 char total (huge deficit)
 	// should trigger regen of the worst corner
-	articles := []model.Article{{URL: "https://example.com/1"}}
 	corners := []config.CornerConfig{
 		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 100},
 	}
+	articles := corneredArticles("C", model.Article{URL: "https://example.com/1"})
 	shortLines := []model.Line{{SpeakerRole: "zundamon", Text: "A"}}                                                  // 1 char
 	longLines := []model.Line{{SpeakerRole: "zundamon", Text: "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえお"}} // ~45 chars
 
@@ -160,10 +169,10 @@ func TestLLMScriptGenerator_Generate_CharCountRegen(t *testing.T) {
 }
 
 func TestLLMScriptGenerator_Generate_NoRegenWhenWithinThreshold(t *testing.T) {
-	articles := []model.Article{{URL: "https://example.com/1"}}
 	corners := []config.CornerConfig{
 		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 100},
 	}
+	articles := corneredArticles("C", model.Article{URL: "https://example.com/1"})
 	// 95 chars → 5% deviation (target=100), within 20% threshold
 	lines := []model.Line{{SpeakerRole: "zundamon", Text: "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいう"}}
 
@@ -194,7 +203,7 @@ func TestLLMScriptGenerator_Generate_EmptyArticles(t *testing.T) {
 		"",
 	)
 
-	got, err := gen.Generate(context.Background(), []model.Article{}, testCorners, testChars)
+	got, err := gen.Generate(context.Background(), model.Articles{}, testCorners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -212,7 +221,7 @@ func TestLLMScriptGenerator_Generate_EmptyCorners(t *testing.T) {
 		"",
 	)
 
-	got, err := gen.Generate(context.Background(), []model.Article{{URL: "u"}}, []config.CornerConfig{}, testChars)
+	got, err := gen.Generate(context.Background(), corneredArticles("AIコーナー", model.Article{URL: "u"}), []config.CornerConfig{}, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -222,10 +231,10 @@ func TestLLMScriptGenerator_Generate_EmptyCorners(t *testing.T) {
 }
 
 func TestLLMScriptGenerator_Generate_NoRegenWhenAllCornersHaveZeroTarget(t *testing.T) {
-	articles := []model.Article{{URL: "https://example.com/1"}}
 	corners := []config.CornerConfig{
 		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 0},
 	}
+	articles := corneredArticles("C", model.Article{URL: "https://example.com/1"})
 	lines := []model.Line{{SpeakerRole: "zundamon", Text: "A"}}
 
 	mw := &mockWriter{lines: lines}

--- a/internal/script/write/write.go
+++ b/internal/script/write/write.go
@@ -52,7 +52,9 @@ func (w *LLMWriter) Write(ctx context.Context, corner config.CornerConfig, summa
 		return nil, fmt.Errorf("marshal corner: %w", err)
 	}
 
-	summariesJSON, err := json.Marshal(model.Summaries{Summaries: summaries})
+	summariesJSON, err := json.Marshal(struct {
+		Summaries []model.Summary `json:"summaries"`
+	}{Summaries: summaries})
 	if err != nil {
 		return nil, fmt.Errorf("marshal summaries: %w", err)
 	}

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -57,19 +57,19 @@ corners:                  # 固定コーナーのリスト
     cast:
       zundamon: "元気に挨拶する進行役"  # キャラID: そのコーナーの役割指示
     target_chars: 200      # 目標文字数（暫定）
+    # source なし → 収集スキップ（挨拶のみのコーナーに使用）
   - title: "ニュースコーナー"
     content: "テック記事を紹介"
     cast:
       zundamon: "司会"
       metan: "解説役"
     target_chars: 1300
-
-feeds:
-  - url: https://example.com/rss.xml
-    max_items: 5
-
-articles:
-  - https://example.com/articles/123
+    source:                # このコーナーのデータソース（省略可）
+      feeds:
+        - url: https://example.com/rss.xml
+          max_items: 5
+      articles:
+        - https://example.com/articles/123
 
 assets:
   jingle:
@@ -88,6 +88,9 @@ assets:
 - `corners`: 固定コーナーのリスト（旧 `show` を再設計）
   - `cast`: キャラID→役割指示のマップ（`vox-radio.yaml` の `characters` のキーを参照）
   - `target_chars`: 暫定の目標文字数（#4 で再生時間化予定）
+  - `source`（省略可）: コーナーのデータソース。省略したコーナーは収集をスキップ
+    - `feeds`: RSS フィードのリスト（`url` / `max_items`）
+    - `articles`: 個別記事 URL のリスト
 - キャラIDは `vox-radio.yaml` の `characters` セクションで定義したIDと一致させること
 
 `assets.*/file` のパスは、このプロファイルファイルが置かれているディレクトリからの相対パスで解決されます。

--- a/profiles/tech/profile.yaml
+++ b/profiles/tech/profile.yaml
@@ -22,20 +22,19 @@ corners:
       zundamon: "司会"
       metan: "解説役"
     target_chars: 1300
+    source:
+      feeds:
+        - url: https://example.com/rss.xml
+          max_items: 5
+        - url: https://another.example.com/feed
+          max_items: 3
+      articles:
+        - https://example.com/articles/123
   - title: "エンディング"
     content: "まとめと次回予告"
     cast:
       zundamon: "進行役"
     target_chars: 200
-
-feeds:
-  - url: https://example.com/rss.xml
-    max_items: 5
-  - url: https://another.example.com/feed
-    max_items: 3
-
-articles:
-  - https://example.com/articles/123
 
 assets:
   jingle:

--- a/profiles/test/profile.yaml
+++ b/profiles/test/profile.yaml
@@ -16,12 +16,10 @@ corners:
     cast:
       zundamon: "進行役"
     target_chars: 300
-
-feeds:
-  - url: https://example.com/rss.xml
-    max_items: 1
-
-articles: []
+    source:
+      feeds:
+        - url: https://example.com/rss.xml
+          max_items: 1
 
 assets:
   jingle:


### PR DESCRIPTION
## Summary

- `Profile` トップレベルの `feeds`/`articles` フィールドを廃止し、`corners[].source` に集約
- `SourceConfig` 型を追加して `CornerConfig.Source *SourceConfig` を追加（省略可）
- `Collector.RunAll()` を追加し、コーナー単位で記事を収集する（`source` なしのコーナーはスキップ）
- `model.Articles` / `model.Summaries` をコーナー別リスト構造 `{"corners": [...]}` に変更
- script パイプラインを各コーナー自身のサマリーのみ渡す形に更新（summarize / write / full）
- `model.Articles.CornerMap()` / `model.Summaries.CornerMap()` メソッドを追加し、重複 map 構築ロジックを解消
- `profiles/tech`, `profiles/test`, config testdata を新スキーマへ移行
- CLIドキュメント（docs/cli/）・README・profiles/README.md を更新

### 未決点の確定

- **articles.json 構造**: コーナー別リスト構造 `{"corners": [{"corner_title": "...", "articles": [...]}]}`
- **記事過多時の選別責務**: write ステップ（LLM が `target_chars` に合わせて選別）

Closes #48

---
🤖 Generated with [Claude Code](https://claude.ai/code)