### PR TITLE
docs: CLIヘルプの説明文を日本語化する

### DIFF
--- a/docs/cli/vox-radio.md
+++ b/docs/cli/vox-radio.md
@@ -1,13 +1,13 @@
 ## vox-radio
 
-AI-powered podcast production tool
+AI を使ったポッドキャスト制作ツール
 
 ### Synopsis
 
-vox-radio is a CLI tool for producing AI-generated podcast episodes.
+vox-radio は AI を活用したポッドキャストエピソード制作 CLI ツールです。
 
-It covers the full pipeline: collecting articles, generating scripts via LLM,
-synthesizing voice clips, assembling audio, and outputting a content manifest.
+記事収集・LLM による台本生成・音声合成・音声組み立て・コンテンツマニフェスト出力まで、
+フルパイプラインをカバーします。
 
 ### Options
 
@@ -17,11 +17,11 @@ synthesizing voice clips, assembling audio, and outputting a content manifest.
 
 ### SEE ALSO
 
-* [vox-radio assemble](vox-radio_assemble.md)	 - Assemble WAV clips into an MP3 episode
-* [vox-radio collect](vox-radio_collect.md)	 - Collect articles from RSS/Atom feeds and URLs per corner
-* [vox-radio init](vox-radio_init.md)	 - Generate template config files in the current directory
-* [vox-radio manifest](vox-radio_manifest.md)	 - Generate a content manifest JSON alongside an episode
-* [vox-radio run](vox-radio_run.md)	 - Run the full podcast production pipeline
-* [vox-radio script](vox-radio_script.md)	 - Generate a script from collected articles using LLM
-* [vox-radio synth](vox-radio_synth.md)	 - Synthesize voice clips from a script
+* [vox-radio assemble](vox-radio_assemble.md)	 - WAV クリップを MP3 エピソードに組み立てる
+* [vox-radio collect](vox-radio_collect.md)	 - コーナーごとに RSS/Atom フィードと URL から記事を収集する
+* [vox-radio init](vox-radio_init.md)	 - カレントディレクトリにテンプレート設定ファイルを生成する
+* [vox-radio manifest](vox-radio_manifest.md)	 - エピソードのコンテンツマニフェスト JSON を生成する
+* [vox-radio run](vox-radio_run.md)	 - ポッドキャスト制作パイプラインをすべて実行する
+* [vox-radio script](vox-radio_script.md)	 - LLM を使って収集した記事から台本を生成する
+* [vox-radio synth](vox-radio_synth.md)	 - 台本から音声クリップを合成する
 

--- a/docs/cli/vox-radio_assemble.md
+++ b/docs/cli/vox-radio_assemble.md
@@ -1,13 +1,13 @@
 ## vox-radio assemble
 
-Assemble WAV clips into an MP3 episode
+WAV クリップを MP3 エピソードに組み立てる
 
 ### Synopsis
 
-Read script.json and the clips directory produced by synth, then use ffmpeg
-to mix intro/outro/SE and produce a final MP3 episode file.
+script.json と synth が生成したクリップディレクトリを読み込み、
+ffmpeg を使ってイントロ・アウトロ・SE をミックスし、最終的な MP3 エピソードを生成します。
 
-Example:
+例:
   vox-radio assemble --in work/script.json --clips work/clips --out work/episode.mp3
   vox-radio assemble --in work/script.json --clips work/clips --out work/episode.mp3 --profile sample-profiles/tech_profile.yaml
 
@@ -18,14 +18,14 @@ vox-radio assemble [flags]
 ### Options
 
 ```
-      --clips string     directory containing clips.json and WAV files (required)
+      --clips string     clips.json と WAV ファイルを含むディレクトリ（必須）
   -h, --help             help for assemble
-      --in string        input script.json path (required)
-      --out string       output mp3 path (required)
-      --profile string   profile YAML file path for assets (optional)
+      --in string        script.json の入力パス（必須）
+      --out string       MP3 の出力先パス（必須）
+      --profile string   アセット設定を含むプロファイル YAML ファイルのパス（任意）
 ```
 
 ### SEE ALSO
 
