### PR TITLE
feat: initコマンドを追加して設定ファイルのテンプレートを生成する

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,28 @@ collect → script → synth → assemble → manifest
 
 | コマンド | 概要 |
 |----------|------|
+| `init` | カレントディレクトリに `vox-radio.yaml` と `profile.yaml` のテンプレートを生成する（初回セットアップ用） |
 | `collect` | `corners[].source` に定義したフィード・URL からコーナーごとに記事を収集し `articles.json` を生成する |
 | `script` | 記事を LLM に渡して台本 `script.json` を生成する（summarize → write → direct の多段パイプライン） |
 | `synth` | `script.json` をもとに VOICEVOX で音声クリップを合成する |
 | `assemble` | 音声クリップとイントロ・アウトロを ffmpeg で結合し MP3 エピソードを生成する |
 | `manifest` | 番組内容（タイトル・概要・要約・コーナー・記事）を記した `manifest.json` を MP3 と並べて出力する。`--script` を指定すると LLM で台本ベースの要約を生成する |
 | `run` | collect → script → synth → assemble → manifest の全パイプラインを一括実行する |
+
+### 設定ファイルの作成
+
+`vox-radio init` を実行すると、カレントディレクトリに `vox-radio.yaml`（共通設定）と `profile.yaml`（プロファイル）のテンプレートが生成されます。
+
+```bash
+# テンプレートを生成
+vox-radio init
+
+# 生成されたファイルを編集（LLM APIキー・番組設定を記入）
+# その後、パイプラインを実行
+vox-radio run --profile profile.yaml
+```
+
+既存ファイルは上書きされません（ファイルごとに独立してスキップ判定します）。
 
 ### 設定ファイル
 
@@ -57,7 +73,7 @@ collect → script → synth → assemble → manifest
 | 種別 | ファイル | 内容 |
 |------|---------|------|
 | 共通設定 (config) | `vox-radio.yaml`（カレントディレクトリ、自動読込） | LLM / VOICEVOX URL / キャラカタログ |
-| ジャンル別設定 (profile) | `sample-profiles/<genre>_profile.yaml` | program / corners（各コーナーの source でデータソース指定） / assets |
+| ジャンル別設定 (profile) | `profile.yaml` または `sample-profiles/<genre>_profile.yaml` | program / corners（各コーナーの source でデータソース指定） / assets |
 
 `vox-radio.yaml` はカレントディレクトリから自動的に読み込まれます（`--config` フラグは不要）。
 
@@ -107,3 +123,118 @@ vox-radio assemble --in work/script.json --clips work/clips --out work/episode.m
 
 - [docs/cli/vox-radio.md](docs/cli/vox-radio.md) — コマンド一覧
 - 各サブコマンドの詳細: `vox-radio <command> --help`
