### PR TITLE
refactor: program設定から配信専用フィールドを削除する

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,17 +64,10 @@ type LLMConfig struct {
 	Steps       map[string]LLMStepConfig `yaml:"steps"`
 }
 
-// ProgramConfig holds program-wide settings (formerly PodcastConfig + SegmentPauseSec from ShowConfig).
+// ProgramConfig holds program-wide settings for content generation.
 type ProgramConfig struct {
 	Title             string  `yaml:"title"`
 	Description       string  `yaml:"description"`
-	Language          string  `yaml:"language"`
-	Author            string  `yaml:"author"`
-	Category          string  `yaml:"category"`
-	Explicit          bool    `yaml:"explicit"`
-	CoverImageURL     string  `yaml:"cover_image_url"`
-	SiteURL           string  `yaml:"site_url"`
-	MaxItems          int     `yaml:"max_items"`
 	SegmentPauseSec   float64 `yaml:"segment_pause_sec"`
 	TargetDurationSec int     `yaml:"target_duration_sec"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,12 +67,6 @@ func TestLoadProfile(t *testing.T) {
 		if profile.Program.Title == "" {
 			t.Error("Program.Title must not be empty")
 		}
-		if profile.Program.Language == "" {
-			t.Error("Program.Language must not be empty")
-		}
-		if profile.Program.MaxItems <= 0 {
-			t.Error("Program.MaxItems must be positive")
-		}
 		if profile.Program.SegmentPauseSec <= 0 {
 			t.Error("Program.SegmentPauseSec must be positive")
 		}

--- a/internal/config/testdata/podcast.yaml
+++ b/internal/config/testdata/podcast.yaml
@@ -1,9 +1,0 @@
-title: "今日のテックニュース"
-description: "毎日5分のニュースラジオ"
-language: ja
-author: vox-radio
-category: News
-explicit: false
-cover_image_url: https://example.github.io/vox-radio/cover.jpg
-site_url: https://example.github.io/vox-radio/
-max_items: 7

--- a/internal/config/testdata/profile.yaml
+++ b/internal/config/testdata/profile.yaml
@@ -1,13 +1,6 @@
 program:
   title: "テストニュース"
   description: "テスト用"
-  language: ja
-  author: test
-  category: News
-  explicit: false
-  cover_image_url: https://example.com/cover.jpg
-  site_url: https://example.com/
-  max_items: 5
   segment_pause_sec: 0.3
   target_duration_sec: 75
 

--- a/sample-profiles/README.md
+++ b/sample-profiles/README.md
@@ -35,13 +35,6 @@ vox-radio collect --out work/articles.json --profile sample-profiles/tech_profil
 program:
   title: "番組タイトル"
   description: "番組の説明"
-  language: ja
-  author: vox-radio
-  category: News
-  explicit: false
-  cover_image_url: https://example.com/cover.jpg
-  site_url: https://example.com/
-  max_items: 7             # フィードに載せる最大件数
   segment_pause_sec: 0.3   # セリフ間の無音（秒）
   target_duration_sec: 240 # 番組全体の目標再生時間（秒）
 
@@ -78,7 +71,7 @@ assets:
 
 ### フィールド説明
 
-- `program`: 番組全体の設定（旧 `podcast` + `show.segment_pause_sec`）
+- `program`: 番組コンテンツ生成に必要な設定（title/description/segment_pause_sec/target_duration_sec のみ。配信専用フィールドは配信リポジトリ側で管理）
   - `target_duration_sec`: 番組全体の目標再生時間（秒）
 - `corners`: 固定コーナーのリスト（旧 `show` を再設計）
   - `cast`: キャラID→役割指示のマップ（`vox-radio.yaml` の `characters` のキーを参照）

--- a/sample-profiles/tech_profile.yaml
+++ b/sample-profiles/tech_profile.yaml
@@ -1,13 +1,6 @@
 program:
   title: "今日のテックニュース"
   description: "毎日5分のニュースラジオ"
-  language: ja
-  author: vox-radio
-  category: News
-  explicit: false
-  cover_image_url: https://example.github.io/vox-radio/cover.jpg
-  site_url: https://example.github.io/vox-radio/
-  max_items: 7
   segment_pause_sec: 0.3
   target_duration_sec: 240
 


### PR DESCRIPTION
## Summary

- `ProgramConfig` から配信専用フィールド（`language` / `author` / `category` / `explicit` / `cover_image_url` / `site_url` / `max_items`）を削除
- 番組コンテンツ生成に必要な `title` / `description` / `segment_pause_sec` / `target_duration_sec` のみを残す
- `internal/config/testdata/podcast.yaml`（参照なしのレガシーファイル）を削除
- `sample-profiles/tech_profile.yaml` / `internal/config/testdata/profile.yaml` から配信フィールドを削除
- `sample-profiles/README.md` のプログラムスキーマ説明を更新

## Background

publish/prune が #78 で削除されたことで、配信専用フィールドの唯一の参照がなくなった。ADR-0012 の方針に基づき、配信メタデータは配信リポジトリ側で管理し、vox-radio はコンテンツ生成に必要な情報のみを持つ構成に整理する。

Closes #69

---
🤖 Generated with [Claude Code](https://claude.ai/code)