-* [vox-radio](vox-radio.md)	 - AI-powered podcast production tool
+* [vox-radio](vox-radio.md)	 - AI を使ったポッドキャスト制作ツール
 

--- a/docs/cli/vox-radio_collect.md
+++ b/docs/cli/vox-radio_collect.md
@@ -1,15 +1,15 @@
 ## vox-radio collect
 
-Collect articles from RSS/Atom feeds and URLs per corner
+コーナーごとに RSS/Atom フィードと URL から記事を収集する
 
 ### Synopsis
 
-Collect articles from RSS/Atom feeds and web URLs defined in corners[].source,
-extract their body text, and write the result to articles.json.
+corners[].source に定義された RSS/Atom フィードや Web URL から記事を収集し、
+本文テキストを抽出して articles.json に書き出します。
 
-Corners without a source field are skipped.
+source フィールドのないコーナーはスキップされます。
 
-Example:
+例:
   vox-radio collect --out work/articles.json
   vox-radio collect --out work/articles.json --profile sample-profiles/tech_profile.yaml
 
@@ -21,11 +21,11 @@ vox-radio collect [flags]
 
 ```
   -h, --help             help for collect
-      --out string       output articles.json path (required)
-      --profile string   profile YAML file path (required)
+      --out string       articles.json の出力先パス（必須）
+      --profile string   プロファイル YAML ファイルのパス（必須）
 ```
 
 ### SEE ALSO
 
-* [vox-radio](vox-radio.md)	 - AI-powered podcast production tool
+* [vox-radio](vox-radio.md)	 - AI を使ったポッドキャスト制作ツール
 

--- a/docs/cli/vox-radio_init.md
+++ b/docs/cli/vox-radio_init.md
@@ -1,17 +1,17 @@
 ## vox-radio init
 
-Generate template config files in the current directory
+カレントディレクトリにテンプレート設定ファイルを生成する
 
 ### Synopsis
 
-Generate vox-radio.yaml (common settings) and profile.yaml (program profile)
-in the current directory.
+vox-radio.yaml（共通設定）と profile.yaml（プログラムプロファイル）を
+カレントディレクトリに生成します。
 
-Existing files are skipped individually to prevent accidental overwrites.
-If both files already exist, nothing is generated.
+既存ファイルは上書きを防ぐため個別にスキップされます。
+両ファイルがすでに存在する場合は何も生成されません。
 
-After generation, edit the files to configure your LLM API key, program
-content, and audio asset paths, then run the pipeline:
+生成後は LLM API キー・番組内容・音声アセットパスを設定ファイルに記入し、
+次のコマンドでパイプラインを実行してください:
 
   vox-radio run --profile profile.yaml
 
@@ -27,5 +27,5 @@ vox-radio init [flags]
 
 ### SEE ALSO
 
-* [vox-radio](vox-radio.md)	 - AI-powered podcast production tool
+* [vox-radio](vox-radio.md)	 - AI を使ったポッドキャスト制作ツール
 

--- a/docs/cli/vox-radio_manifest.md
+++ b/docs/cli/vox-radio_manifest.md
@@ -25,13 +25,13 @@ vox-radio manifest [flags]
 ### Options
 
 ```
-      --articles string   articles.json のパス（任意）省略するとコーナーの記事は空になる
+      --articles string   articles.json のパス（任意）。省略するとコーナーの記事は空になる
       --audio string      音声ファイルのパス。ファイル名のみマニフェストに記録される（必須）
   -h, --help              help for manifest
       --out string        manifest.json の出力先パス（必須）
       --profile string    プロファイル YAML ファイルのパス（必須）
       --prompts string    プロンプトテンプレートを含むディレクトリ（--script 指定時に使用） (default "prompts")
-      --script string     script.json のパス（任意）指定すると LLM が台本から要約を生成する
+      --script string     script.json のパス（任意）。指定すると LLM が台本から要約を生成する
 ```
 
 ### SEE ALSO

--- a/docs/cli/vox-radio_manifest.md
+++ b/docs/cli/vox-radio_manifest.md
@@ -1,19 +1,19 @@
 ## vox-radio manifest
 
-Generate a content manifest JSON alongside an episode
+エピソードのコンテンツマニフェスト JSON を生成する
 
 ### Synopsis
 