+
+## 設定ファイルリファレンス
+
+### vox-radio.yaml（共通設定）
+
+`vox-radio.yaml` はカレントディレクトリから自動読み込みされます。フィールド定義は `internal/config/config.go` の構造体が正です。
+
+#### `llm` セクション
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `base_url` | string | 必須 | LLM API のベースURL（OpenAI 互換エンドポイント） |
+| `api_key_env` | string | 必須 | APIキーを格納する環境変数名 |
+| `model` | string | 必須 | 使用するモデル名 |
+| `temperature` | float64 | 任意 | 生成のランダム性（0.0〜1.0）。デフォルト: 0（Go ゼロ値） |
+| `max_retries` | int | 任意 | APIリトライ回数。デフォルト: 0（Go ゼロ値） |
+| `steps` | map[string]LLMStepConfig | 任意 | ステップごとの設定（キー: ステップ名） |
+
+##### `llm.steps.<step>` サブフィールド
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `temperature` | *float64 | 任意 | このステップの温度（省略時は `llm.temperature` を使用） |
+
+組み込みステップ名: `summarize`（記事要約）、`plan`（台本設計）、`write`（セリフ執筆）、`direct`（ダイレクト生成）。
+
+#### `voicevox` セクション
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `url` | string | 必須 | VOICEVOX Engine のURL |
+
+#### `characters` セクション
+
+`characters` はキャラID（文字列キー）をキーにしたマップです。プロファイルの `corners[].cast` で使用するIDを定義します。
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `name` | string | 必須 | キャラクターの表示名 |
+| `pronoun` | string | 任意 | 一人称代名詞（台本生成時に LLM へ渡す） |
+| `speech_suffix` | []string | 任意 | 語尾パターン（台本生成時に LLM へ渡す） |
+| `personality` | []string | 任意 | 性格特徴（台本生成時に LLM へ渡す） |
+| `default_style` | string | 任意 | デフォルトの音声スタイル名（`styles` のキーと一致させること） |
+| `styles` | map[string]int | 任意 | スタイル名 → VOICEVOX 話者ID のマップ |
+
+`default_style` を指定した場合、その値は `styles` のキーとして存在しなければなりません（起動時検証あり）。
+
+---
+
+### profile.yaml（プロファイル）
+
+`--profile` フラグで指定するジャンル別設定ファイルです。`vox-radio init` で生成されるテンプレートは `profile.yaml` という名前です。詳細は [sample-profiles/README.md](sample-profiles/README.md) も参照してください。
+
+#### `program` セクション
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `title` | string | 任意 | 番組タイトル |
+| `description` | string | 任意 | 番組の説明（LLM への指示に使用） |
+| `segment_pause_sec` | float64 | 任意 | コーナー間の無音時間（秒）。デフォルト: 0（Go ゼロ値） |
+| `target_duration_sec` | int | 任意 | 番組全体の目標収録時間（秒）。デフォルト: 0（Go ゼロ値） |
+
+#### `corners` セクション
+
+`corners` はコーナー定義のリストです。番組を構成するセグメントを順番に記述します。
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `title` | string | 必須 | コーナータイトル |
+| `content` | string | 任意 | コーナーの内容説明（LLM への指示に使用） |
+| `cast` | map[string]string | 任意 | キャラID → 役割説明のマップ（キーは `vox-radio.yaml` の `characters` のキーと一致させること） |
+| `target_duration_sec` | int | 任意 | このコーナーの目標収録時間（秒）。台本生成時に文字数（≈7文字/秒）へ換算される |
+| `source` | SourceConfig | 任意 | データソース（省略するとこのコーナーの収集はスキップ） |
+
+##### `corners[].source` サブフィールド
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `feeds` | []FeedEntry | 任意 | RSS/Atom フィードのリスト |
+| `articles` | []string | 任意 | 個別記事 URL のリスト |
+
+##### `corners[].source.feeds[]` サブフィールド
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `url` | string | 必須 | フィードの URL |
+| `max_items` | int | 任意 | 取得する最大記事数。デフォルト: 0（Go ゼロ値、実質無制限） |
+
+#### `assets` セクション
+
+`assets` はジングル・SE・BGM の音声素材を設定します。バイナリ素材は別途用意してください。ファイルパスはプロファイルファイルのディレクトリからの相対パスで解決されます。
+
+##### `assets.jingle` マップ値
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `file` | string | 必須 | 音声ファイルパス |
+| `fade_in` | float64 | 任意 | フェードイン時間（秒）。デフォルト: 0 |
+| `fade_out` | float64 | 任意 | フェードアウト時間（秒）。デフォルト: 0 |
+
+##### `assets.se` マップ値
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `file` | string | 必須 | 音声ファイルパス |
+| `volume` | float64 | 任意 | 音量倍率。デフォルト: 0（Go ゼロ値） |
+
+##### `assets.bgm` マップ値
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `file` | string | 必須 | 音声ファイルパス |
+| `volume` | float64 | 任意 | 音量倍率。デフォルト: 0（Go ゼロ値） |
+| `duck_ratio` | float64 | 任意 | セリフ再生中の音量低減比率。デフォルト: 0 |
+| `loop` | bool | 任意 | ループ再生するかどうか。デフォルト: false |

--- a/docs/cli/vox-radio.md
+++ b/docs/cli/vox-radio.md
@@ -19,6 +19,7 @@ synthesizing voice clips, assembling audio, and outputting a content manifest.
 
 * [vox-radio assemble](vox-radio_assemble.md)	 - Assemble WAV clips into an MP3 episode
 * [vox-radio collect](vox-radio_collect.md)	 - Collect articles from RSS/Atom feeds and URLs per corner
+* [vox-radio init](vox-radio_init.md)	 - Generate template config files in the current directory
 * [vox-radio manifest](vox-radio_manifest.md)	 - Generate a content manifest JSON alongside an episode
 * [vox-radio run](vox-radio_run.md)	 - Run the full podcast production pipeline
 * [vox-radio script](vox-radio_script.md)	 - Generate a script from collected articles using LLM

