### PR TITLE
feat: target_chars → target_duration_sec（文字数係数≈7文字/秒で概算換算）

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// CharsPerSec is the approximate number of characters spoken per second,
+// used to convert target_duration_sec to a target character count.
+const CharsPerSec = 7
+
+// DurationSecToTargetChars converts a duration in seconds to an approximate target character count.
+func DurationSecToTargetChars(sec int) int {
+	return sec * CharsPerSec
+}
+
 type FeedEntry struct {
 	URL      string `yaml:"url"`
 	MaxItems int    `yaml:"max_items"`
@@ -57,16 +66,17 @@ type LLMConfig struct {
 
 // ProgramConfig holds program-wide settings (formerly PodcastConfig + SegmentPauseSec from ShowConfig).
 type ProgramConfig struct {
-	Title           string  `yaml:"title"`
-	Description     string  `yaml:"description"`
-	Language        string  `yaml:"language"`
-	Author          string  `yaml:"author"`
-	Category        string  `yaml:"category"`
-	Explicit        bool    `yaml:"explicit"`
-	CoverImageURL   string  `yaml:"cover_image_url"`
-	SiteURL         string  `yaml:"site_url"`
-	MaxItems        int     `yaml:"max_items"`
-	SegmentPauseSec float64 `yaml:"segment_pause_sec"`
+	Title             string  `yaml:"title"`
+	Description       string  `yaml:"description"`
+	Language          string  `yaml:"language"`
+	Author            string  `yaml:"author"`
+	Category          string  `yaml:"category"`
+	Explicit          bool    `yaml:"explicit"`
+	CoverImageURL     string  `yaml:"cover_image_url"`
+	SiteURL           string  `yaml:"site_url"`
+	MaxItems          int     `yaml:"max_items"`
+	SegmentPauseSec   float64 `yaml:"segment_pause_sec"`
+	TargetDurationSec int     `yaml:"target_duration_sec"`
 }
 
 // SourceConfig defines the data sources for a corner (feeds and individual article URLs).
@@ -76,13 +86,12 @@ type SourceConfig struct {
 }
 
 // CornerConfig defines a fixed corner in the program structure.
-// target_chars is provisional; will be replaced by target_duration_sec in #4.
 type CornerConfig struct {
-	Title       string            `yaml:"title"`
-	Content     string            `yaml:"content"`
-	Cast        map[string]string `yaml:"cast"`
-	TargetChars int               `yaml:"target_chars"`
-	Source      *SourceConfig     `yaml:"source,omitempty"`
+	Title             string            `yaml:"title"`
+	Content           string            `yaml:"content"`
+	Cast              map[string]string `yaml:"cast"`
+	TargetDurationSec int               `yaml:"target_duration_sec"`
+	Source            *SourceConfig     `yaml:"source,omitempty"`
 }
 
 type VoicevoxConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,24 @@ import (
 	"github.com/canpok1/vox-radio/internal/config"
 )
 
+func TestDurationSecToTargetChars(t *testing.T) {
+	tests := []struct {
+		sec  int
+		want int
+	}{
+		{sec: 0, want: 0},
+		{sec: 1, want: 7},
+		{sec: 14, want: 98},
+		{sec: 30, want: 210},
+	}
+	for _, tt := range tests {
+		got := config.DurationSecToTargetChars(tt.sec)
+		if got != tt.want {
+			t.Errorf("DurationSecToTargetChars(%d) = %d, want %d", tt.sec, got, tt.want)
+		}
+	}
+}
+
 func TestLoadConfig(t *testing.T) {
 	cfg, err := config.LoadConfig("testdata/config.yaml")
 	if err != nil {
@@ -73,6 +91,15 @@ func TestLoadProfile(t *testing.T) {
 		}
 		if len(c.Cast) == 0 {
 			t.Error("Corners[0].Cast must not be empty")
+		}
+		if c.TargetDurationSec <= 0 {
+			t.Error("Corners[0].TargetDurationSec must be positive")
+		}
+	})
+
+	t.Run("ProgramTargetDurationSec", func(t *testing.T) {
+		if profile.Program.TargetDurationSec <= 0 {
+			t.Error("Program.TargetDurationSec must be positive")
 		}
 	})
 

--- a/internal/config/testdata/profile.yaml
+++ b/internal/config/testdata/profile.yaml
@@ -9,18 +9,19 @@ program:
   site_url: https://example.com/
   max_items: 5
   segment_pause_sec: 0.3
+  target_duration_sec: 75
 
 corners:
   - title: "オープニング"
     content: "番組の挨拶とトピック紹介"
     cast:
       zundamon: "元気に挨拶する進行役"
-    target_chars: 300
+    target_duration_sec: 45
   - title: "ニュースコーナー"
     content: "テック記事を紹介"
     cast:
       zundamon: "司会"
-    target_chars: 200
+    target_duration_sec: 30
     source:
       feeds:
         - url: https://example.com/rss.xml

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -114,7 +114,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 	}
 	totalTarget := 0
 	for _, c := range corners {
-		totalTarget += c.TargetChars
+		totalTarget += config.DurationSecToTargetChars(c.TargetDurationSec)
 	}
 	if totalTarget <= 0 {
 		return cornerLines
@@ -133,11 +133,12 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, cornerLines [][]
 	worstIdx := 0
 	worstDev := 0.0
 	for i, corner := range corners {
-		if corner.TargetChars <= 0 {
+		targetChars := config.DurationSecToTargetChars(corner.TargetDurationSec)
+		if targetChars <= 0 {
 			continue
 		}
 		actual := countChars(cornerLines[i])
-		dev := absDeviation(actual, corner.TargetChars)
+		dev := absDeviation(actual, targetChars)
 		if dev > worstDev {
 			worstDev = dev
 			worstIdx = i

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -70,7 +70,7 @@ var testChars = map[string]config.CharacterConfig{
 }
 
 var testCorners = []config.CornerConfig{
-	{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 100},
+	{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, TargetDurationSec: 15},
 }
 
 // corneredArticles wraps articles into a model.Articles attributed to the given corner title.
@@ -138,10 +138,10 @@ func TestLLMScriptGenerator_Generate_WriteError(t *testing.T) {
 }
 
 func TestLLMScriptGenerator_Generate_CharCountRegen(t *testing.T) {
-	// TargetChars=100, but writer first returns 1 char total (huge deficit)
+	// TargetDurationSec=15 → 105 chars, but writer first returns 1 char total (huge deficit)
 	// should trigger regen of the worst corner
 	corners := []config.CornerConfig{
-		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 100},
+		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetDurationSec: 15},
 	}
 	articles := corneredArticles("C", model.Article{URL: "https://example.com/1"})
 	shortLines := []model.Line{{SpeakerRole: "zundamon", Text: "A"}}                                                  // 1 char
@@ -170,10 +170,10 @@ func TestLLMScriptGenerator_Generate_CharCountRegen(t *testing.T) {
 
 func TestLLMScriptGenerator_Generate_NoRegenWhenWithinThreshold(t *testing.T) {
 	corners := []config.CornerConfig{
-		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 100},
+		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetDurationSec: 15},
 	}
 	articles := corneredArticles("C", model.Article{URL: "https://example.com/1"})
-	// 95 chars → 5% deviation (target=100), within 20% threshold
+	// 95 chars → ~9.5% deviation (target=105 = 15sec*7), within 20% threshold
 	lines := []model.Line{{SpeakerRole: "zundamon", Text: "あいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいうえおかきくけこさしすせそたちつてとなにぬねのはひふへほまみむめもやゆよらりるれろわをんあいう"}}
 
 	mw := &mockWriter{lines: lines}
@@ -232,7 +232,7 @@ func TestLLMScriptGenerator_Generate_EmptyCorners(t *testing.T) {
 
 func TestLLMScriptGenerator_Generate_NoRegenWhenAllCornersHaveZeroTarget(t *testing.T) {
 	corners := []config.CornerConfig{
-		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 0},
+		{Title: "C", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetDurationSec: 0},
 	}
 	articles := corneredArticles("C", model.Article{URL: "https://example.com/1"})
 	lines := []model.Line{{SpeakerRole: "zundamon", Text: "A"}}

--- a/internal/script/write/write.go
+++ b/internal/script/write/write.go
@@ -32,6 +32,15 @@ var linesSchema = json.RawMessage(`{
   "additionalProperties": false
 }`)
 
+// cornerForPrompt is the subset of corner data passed to the LLM.
+// TargetChars is computed from TargetDurationSec via config.DurationSecToTargetChars.
+type cornerForPrompt struct {
+	Title       string            `json:"title"`
+	Content     string            `json:"content"`
+	Cast        map[string]string `json:"cast"`
+	TargetChars int               `json:"target_chars"`
+}
+
 type Writer interface {
 	Write(ctx context.Context, corner config.CornerConfig, summaries []model.Summary, chars map[string]config.CharacterConfig) ([]model.Line, error)
 }
@@ -47,7 +56,13 @@ func NewLLMWriter(client llm.Client, promptTemplate string, temperature float64)
 }
 
 func (w *LLMWriter) Write(ctx context.Context, corner config.CornerConfig, summaries []model.Summary, chars map[string]config.CharacterConfig) ([]model.Line, error) {
-	cornerJSON, err := json.Marshal(corner)
+	promptCorner := cornerForPrompt{
+		Title:       corner.Title,
+		Content:     corner.Content,
+		Cast:        corner.Cast,
+		TargetChars: config.DurationSecToTargetChars(corner.TargetDurationSec),
+	}
+	cornerJSON, err := json.Marshal(promptCorner)
 	if err != nil {
 		return nil, fmt.Errorf("marshal corner: %w", err)
 	}

--- a/internal/script/write/write_test.go
+++ b/internal/script/write/write_test.go
@@ -43,7 +43,7 @@ func TestLLMWriter_Write_Success(t *testing.T) {
 	mc := &mockClient{response: linesJSON}
 	w := write.NewLLMWriter(mc, "corner={{corner}} summaries={{summary}} cast={{cast_info}}", 0)
 
-	corner := config.CornerConfig{Title: "コーナー1", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 100}
+	corner := config.CornerConfig{Title: "コーナー1", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetDurationSec: 14}
 	summaries := []model.Summary{{URL: "https://example.com/1", Summary: "要約", Points: []string{"p1"}}}
 	chars := map[string]config.CharacterConfig{
 		"zundamon": {Name: "ずんだもん", Pronoun: "ボク", SpeechSuffix: []string{"〜のだ"}, Personality: []string{"元気"}},
@@ -65,7 +65,7 @@ func TestLLMWriter_Write_PromptContainsCornerAndCastInfo(t *testing.T) {
 	mc := &mockClient{response: linesJSON}
 	w := write.NewLLMWriter(mc, "c={{corner}} s={{summary}} cast={{cast_info}}", 0)
 
-	corner := config.CornerConfig{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, TargetChars: 100}
+	corner := config.CornerConfig{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, TargetDurationSec: 14}
 	summaries := []model.Summary{{URL: "https://example.com/1", Summary: "AI要約", Points: []string{"p1"}}}
 	chars := map[string]config.CharacterConfig{
 		"zundamon": {Name: "ずんだもん", Pronoun: "ボク", SpeechSuffix: []string{"〜のだ"}, Personality: []string{"元気"}},
@@ -98,5 +98,25 @@ func TestLLMWriter_Write_LLMError(t *testing.T) {
 	_, err := w.Write(context.Background(), config.CornerConfig{}, nil, nil)
 	if err == nil {
 		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestLLMWriter_Write_PromptContainsConvertedTargetChars(t *testing.T) {
+	mc := &mockClient{response: linesJSON}
+	w := write.NewLLMWriter(mc, "c={{corner}}", 0)
+
+	// 14sec * 7chars/sec = 98 chars
+	corner := config.CornerConfig{Title: "Test", Content: "内容", Cast: map[string]string{"zundamon": "司会"}, TargetDurationSec: 14}
+	_, _ = w.Write(context.Background(), corner, nil, nil)
+
+	if len(mc.captured) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	prompt := mc.captured[0].Messages[0].Content
+	if !strings.Contains(prompt, `"target_chars":98`) {
+		t.Errorf("prompt should contain target_chars:98 (14sec*7), got: %s", prompt)
+	}
+	if strings.Contains(prompt, "target_duration_sec") {
+		t.Errorf("prompt should not expose target_duration_sec to LLM, got: %s", prompt)
 	}
 }

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -48,22 +48,23 @@ program:
   explicit: false
   cover_image_url: https://example.com/cover.jpg
   site_url: https://example.com/
-  max_items: 7            # フィードに載せる最大件数
-  segment_pause_sec: 0.3  # セリフ間の無音（秒）
+  max_items: 7             # フィードに載せる最大件数
+  segment_pause_sec: 0.3   # セリフ間の無音（秒）
+  target_duration_sec: 240 # 番組全体の目標再生時間（秒）
 
 corners:                  # 固定コーナーのリスト
   - title: "オープニング"
     content: "番組の挨拶と本日のトピック紹介"
     cast:
       zundamon: "元気に挨拶する進行役"  # キャラID: そのコーナーの役割指示
-    target_chars: 200      # 目標文字数（暫定）
+    target_duration_sec: 30  # コーナーの目標再生時間（秒）
     # source なし → 収集スキップ（挨拶のみのコーナーに使用）
   - title: "ニュースコーナー"
     content: "テック記事を紹介"
     cast:
       zundamon: "司会"
       metan: "解説役"
-    target_chars: 1300
+    target_duration_sec: 180
     source:                # このコーナーのデータソース（省略可）
       feeds:
         - url: https://example.com/rss.xml
@@ -85,9 +86,10 @@ assets:
 ### フィールド説明
 
 - `program`: 番組全体の設定（旧 `podcast` + `show.segment_pause_sec`）
+  - `target_duration_sec`: 番組全体の目標再生時間（秒）
 - `corners`: 固定コーナーのリスト（旧 `show` を再設計）
   - `cast`: キャラID→役割指示のマップ（`vox-radio.yaml` の `characters` のキーを参照）
-  - `target_chars`: 暫定の目標文字数（#4 で再生時間化予定）
+  - `target_duration_sec`: コーナーの目標再生時間（秒）。台本生成時に文字数係数（≈7文字/秒）で換算される
   - `source`（省略可）: コーナーのデータソース。省略したコーナーは収集をスキップ
     - `feeds`: RSS フィードのリスト（`url` / `max_items`）
     - `articles`: 個別記事 URL のリスト

--- a/profiles/tech/profile.yaml
+++ b/profiles/tech/profile.yaml
@@ -9,19 +9,20 @@ program:
   site_url: https://example.github.io/vox-radio/
   max_items: 7
   segment_pause_sec: 0.3
+  target_duration_sec: 240
 
 corners:
   - title: "オープニング"
     content: "番組の挨拶と本日のトピック紹介"
     cast:
       zundamon: "元気に挨拶する進行役"
-    target_chars: 200
+    target_duration_sec: 30
   - title: "今日のテックニュース"
     content: "テック記事を2〜3本、噛み砕いて紹介"
     cast:
       zundamon: "司会"
       metan: "解説役"
-    target_chars: 1300
+    target_duration_sec: 180
     source:
       feeds:
         - url: https://example.com/rss.xml
@@ -34,7 +35,7 @@ corners:
     content: "まとめと次回予告"
     cast:
       zundamon: "進行役"
-    target_chars: 200
+    target_duration_sec: 30
 
 assets:
   jingle:

--- a/profiles/test/profile.yaml
+++ b/profiles/test/profile.yaml
@@ -9,13 +9,14 @@ program:
   site_url: https://example.github.io/vox-radio/
   max_items: 3
   segment_pause_sec: 0.3
+  target_duration_sec: 60
 
 corners:
   - title: "メインコーナー"
     content: "本日のニュースを紹介"
     cast:
       zundamon: "進行役"
-    target_chars: 300
+    target_duration_sec: 45
     source:
       feeds:
         - url: https://example.com/rss.xml


### PR DESCRIPTION
## Summary

- `config.CornerConfig` / `ProgramConfig` の `target_chars` を廃止し `target_duration_sec`（秒）に置き換え
- `CharsPerSec = 7`（≈7文字/秒）定数と `DurationSecToTargetChars` 換算ユーティリティを `internal/config` に追加
- `script.go` の `regenIfNeeded` 偏差判定を `DurationSecToTargetChars` 経由の換算値で実施
- `write.go` では `cornerForPrompt` 構造体を介して換算済み `target_chars` を LLM プロンプトに渡す（`target_duration_sec` は LLM に露出しない）
- `profiles/{tech,test}/profile.yaml`、`internal/config/testdata/profile.yaml`、`profiles/README.md` を更新

## Test plan

- [x] `TestDurationSecToTargetChars` — 換算ユーティリティの単体テスト（0, 1, 14, 30秒）
- [x] `TestLoadProfile` — `CornerConfig.TargetDurationSec` と `ProgramConfig.TargetDurationSec` のロードテスト
- [x] `TestLLMWriter_Write_PromptContainsConvertedTargetChars` — LLM プロンプトに `target_chars`（換算値）が含まれ `target_duration_sec` が露出しないことを確認
- [x] `TestLLMScriptGenerator_Generate_CharCountRegen` — regen トリガーが換算値ベースで動作
- [x] `TestLLMScriptGenerator_Generate_NoRegenWhenWithinThreshold` — 閾値内は regen しない
- [x] `make test` / `gofmt` / `golangci-lint` / `go mod tidy` クリーン

Closes #49

---
🤖 Generated with [Claude Code](https://claude.ai/code)