-Build a manifest.json that describes the episode content: title, description,
-summary, datetime, audio filename, and corners with their articles.
+エピソードの内容を記述する manifest.json を生成します。
+タイトル・説明・要約・日時・音声ファイル名・各コーナーの記事情報を含みます。
 
-The manifest is intended for use by a separate publishing service to generate
-RSS feeds without re-running the full pipeline.
+マニフェストは別の配信サービスが RSS フィードを生成する際に使用することを想定しており、
+フルパイプラインを再実行せずに済みます。
 
-When --script is provided, an LLM-generated summary is added to the manifest
-using vox-radio.yaml for LLM configuration.
+--script を指定すると、vox-radio.yaml の LLM 設定を使って
+LLM が生成した要約をマニフェストに追加します。
 
-Example:
+例:
   vox-radio manifest --profile sample-profiles/tech_profile.yaml --audio output/episode.mp3 --out output/manifest.json
   vox-radio manifest --profile sample-profiles/tech_profile.yaml --articles output/intermediate/articles.json --audio output/episode.mp3 --out output/manifest.json
   vox-radio manifest --profile sample-profiles/tech_profile.yaml --script output/intermediate/script.json --audio output/episode.mp3 --out output/manifest.json
@@ -25,16 +25,16 @@ vox-radio manifest [flags]
 ### Options
 
 ```
-      --articles string   articles.json path (optional; corners get empty articles when omitted)
-      --audio string      audio file path; basename is stored in manifest (required)
+      --articles string   articles.json のパス（任意）省略するとコーナーの記事は空になる
+      --audio string      音声ファイルのパス。ファイル名のみマニフェストに記録される（必須）
   -h, --help              help for manifest
-      --out string        output manifest.json path (required)
-      --profile string    profile YAML file path (required)
-      --prompts string    directory containing prompt templates (used when --script is provided) (default "prompts")
-      --script string     script.json path (optional; when provided, LLM generates a summary from the script)
+      --out string        manifest.json の出力先パス（必須）
+      --profile string    プロファイル YAML ファイルのパス（必須）
+      --prompts string    プロンプトテンプレートを含むディレクトリ（--script 指定時に使用） (default "prompts")
+      --script string     script.json のパス（任意）指定すると LLM が台本から要約を生成する
 ```
 
 ### SEE ALSO
 
-* [vox-radio](vox-radio.md)	 - AI-powered podcast production tool
+* [vox-radio](vox-radio.md)	 - AI を使ったポッドキャスト制作ツール
 

--- a/docs/cli/vox-radio_run.md
+++ b/docs/cli/vox-radio_run.md
@@ -1,17 +1,17 @@
 ## vox-radio run
 
-Run the full podcast production pipeline
+ポッドキャスト制作パイプラインをすべて実行する
 
 ### Synopsis
 
-Run collect → script → synth → assemble → manifest in one shot.
+collect → script → synth → assemble → manifest を一括実行します。
 
-Intermediate files are written to <out-dir>/intermediate/ and the final
-episode.mp3 is placed directly under <out-dir>/.
+中間ファイルは <out-dir>/intermediate/ に書き出され、
+最終的な episode.mp3 は <out-dir>/ 直下に配置されます。
 
-vox-radio.yaml is automatically loaded from the current directory.
+vox-radio.yaml はカレントディレクトリから自動読み込みされます。
 
-Example:
+例:
   vox-radio run
   vox-radio run --out-dir output --profile sample-profiles/tech_profile.yaml
 
@@ -23,12 +23,12 @@ vox-radio run [flags]
 
 ```
   -h, --help             help for run
-      --out-dir string   output directory (episode.mp3 placed here, intermediate files in <out-dir>/intermediate/) (default "output")
-      --profile string   profile YAML file path (required)
-      --prompts string   directory containing prompt templates (default "prompts")
+      --out-dir string   出力ディレクトリ（episode.mp3 をここに配置し、中間ファイルは <out-dir>/intermediate/ に配置） (default "output")
+      --profile string   プロファイル YAML ファイルのパス（必須）
+      --prompts string   プロンプトテンプレートを含むディレクトリ (default "prompts")
 ```
 
 ### SEE ALSO
 