--- a/docs/cli/vox-radio_init.md
+++ b/docs/cli/vox-radio_init.md
@@ -1,0 +1,31 @@
+## vox-radio init
+
+Generate template config files in the current directory
+
+### Synopsis
+
+Generate vox-radio.yaml (common settings) and profile.yaml (program profile)
+in the current directory.
+
+Existing files are skipped individually to prevent accidental overwrites.
+If both files already exist, nothing is generated.
+
+After generation, edit the files to configure your LLM API key, program
+content, and audio asset paths, then run the pipeline:
+
+  vox-radio run --profile profile.yaml
+
+```
+vox-radio init [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for init
+```
+
+### SEE ALSO
+
+* [vox-radio](vox-radio.md)	 - AI-powered podcast production tool
+

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -18,7 +18,7 @@ func TestRootHelp(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	out := buf.String()
-	for _, sub := range []string{"collect", "script", "synth", "assemble", "manifest", "run"} {
+	for _, sub := range []string{"init", "collect", "script", "synth", "assemble", "manifest", "run"} {
 		if !strings.Contains(out, sub) {
 			t.Errorf("root help missing subcommand %q", sub)
 		}
@@ -123,7 +123,7 @@ func TestRootCmdDisableAutoGenTag(t *testing.T) {
 }
 
 func TestSubcommandHelp(t *testing.T) {
-	for _, sub := range []string{"collect", "synth", "assemble", "manifest", "script", "run"} {
+	for _, sub := range []string{"init", "collect", "synth", "assemble", "manifest", "script", "run"} {
 		t.Run(sub, func(t *testing.T) {
 			cmd := cli.NewRootCmd()
 			buf := &bytes.Buffer{}

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed templates/vox-radio.yaml
+var configTemplate []byte
+
+//go:embed templates/profile.yaml
+var profileTemplate []byte
+
+func newInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "init",
+		Short: "Generate template config files in the current directory",
+		Long: `Generate vox-radio.yaml (common settings) and profile.yaml (program profile)
+in the current directory.
+
+Existing files are skipped individually to prevent accidental overwrites.
+If both files already exist, nothing is generated.
+
+After generation, edit the files to configure your LLM API key, program
+content, and audio asset paths, then run the pipeline:
+
+  vox-radio run --profile profile.yaml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := generateFile(cmd, "vox-radio.yaml", configTemplate); err != nil {
+				return err
+			}
+			return generateFile(cmd, "profile.yaml", profileTemplate)
+		},
+	}
+}
+
+func generateFile(cmd *cobra.Command, path string, content []byte) error {
+	if _, err := os.Stat(path); err == nil {
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "skip: %s already exists\n", path)
+		return nil
+	}
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "created: %s\n", path)
+	return nil
+}

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -1,0 +1,132 @@
+package cli_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/cli"
+	"github.com/canpok1/vox-radio/internal/config"
+)
+
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	return dir
+}
+
+func runInitCmd(t *testing.T) (string, error) {
+	t.Helper()
+	cmd := cli.NewRootCmd()
+	var buf strings.Builder
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"init"})
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+func TestInitCmd_BothGenerated(t *testing.T) {
+	dir := chdirTemp(t)
+	_, err := runInitCmd(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vox-radio.yaml")); os.IsNotExist(err) {
+		t.Error("vox-radio.yaml was not generated")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "profile.yaml")); os.IsNotExist(err) {
+		t.Error("profile.yaml was not generated")
+	}
+}
+
+func TestInitCmd_ConfigExists_ProfileGenerated(t *testing.T) {
+	dir := chdirTemp(t)
+	existingContent := []byte("# existing")
+	if err := os.WriteFile(filepath.Join(dir, "vox-radio.yaml"), existingContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runInitCmd(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "vox-radio.yaml"))
+	if string(data) != string(existingContent) {
+		t.Error("vox-radio.yaml should not be overwritten")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "profile.yaml")); os.IsNotExist(err) {
+		t.Error("profile.yaml was not generated")
+	}
+	if !strings.Contains(out, "skip") {
+		t.Errorf("expected skip message for vox-radio.yaml, got: %s", out)
+	}
+}
+
+func TestInitCmd_ProfileExists_ConfigGenerated(t *testing.T) {
+	dir := chdirTemp(t)
+	existingContent := []byte("# existing")
+	if err := os.WriteFile(filepath.Join(dir, "profile.yaml"), existingContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := runInitCmd(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "profile.yaml"))
+	if string(data) != string(existingContent) {
+		t.Error("profile.yaml should not be overwritten")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "vox-radio.yaml")); os.IsNotExist(err) {
+		t.Error("vox-radio.yaml was not generated")
+	}
+	if !strings.Contains(out, "skip") {
+		t.Errorf("expected skip message for profile.yaml, got: %s", out)
+	}
+}
+
+func TestInitCmd_BothExist_NothingGenerated(t *testing.T) {
+	dir := chdirTemp(t)
+	existingContent := []byte("# existing")
+	for _, name := range []string{"vox-radio.yaml", "profile.yaml"} {
+		if err := os.WriteFile(filepath.Join(dir, name), existingContent, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := runInitCmd(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, name := range []string{"vox-radio.yaml", "profile.yaml"} {
+		data, _ := os.ReadFile(filepath.Join(dir, name))
+		if string(data) != string(existingContent) {
+			t.Errorf("%s should not be overwritten", name)
+		}
+	}
+}
+
+func TestInitCmd_GeneratedFilesLoadable(t *testing.T) {
+	dir := chdirTemp(t)
+	_, err := runInitCmd(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg, err := config.LoadConfig(filepath.Join(dir, "vox-radio.yaml"))
+	if err != nil {
+		t.Fatalf("LoadConfig failed on generated template: %v", err)
+	}
+	profile, err := config.LoadProfile(filepath.Join(dir, "profile.yaml"))
+	if err != nil {
+		t.Fatalf("LoadProfile failed on generated template: %v", err)
+	}
+	if err := config.ValidateProfileCast(profile, cfg.Characters); err != nil {
+		t.Fatalf("ValidateProfileCast failed: %v", err)
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,6 +18,7 @@ synthesizing voice clips, assembling audio, and outputting a content manifest.`,
 	}
 
 	root.AddCommand(
+		newInitCmd(),
 		newCollectCmd(),
 		newScriptCmd(),
 		newSynthCmd(),

--- a/internal/cli/templates/profile.yaml
+++ b/internal/cli/templates/profile.yaml
@@ -1,0 +1,60 @@
+# profile.yaml - プロファイル設定ファイル
+# このファイルを編集して番組の構成・コーナー・音声素材のパスを設定してください。
+# vox-radio run --profile profile.yaml で実行できます。
+
+# 番組全体の設定
+program:
+  # 番組タイトル
+  title: "番組タイトル"
+  # 番組の説明（LLM への指示に使用）
+  description: "番組の説明"
+  # コーナー間の無音時間（秒）
+  segment_pause_sec: 0.3
+  # 番組全体の目標収録時間（秒）
+  target_duration_sec: 240
+
+# コーナー定義（番組を構成する各コーナーを順番に記述）
+corners:
+  - title: "オープニング"
+    # コーナーの内容説明（LLM への指示に使用）
+    content: "番組の挨拶と本日のトピック紹介"
+    # 出演キャラクター（キャラクターID: 役割の説明）
+    # キャラクターIDは vox-radio.yaml の characters のキーと一致させること
+    cast:
+      zundamon: "元気に挨拶する進行役"
+    # このコーナーの目標時間（秒）
+    target_duration_sec: 30
+
+  - title: "メインコーナー"
+    content: "メインコンテンツの紹介"
+    cast:
+      zundamon: "進行役"
+      metan: "解説役"
+    target_duration_sec: 180
+    # ソース設定（RSSフィードや記事URLからコンテンツを収集する場合に設定）
+    # ソースがない場合はこのブロックを省略してください
+    source:
+      feeds:
+        - url: https://example.com/feed
+          max_items: 5
+      articles: []
+
+  - title: "エンディング"
+    content: "まとめと締め"
+    cast:
+      zundamon: "進行役"
+    target_duration_sec: 30
+
+# アセット設定（ジングル・SE・BGM）
+# バイナリ素材ファイルは別途用意してください。
+# ファイルパスはこのプロファイルファイルからの相対パスで解決されます。
+# 素材が不要な場合はこのセクション全体をコメントアウトするか削除してください。
+# assets:
+#   jingle:
+#     opening: { file: assets/jingle/opening.mp3, fade_in: 0.5, fade_out: 0.5 }
+#     ending:  { file: assets/jingle/ending.mp3,  fade_in: 0.5, fade_out: 1.0 }
+#   se:
+#     chime:      { file: assets/se/chime.wav,      volume: 0.8 }
+#     transition: { file: assets/se/transition.wav, volume: 0.8 }
+#   bgm:
+#     talk_bgm: { file: assets/bgm/talk.mp3, volume: 0.3, duck_ratio: 8, loop: true }

--- a/internal/cli/templates/vox-radio.yaml
+++ b/internal/cli/templates/vox-radio.yaml
@@ -1,0 +1,69 @@
+# vox-radio.yaml - 共通設定ファイル
+# このファイルを編集して LLM・VOICEVOX の接続情報とキャラクター設定を行ってください。
+
+# LLM（大規模言語モデル）の接続設定
+llm:
+  # LLM API のベースURL（OpenAI 互換エンドポイント）
+  base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+  # APIキーを格納する環境変数名（export GEMINI_API_KEY=xxx などで設定）
+  api_key_env: GEMINI_API_KEY
+  # 使用するモデル名
+  model: gemini-3.1-flash-lite
+  # 生成のランダム性（0.0〜1.0）。低いほど安定、高いほど多様な出力になる
+  temperature: 0.7
+  # APIリトライ回数
+  max_retries: 3
+  # ステップごとの温度設定（省略時は上記 temperature を使用）
+  steps:
+    summarize: { temperature: 0.2 }
+    plan:      { temperature: 0.4 }
+    write:     { temperature: 0.8 }
+    direct:    { temperature: 0.2 }
+
+# VOICEVOX 音声合成エンジンの接続設定
+voicevox:
+  # VOICEVOX Engine の URL
+  # devcontainer 環境で利用する場合は http://voicevox:50021 に変更してください
+  url: http://localhost:50021
+
+# キャラクター設定（VOICEVOX の話者IDと紐付け）
+# キャラクターIDは corners[].cast のキーとして使用します
+characters:
+  zundamon:
+    name: ずんだもん
+    pronoun: ボク
+    speech_suffix: ["〜のだ", "〜なのだ"]
+    personality: ["元気", "明るい", "素直", "前向き", "おっちょこちょい", "好奇心旺盛"]
+    # デフォルトで使用するスタイル名（styles のキーと一致させること）
+    default_style: ノーマル
+    # スタイル名と VOICEVOX 話者IDの対応
+    styles:
+      ノーマル: 3
+      あまあま: 1
+      ツンツン: 7
+      セクシー: 5
+      ささやき: 22
+      ヒソヒソ: 38
+      ヘロヘロ: 75
+      なみだめ: 76
+  zunko:
+    name: 東北ずん子
+    pronoun: 私
+    speech_suffix: ["〜です", "〜ます"]
+    personality: ["前向き", "明るい", "母性の塊", "穏やか"]
+    default_style: ノーマル
+    styles:
+      ノーマル: 107
+  metan:
+    name: 四国めたん
+    pronoun: わたくし
+    speech_suffix: ["〜かしら", "〜だわ", "〜ですわ"]
+    personality: ["お嬢様", "しっかり者", "気まぐれ", "負けず嫌い", "世話好き"]
+    default_style: ノーマル
+    styles:
+      ノーマル: 2
+      あまあま: 0
+      ツンツン: 6
+      セクシー: 4
+      ささやき: 36
+      ヒソヒソ: 37


### PR DESCRIPTION
## Summary

- `vox-radio init` コマンドを追加し、カレントディレクトリに `vox-radio.yaml`（共通設定）と `profile.yaml`（プロファイル）のテンプレートを生成できるようにした
- 既存ファイルはそれぞれ独立してスキップ判定し、上書きしない（誤って設定を破壊しない設計）
- `go:embed` でテンプレートYAMLを埋め込み、TDD（テスト先書き）で実装（5テストケース）
- 生成ファイルが `LoadConfig` / `LoadProfile` / `ValidateProfileCast` を通ることをテストで担保
- `make docs` で `docs/cli/` を再生成（`vox-radio_init.md` を追加）
- README に `vox-radio init` の使い方と設定ファイルのフィールド単位リファレンスを追記

## Changes

| ファイル | 変更内容 |
|---|---|
| `internal/cli/init.go` | `vox-radio init` コマンド実装 |
| `internal/cli/init_test.go` | 5テストケース（両ファイル生成・片方スキップ・両方スキップ・ロード可能性） |
| `internal/cli/templates/vox-radio.yaml` | 共通設定テンプレート（コメント付き、voicevox URL は一般利用者向け `localhost:50021`） |
| `internal/cli/templates/profile.yaml` | プロファイルテンプレート（assets はコメントアウト、素材は別途用意する旨を明記） |
| `internal/cli/root.go` | `newInitCmd()` を AddCommand に追加 |
| `internal/cli/cli_test.go` | TestRootHelp / TestSubcommandHelp に `init` を追加 |
| `docs/cli/vox-radio_init.md` | `make docs` で自動生成 |
| `README.md` | `vox-radio init` 使い方・設定ファイルリファレンス追記 |

Closes #84

---
🤖 Generated with [Claude Code](https://claude.ai/code)