-* [vox-radio](vox-radio.md)	 - AI-powered podcast production tool
+* [vox-radio](vox-radio.md)	 - AI を使ったポッドキャスト制作ツール
 

--- a/docs/cli/vox-radio_script.md
+++ b/docs/cli/vox-radio_script.md
@@ -1,21 +1,21 @@
 ## vox-radio script
 
-Generate a script from collected articles using LLM
+LLM を使って収集した記事から台本を生成する
 
 ### Synopsis
 
-Run the multi-stage LLM pipeline (summarize → write → direct) to
-produce script.json from articles.json.
+多段階 LLM パイプライン（summarize → write → direct）を実行し、
+articles.json から script.json を生成します。
 
-vox-radio.yaml is automatically loaded from the current directory.
-Corner definitions come from the profile (no plan step).
+vox-radio.yaml はカレントディレクトリから自動読み込みされます。
+コーナー定義はプロファイルから取得します（plan ステップはありません）。
 
-Use --step to run a single stage independently:
-  summarize  Summarize each article per corner (writes summaries.json)
-  write      Write lines per corner (writes lines.json)
-  direct     Assign SE/speakers to lines (writes script.json)
+--step で単一ステージのみ実行できます:
+  summarize  コーナーごとに各記事を要約します（summaries.json を出力）
+  write      コーナーごとに台詞を書きます（lines.json を出力）
+  direct     台詞に SE・話者を割り当てます（script.json を出力）
 
-Example:
+例:
   vox-radio script --in work/articles.json --out work/script.json
   vox-radio script --out work/script.json --step write
   vox-radio script --in work/articles.json --out work/script.json --profile sample-profiles/tech_profile.yaml
@@ -28,14 +28,14 @@ vox-radio script [flags]
 
 ```
   -h, --help             help for script
-      --in string        input articles.json path (required for full pipeline or summarize step)
-      --out string       output script.json path (required)
-      --profile string   profile YAML file path (required)
-      --prompts string   directory containing prompt templates (default "prompts")
-      --step string      run a single step: summarize|write|direct
+      --in string        articles.json の入力パス（フルパイプラインまたは summarize ステップで必須）
+      --out string       script.json の出力先パス（必須）
+      --profile string   プロファイル YAML ファイルのパス（必須）
+      --prompts string   プロンプトテンプレートを含むディレクトリ (default "prompts")
+      --step string      単一ステップを実行する: summarize|write|direct
 ```
 
 ### SEE ALSO
 
-* [vox-radio](vox-radio.md)	 - AI-powered podcast production tool
+* [vox-radio](vox-radio.md)	 - AI を使ったポッドキャスト制作ツール
 

--- a/docs/cli/vox-radio_synth.md
+++ b/docs/cli/vox-radio_synth.md
@@ -1,17 +1,17 @@
 ## vox-radio synth
 
-Synthesize voice clips from a script
+台本から音声クリップを合成する
 
 ### Synopsis
 
-Read script.json and call VOICEVOX to synthesize each line into WAV clips.
-The output directory will contain per-line WAV files and a clips.json manifest.
+script.json を読み込み、VOICEVOX を呼び出して各台詞を WAV クリップに合成します。
+出力ディレクトリには台詞ごとの WAV ファイルと clips.json マニフェストが格納されます。
 
-vox-radio.yaml is automatically loaded from the current directory.
-The voicevox.url field specifies the VOICEVOX engine URL (default: http://localhost:50021).
-Speaker IDs are resolved from the characters catalog in vox-radio.yaml.
+vox-radio.yaml はカレントディレクトリから自動読み込みされます。
+voicevox.url フィールドで VOICEVOX エンジンの URL を指定します（デフォルト: http://localhost:50021）。
+話者 ID は vox-radio.yaml のキャラクターカタログから解決されます。
 
-Example:
+例:
   vox-radio synth --in work/script.json --out-dir work/clips
 
 ```
@@ -22,11 +22,11 @@ vox-radio synth [flags]
 
 ```
   -h, --help             help for synth
-      --in string        input script.json path (required)
-      --out-dir string   output directory for WAV clips (required)
+      --in string        script.json の入力パス（必須）
+      --out-dir string   WAV クリップの出力ディレクトリ（必須）
 ```
 
 ### SEE ALSO
 
-* [vox-radio](vox-radio.md)	 - AI-powered podcast production tool
+* [vox-radio](vox-radio.md)	 - AI を使ったポッドキャスト制作ツール
 

--- a/internal/cli/assemble.go
+++ b/internal/cli/assemble.go
@@ -21,11 +21,11 @@ func newAssembleCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "assemble",
-		Short: "Assemble WAV clips into an MP3 episode",
-		Long: `Read script.json and the clips directory produced by synth, then use ffmpeg
-to mix intro/outro/SE and produce a final MP3 episode file.
+		Short: "WAV クリップを MP3 エピソードに組み立てる",
+		Long: `script.json と synth が生成したクリップディレクトリを読み込み、
+ffmpeg を使ってイントロ・アウトロ・SE をミックスし、最終的な MP3 エピソードを生成します。
 
-Example:
+例:
   vox-radio assemble --in work/script.json --clips work/clips --out work/episode.mp3
   vox-radio assemble --in work/script.json --clips work/clips --out work/episode.mp3 --profile sample-profiles/tech_profile.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -69,10 +69,10 @@ Example:
 		},
 	}
 
-	cmd.Flags().StringVar(&in, "in", "", "input script.json path (required)")
-	cmd.Flags().StringVar(&clipsDir, "clips", "", "directory containing clips.json and WAV files (required)")
-	cmd.Flags().StringVar(&out, "out", "", "output mp3 path (required)")
-	cmd.Flags().StringVar(&profilePath, "profile", "", "profile YAML file path for assets (optional)")
+	cmd.Flags().StringVar(&in, "in", "", "script.json の入力パス（必須）")
+	cmd.Flags().StringVar(&clipsDir, "clips", "", "clips.json と WAV ファイルを含むディレクトリ（必須）")
+	cmd.Flags().StringVar(&out, "out", "", "MP3 の出力先パス（必須）")
+	cmd.Flags().StringVar(&profilePath, "profile", "", "アセット設定を含むプロファイル YAML ファイルのパス（任意）")
 	_ = cmd.MarkFlagRequired("in")
 	_ = cmd.MarkFlagRequired("clips")
 	_ = cmd.MarkFlagRequired("out")

--- a/internal/cli/collect.go
+++ b/internal/cli/collect.go
@@ -15,13 +15,13 @@ func newCollectCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "collect",
-		Short: "Collect articles from RSS/Atom feeds and URLs per corner",
-		Long: `Collect articles from RSS/Atom feeds and web URLs defined in corners[].source,
-extract their body text, and write the result to articles.json.
+		Short: "コーナーごとに RSS/Atom フィードと URL から記事を収集する",
+		Long: `corners[].source に定義された RSS/Atom フィードや Web URL から記事を収集し、
+本文テキストを抽出して articles.json に書き出します。
 
-Corners without a source field are skipped.
+source フィールドのないコーナーはスキップされます。
 
-Example:
+例:
   vox-radio collect --out work/articles.json
   vox-radio collect --out work/articles.json --profile sample-profiles/tech_profile.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -50,7 +50,7 @@ Example:
 	}
 
 	registerProfileFlag(cmd, &profilePath)
-	cmd.Flags().StringVar(&out, "out", "", "output articles.json path (required)")
+	cmd.Flags().StringVar(&out, "out", "", "articles.json の出力先パス（必須）")
 	_ = cmd.MarkFlagRequired("out")
 
 	return cmd

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -17,15 +17,15 @@ var profileTemplate []byte
 func newInitCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
-		Short: "Generate template config files in the current directory",
-		Long: `Generate vox-radio.yaml (common settings) and profile.yaml (program profile)
-in the current directory.
+		Short: "カレントディレクトリにテンプレート設定ファイルを生成する",
+		Long: `vox-radio.yaml（共通設定）と profile.yaml（プログラムプロファイル）を
+カレントディレクトリに生成します。
 
-Existing files are skipped individually to prevent accidental overwrites.
-If both files already exist, nothing is generated.
+既存ファイルは上書きを防ぐため個別にスキップされます。
+両ファイルがすでに存在する場合は何も生成されません。
 
-After generation, edit the files to configure your LLM API key, program
-content, and audio asset paths, then run the pipeline:
+生成後は LLM API キー・番組内容・音声アセットパスを設定ファイルに記入し、
+次のコマンドでパイプラインを実行してください:
 
   vox-radio run --profile profile.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -25,17 +25,17 @@ func newManifestCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "manifest",
-		Short: "Generate a content manifest JSON alongside an episode",
-		Long: `Build a manifest.json that describes the episode content: title, description,
-summary, datetime, audio filename, and corners with their articles.
+		Short: "エピソードのコンテンツマニフェスト JSON を生成する",
+		Long: `エピソードの内容を記述する manifest.json を生成します。
+タイトル・説明・要約・日時・音声ファイル名・各コーナーの記事情報を含みます。
 
-The manifest is intended for use by a separate publishing service to generate
-RSS feeds without re-running the full pipeline.
+マニフェストは別の配信サービスが RSS フィードを生成する際に使用することを想定しており、
+フルパイプラインを再実行せずに済みます。
 
-When --script is provided, an LLM-generated summary is added to the manifest
-using vox-radio.yaml for LLM configuration.
+--script を指定すると、vox-radio.yaml の LLM 設定を使って
+LLM が生成した要約をマニフェストに追加します。
 
-Example:
+例:
   vox-radio manifest --profile sample-profiles/tech_profile.yaml --audio output/episode.mp3 --out output/manifest.json
   vox-radio manifest --profile sample-profiles/tech_profile.yaml --articles output/intermediate/articles.json --audio output/episode.mp3 --out output/manifest.json
   vox-radio manifest --profile sample-profiles/tech_profile.yaml --script output/intermediate/script.json --audio output/episode.mp3 --out output/manifest.json`,
@@ -99,11 +99,11 @@ Example:
 	}
 
 	registerProfileFlag(cmd, &profilePath)
-	cmd.Flags().StringVar(&articlesPath, "articles", "", "articles.json path (optional; corners get empty articles when omitted)")
-	cmd.Flags().StringVar(&audioPath, "audio", "", "audio file path; basename is stored in manifest (required)")
-	cmd.Flags().StringVar(&out, "out", "", "output manifest.json path (required)")
-	cmd.Flags().StringVar(&scriptPath, "script", "", "script.json path (optional; when provided, LLM generates a summary from the script)")
-	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "directory containing prompt templates (used when --script is provided)")
+	cmd.Flags().StringVar(&articlesPath, "articles", "", "articles.json のパス（任意）省略するとコーナーの記事は空になる")
+	cmd.Flags().StringVar(&audioPath, "audio", "", "音声ファイルのパス。ファイル名のみマニフェストに記録される（必須）")
+	cmd.Flags().StringVar(&out, "out", "", "manifest.json の出力先パス（必須）")
+	cmd.Flags().StringVar(&scriptPath, "script", "", "script.json のパス（任意）指定すると LLM が台本から要約を生成する")
+	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "プロンプトテンプレートを含むディレクトリ（--script 指定時に使用）")
 	_ = cmd.MarkFlagRequired("audio")
 	_ = cmd.MarkFlagRequired("out")
 

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -99,10 +99,10 @@ LLM が生成した要約をマニフェストに追加します。
 	}
 
 	registerProfileFlag(cmd, &profilePath)
-	cmd.Flags().StringVar(&articlesPath, "articles", "", "articles.json のパス（任意）省略するとコーナーの記事は空になる")
+	cmd.Flags().StringVar(&articlesPath, "articles", "", "articles.json のパス（任意）。省略するとコーナーの記事は空になる")
 	cmd.Flags().StringVar(&audioPath, "audio", "", "音声ファイルのパス。ファイル名のみマニフェストに記録される（必須）")
 	cmd.Flags().StringVar(&out, "out", "", "manifest.json の出力先パス（必須）")
-	cmd.Flags().StringVar(&scriptPath, "script", "", "script.json のパス（任意）指定すると LLM が台本から要約を生成する")
+	cmd.Flags().StringVar(&scriptPath, "script", "", "script.json のパス（任意）。指定すると LLM が台本から要約を生成する")
 	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "プロンプトテンプレートを含むディレクトリ（--script 指定時に使用）")
 	_ = cmd.MarkFlagRequired("audio")
 	_ = cmd.MarkFlagRequired("out")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -7,11 +7,11 @@ import (
 func NewRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "vox-radio",
-		Short: "AI-powered podcast production tool",
-		Long: `vox-radio is a CLI tool for producing AI-generated podcast episodes.
+		Short: "AI を使ったポッドキャスト制作ツール",
+		Long: `vox-radio は AI を活用したポッドキャストエピソード制作 CLI ツールです。
 
-It covers the full pipeline: collecting articles, generating scripts via LLM,
-synthesizing voice clips, assembling audio, and outputting a content manifest.`,
+記事収集・LLM による台本生成・音声合成・音声組み立て・コンテンツマニフェスト出力まで、
+フルパイプラインをカバーします。`,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 		DisableAutoGenTag: true,

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -26,15 +26,15 @@ func newRunCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "run",
-		Short: "Run the full podcast production pipeline",
-		Long: `Run collect → script → synth → assemble → manifest in one shot.
+		Short: "ポッドキャスト制作パイプラインをすべて実行する",
+		Long: `collect → script → synth → assemble → manifest を一括実行します。
 
-Intermediate files are written to <out-dir>/intermediate/ and the final
-episode.mp3 is placed directly under <out-dir>/.
+中間ファイルは <out-dir>/intermediate/ に書き出され、
+最終的な episode.mp3 は <out-dir>/ 直下に配置されます。
 
-vox-radio.yaml is automatically loaded from the current directory.
+vox-radio.yaml はカレントディレクトリから自動読み込みされます。
 
-Example:
+例:
   vox-radio run
   vox-radio run --out-dir output --profile sample-profiles/tech_profile.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -94,9 +94,9 @@ Example:
 		},
 	}
 
-	cmd.Flags().StringVar(&outDir, "out-dir", "output", "output directory (episode.mp3 placed here, intermediate files in <out-dir>/intermediate/)")
+	cmd.Flags().StringVar(&outDir, "out-dir", "output", "出力ディレクトリ（episode.mp3 をここに配置し、中間ファイルは <out-dir>/intermediate/ に配置）")
 	registerProfileFlag(cmd, &profilePath)
-	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "directory containing prompt templates")
+	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "プロンプトテンプレートを含むディレクトリ")
 
 	return cmd
 }

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -27,19 +27,19 @@ func newScriptCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "script",
-		Short: "Generate a script from collected articles using LLM",
-		Long: `Run the multi-stage LLM pipeline (summarize → write → direct) to
-produce script.json from articles.json.
+		Short: "LLM を使って収集した記事から台本を生成する",
+		Long: `多段階 LLM パイプライン（summarize → write → direct）を実行し、
+articles.json から script.json を生成します。
 
-vox-radio.yaml is automatically loaded from the current directory.
-Corner definitions come from the profile (no plan step).
+vox-radio.yaml はカレントディレクトリから自動読み込みされます。
+コーナー定義はプロファイルから取得します（plan ステップはありません）。
 
-Use --step to run a single stage independently:
-  summarize  Summarize each article per corner (writes summaries.json)
-  write      Write lines per corner (writes lines.json)
-  direct     Assign SE/speakers to lines (writes script.json)
+--step で単一ステージのみ実行できます:
+  summarize  コーナーごとに各記事を要約します（summaries.json を出力）
+  write      コーナーごとに台詞を書きます（lines.json を出力）
+  direct     台詞に SE・話者を割り当てます（script.json を出力）
 
-Example:
+例:
   vox-radio script --in work/articles.json --out work/script.json
   vox-radio script --out work/script.json --step write
   vox-radio script --in work/articles.json --out work/script.json --profile sample-profiles/tech_profile.yaml`,
@@ -85,11 +85,11 @@ Example:
 		},
 	}
 
-	cmd.Flags().StringVar(&in, "in", "", "input articles.json path (required for full pipeline or summarize step)")
-	cmd.Flags().StringVar(&out, "out", "", "output script.json path (required)")
-	cmd.Flags().StringVar(&step, "step", "", "run a single step: summarize|write|direct")
+	cmd.Flags().StringVar(&in, "in", "", "articles.json の入力パス（フルパイプラインまたは summarize ステップで必須）")
+	cmd.Flags().StringVar(&out, "out", "", "script.json の出力先パス（必須）")
+	cmd.Flags().StringVar(&step, "step", "", "単一ステップを実行する: summarize|write|direct")
 	registerProfileFlag(cmd, &profilePath)
-	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "directory containing prompt templates")
+	cmd.Flags().StringVar(&promptsDir, "prompts", "prompts", "プロンプトテンプレートを含むディレクトリ")
 	_ = cmd.MarkFlagRequired("out")
 
 	return cmd

--- a/internal/cli/synth.go
+++ b/internal/cli/synth.go
@@ -18,15 +18,15 @@ func newSynthCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "synth",
-		Short: "Synthesize voice clips from a script",
-		Long: `Read script.json and call VOICEVOX to synthesize each line into WAV clips.
-The output directory will contain per-line WAV files and a clips.json manifest.
+		Short: "台本から音声クリップを合成する",
+		Long: `script.json を読み込み、VOICEVOX を呼び出して各台詞を WAV クリップに合成します。
+出力ディレクトリには台詞ごとの WAV ファイルと clips.json マニフェストが格納されます。
 
-vox-radio.yaml is automatically loaded from the current directory.
-The voicevox.url field specifies the VOICEVOX engine URL (default: http://localhost:50021).
-Speaker IDs are resolved from the characters catalog in vox-radio.yaml.
+vox-radio.yaml はカレントディレクトリから自動読み込みされます。
+voicevox.url フィールドで VOICEVOX エンジンの URL を指定します（デフォルト: http://localhost:50021）。
+話者 ID は vox-radio.yaml のキャラクターカタログから解決されます。
 
-Example:
+例:
   vox-radio synth --in work/script.json --out-dir work/clips`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := config.LoadConfig("vox-radio.yaml")
@@ -59,8 +59,8 @@ Example:
 		},
 	}
 
-	cmd.Flags().StringVar(&in, "in", "", "input script.json path (required)")
-	cmd.Flags().StringVar(&outDir, "out-dir", "", "output directory for WAV clips (required)")
+	cmd.Flags().StringVar(&in, "in", "", "script.json の入力パス（必須）")
+	cmd.Flags().StringVar(&outDir, "out-dir", "", "WAV クリップの出力ディレクトリ（必須）")
 	_ = cmd.MarkFlagRequired("in")
 	_ = cmd.MarkFlagRequired("out-dir")
 

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -14,7 +14,7 @@ import (
 // to profilePath. Used by every command that loads a profile (assemble is the
 // exception: its --profile is optional because assets can be skipped).
 func registerProfileFlag(cmd *cobra.Command, profilePath *string) {
-	cmd.Flags().StringVar(profilePath, "profile", "", "profile YAML file path (required)")
+	cmd.Flags().StringVar(profilePath, "profile", "", "プロファイル YAML ファイルのパス（必須）")
 	_ = cmd.MarkFlagRequired("profile")
 }
 


### PR DESCRIPTION
## Summary

- `internal/cli/**` の全コマンド（root / init / collect / script / synth / assemble / manifest / run）の `Short` / `Long` 説明文を英語から日本語に翻訳
- 全フラグの usage 文言（`--in` / `--out` / `--out-dir` / `--profile` / `--prompts` / `--clips` / `--audio` / `--articles` / `--script` / `--step` など）を日本語化
- フラグの必須・任意表記を `（必須）` / `（任意）` に統一
- `make docs` を実行して `docs/cli/` を再生成し、コミットに含める

## 完了条件の確認

- [x] `vox-radio --help` および各 `vox-radio <command> --help` の説明文・フラグ usage が日本語で表示される
- [x] `docs/cli/` が日本語で再生成され、コミットに含まれている
- [x] `make test` / `make lint` / `make build` が通る

Closes #82

---
🤖 Generated with [Claude Code](https://claude.ai/code)