### PR TITLE
feat: LLM リクエストの最小インターバル設定を追加してレート制限への到達を防ぐ

### DIFF
--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -82,11 +82,12 @@ LLM が生成した要約をマニフェストに追加します。
 
 				apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
 				llmClient := llm.NewClient(llm.Config{
-					BaseURL:     cfg.LLM.BaseURL,
-					APIKey:      apiKey,
-					Model:       cfg.LLM.Model,
-					Temperature: cfg.LLM.Temperature,
-					MaxRetries:  cfg.LLM.MaxRetries,
+					BaseURL:              cfg.LLM.BaseURL,
+					APIKey:               apiKey,
+					Model:                cfg.LLM.Model,
+					Temperature:          cfg.LLM.Temperature,
+					MaxRetries:           cfg.LLM.MaxRetries,
+					MinRequestIntervalMS: cfg.LLM.EffectiveMinRequestIntervalMS(),
 				})
 
 				s := programsummary.NewLLMProgramSummarizer(llmClient, string(summaryPromptData), stepTemp(cfg.LLM, "summary"))

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -10,7 +10,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/manifest"
 	"github.com/canpok1/vox-radio/internal/model"
-	"github.com/canpok1/vox-radio/internal/script/llm"
 	programsummary "github.com/canpok1/vox-radio/internal/script/summary"
 	"github.com/spf13/cobra"
 )
@@ -80,15 +79,7 @@ LLM が生成した要約をマニフェストに追加します。
 					return fmt.Errorf("read summary.md: %w", err)
 				}
 
-				apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
-				llmClient := llm.NewClient(llm.Config{
-					BaseURL:              cfg.LLM.BaseURL,
-					APIKey:               apiKey,
-					Model:                cfg.LLM.Model,
-					Temperature:          cfg.LLM.Temperature,
-					MaxRetries:           cfg.LLM.MaxRetries,
-					MinRequestIntervalMS: cfg.LLM.EffectiveMinRequestIntervalMS(),
-				})
+				llmClient := newLLMClient(cfg)
 
 				s := programsummary.NewLLMProgramSummarizer(llmClient, string(summaryPromptData), stepTemp(cfg.LLM, "summary"))
 				programSummary, err = s.Summarize(context.Background(), scr)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -51,11 +51,12 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 
 			apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
 			llmClient := llm.NewClient(llm.Config{
-				BaseURL:     cfg.LLM.BaseURL,
-				APIKey:      apiKey,
-				Model:       cfg.LLM.Model,
-				Temperature: cfg.LLM.Temperature,
-				MaxRetries:  cfg.LLM.MaxRetries,
+				BaseURL:              cfg.LLM.BaseURL,
+				APIKey:               apiKey,
+				Model:                cfg.LLM.Model,
+				Temperature:          cfg.LLM.Temperature,
+				MaxRetries:           cfg.LLM.MaxRetries,
+				MinRequestIntervalMS: cfg.LLM.EffectiveMinRequestIntervalMS(),
 			})
 
 			prompts, err := loadPrompts(promptsDir)

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/canpok1/vox-radio/internal/assemble"
 	"github.com/canpok1/vox-radio/internal/collect"
@@ -11,7 +10,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/pipeline"
 	"github.com/canpok1/vox-radio/internal/script"
 	"github.com/canpok1/vox-radio/internal/script/direct"
-	"github.com/canpok1/vox-radio/internal/script/llm"
 	"github.com/canpok1/vox-radio/internal/script/summarize"
 	programsummary "github.com/canpok1/vox-radio/internal/script/summary"
 	"github.com/canpok1/vox-radio/internal/script/write"
@@ -49,15 +47,7 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 				return err
 			}
 
-			apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
-			llmClient := llm.NewClient(llm.Config{
-				BaseURL:              cfg.LLM.BaseURL,
-				APIKey:               apiKey,
-				Model:                cfg.LLM.Model,
-				Temperature:          cfg.LLM.Temperature,
-				MaxRetries:           cfg.LLM.MaxRetries,
-				MinRequestIntervalMS: cfg.LLM.EffectiveMinRequestIntervalMS(),
-			})
+			llmClient := newLLMClient(cfg)
 
 			prompts, err := loadPrompts(promptsDir)
 			if err != nil {

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -56,15 +56,7 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 				return err
 			}
 
-			apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
-			llmClient := llm.NewClient(llm.Config{
-				BaseURL:              cfg.LLM.BaseURL,
-				APIKey:               apiKey,
-				Model:                cfg.LLM.Model,
-				Temperature:          cfg.LLM.Temperature,
-				MaxRetries:           cfg.LLM.MaxRetries,
-				MinRequestIntervalMS: cfg.LLM.EffectiveMinRequestIntervalMS(),
-			})
+			llmClient := newLLMClient(cfg)
 
 			prompts, err := loadPrompts(promptsDir)
 			if err != nil {

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -58,11 +58,12 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 
 			apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
 			llmClient := llm.NewClient(llm.Config{
-				BaseURL:     cfg.LLM.BaseURL,
-				APIKey:      apiKey,
-				Model:       cfg.LLM.Model,
-				Temperature: cfg.LLM.Temperature,
-				MaxRetries:  cfg.LLM.MaxRetries,
+				BaseURL:              cfg.LLM.BaseURL,
+				APIKey:               apiKey,
+				Model:                cfg.LLM.Model,
+				Temperature:          cfg.LLM.Temperature,
+				MaxRetries:           cfg.LLM.MaxRetries,
+				MinRequestIntervalMS: cfg.LLM.EffectiveMinRequestIntervalMS(),
 			})
 
 			prompts, err := loadPrompts(promptsDir)

--- a/internal/cli/templates/vox-radio.yaml
+++ b/internal/cli/templates/vox-radio.yaml
@@ -13,6 +13,8 @@ llm:
   temperature: 0.7
   # APIリトライ回数
   max_retries: 3
+  # LLM リクエストの最小インターバル（ミリ秒）。省略時は 4500ms（≈13.3 RPM）が適用される。0 を明示するとスロットリング無効。
+  min_request_interval_ms: 4500
   # ステップごとの温度設定（省略時は上記 temperature を使用）
   steps:
     summarize: { temperature: 0.2 }

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/logging"
+	"github.com/canpok1/vox-radio/internal/script/llm"
 	"github.com/spf13/cobra"
 )
 
@@ -45,6 +46,18 @@ func setupLogger(commandName string, logDir string) (*slog.Logger, *os.File, err
 		logDir = "logs"
 	}
 	return logging.NewSetup(time.Now(), commandName, logDir)
+}
+
+func newLLMClient(cfg *config.Config) llm.Client {
+	apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
+	return llm.NewClient(llm.Config{
+		BaseURL:              cfg.LLM.BaseURL,
+		APIKey:               apiKey,
+		Model:                cfg.LLM.Model,
+		Temperature:          cfg.LLM.Temperature,
+		MaxRetries:           cfg.LLM.MaxRetries,
+		MinRequestIntervalMS: cfg.LLM.EffectiveMinRequestIntervalMS(),
+	})
 }
 
 func loadConfigAndProfile(profilePath string) (*config.Config, *config.Profile, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,10 @@ import (
 // used to convert target_duration_sec to a target character count.
 const CharsPerSec = 7
 
+// DefaultMinRequestIntervalMS is the default minimum interval (ms) between LLM API requests.
+// Based on gemini-3.1-flash-lite free tier (15 RPM) with ~10% safety margin: 60000/15 * 1.1 ≈ 4500.
+const DefaultMinRequestIntervalMS = 4500
+
 // DurationSecToTargetChars converts a duration in seconds to an approximate target character count.
 func DurationSecToTargetChars(sec int) int {
 	return sec * CharsPerSec
@@ -56,12 +60,22 @@ type LLMStepConfig struct {
 }
 
 type LLMConfig struct {
-	BaseURL     string                   `yaml:"base_url"`
-	APIKeyEnv   string                   `yaml:"api_key_env"`
-	Model       string                   `yaml:"model"`
-	Temperature float64                  `yaml:"temperature"`
-	MaxRetries  int                      `yaml:"max_retries"`
-	Steps       map[string]LLMStepConfig `yaml:"steps"`
+	BaseURL              string                   `yaml:"base_url"`
+	APIKeyEnv            string                   `yaml:"api_key_env"`
+	Model                string                   `yaml:"model"`
+	Temperature          float64                  `yaml:"temperature"`
+	MaxRetries           int                      `yaml:"max_retries"`
+	MinRequestIntervalMS *int                     `yaml:"min_request_interval_ms,omitempty"`
+	Steps                map[string]LLMStepConfig `yaml:"steps"`
+}
+
+// EffectiveMinRequestIntervalMS returns the resolved minimum request interval in milliseconds.
+// Nil (unspecified in YAML) returns DefaultMinRequestIntervalMS; explicit 0 disables throttling.
+func (c LLMConfig) EffectiveMinRequestIntervalMS() int {
+	if c.MinRequestIntervalMS == nil {
+		return DefaultMinRequestIntervalMS
+	}
+	return *c.MinRequestIntervalMS
 }
 
 // ProgramConfig holds program-wide settings for content generation.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -243,6 +243,45 @@ func TestLoadConfig_ValidationError_DefaultStyleNotInStyles(t *testing.T) {
 	}
 }
 
+func TestLLMConfig_EffectiveMinRequestIntervalMS_Unspecified(t *testing.T) {
+	c := config.LLMConfig{}
+	got := c.EffectiveMinRequestIntervalMS()
+	if got != config.DefaultMinRequestIntervalMS {
+		t.Errorf("got %d, want DefaultMinRequestIntervalMS=%d", got, config.DefaultMinRequestIntervalMS)
+	}
+}
+
+func TestLLMConfig_EffectiveMinRequestIntervalMS_Zero(t *testing.T) {
+	v := 0
+	c := config.LLMConfig{MinRequestIntervalMS: &v}
+	got := c.EffectiveMinRequestIntervalMS()
+	if got != 0 {
+		t.Errorf("got %d, want 0 (throttling disabled)", got)
+	}
+}
+
+func TestLLMConfig_EffectiveMinRequestIntervalMS_Custom(t *testing.T) {
+	v := 1000
+	c := config.LLMConfig{MinRequestIntervalMS: &v}
+	got := c.EffectiveMinRequestIntervalMS()
+	if got != 1000 {
+		t.Errorf("got %d, want 1000", got)
+	}
+}
+
+func TestLoadConfig_LLM_MinRequestIntervalMS(t *testing.T) {
+	cfg, err := config.LoadConfig("testdata/config_with_interval.yaml")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.LLM.MinRequestIntervalMS == nil {
+		t.Fatal("LLM.MinRequestIntervalMS should be non-nil when specified in YAML")
+	}
+	if *cfg.LLM.MinRequestIntervalMS != 2000 {
+		t.Errorf("LLM.MinRequestIntervalMS: got %d, want 2000", *cfg.LLM.MinRequestIntervalMS)
+	}
+}
+
 func TestValidateProfileCast_Valid(t *testing.T) {
 	p := &config.Profile{
 		Corners: []config.CornerConfig{

--- a/internal/config/testdata/config_with_interval.yaml
+++ b/internal/config/testdata/config_with_interval.yaml
@@ -1,0 +1,27 @@
+llm:
+  base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+  api_key_env: GEMINI_API_KEY
+  model: gemini-3.1-flash-lite
+  temperature: 0.7
+  max_retries: 3
+  min_request_interval_ms: 2000
+  steps:
+    summarize: { temperature: 0.2 }
+    plan:      { temperature: 0.4 }
+    write:     { temperature: 0.8 }
+    direct:    { temperature: 0.2 }
+
+voicevox:
+  url: http://localhost:50021
+
+characters:
+  zundamon:
+    name: ずんだもん
+    pronoun: ボク
+    speech_suffix: ["〜のだ", "〜なのだ"]
+    personality: ["元気", "明るい", "素直", "前向き"]
+    default_style: ノーマル
+    styles:
+      ノーマル: 3
+      あまあま: 1
+      なみだめ: 76

--- a/internal/script/llm/client.go
+++ b/internal/script/llm/client.go
@@ -132,12 +132,10 @@ func (c *openAIClient) throttle(ctx context.Context) error {
 	c.mu.Lock()
 	now := time.Now()
 	next := c.lastRequestTime.Add(interval)
-	if next.After(now) {
-		c.lastRequestTime = next
-	} else {
-		c.lastRequestTime = now
+	if next.Before(now) {
 		next = now
 	}
+	c.lastRequestTime = next
 	c.mu.Unlock()
 
 	waitDur := time.Until(next)

--- a/internal/script/llm/client.go
+++ b/internal/script/llm/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/xeipuuv/gojsonschema"
@@ -20,17 +21,20 @@ const (
 
 // Config holds the settings for the OpenAI-compatible LLM client.
 type Config struct {
-	BaseURL     string
-	APIKey      string
-	Model       string
-	MaxRetries  int
-	Temperature float64
+	BaseURL              string
+	APIKey               string
+	Model                string
+	MaxRetries           int
+	Temperature          float64
+	MinRequestIntervalMS int
 }
 
 type openAIClient struct {
-	cfg      Config
-	hc       *http.Client
-	endpoint string
+	cfg             Config
+	hc              *http.Client
+	endpoint        string
+	mu              sync.Mutex
+	lastRequestTime time.Time
 }
 
 // NewClient creates a new OpenAI-compatible LLM client.
@@ -116,7 +120,43 @@ func (c *openAIClient) Complete(ctx context.Context, req CompletionRequest) (jso
 	return nil, fmt.Errorf("validation failed after %d retries", c.cfg.MaxRetries)
 }
 
+// throttle ensures the minimum interval between requests is respected.
+// It reserves a time slot under the mutex and waits outside of it,
+// respecting context cancellation.
+func (c *openAIClient) throttle(ctx context.Context) error {
+	if c.cfg.MinRequestIntervalMS <= 0 {
+		return nil
+	}
+	interval := time.Duration(c.cfg.MinRequestIntervalMS) * time.Millisecond
+
+	c.mu.Lock()
+	now := time.Now()
+	next := c.lastRequestTime.Add(interval)
+	if next.After(now) {
+		c.lastRequestTime = next
+	} else {
+		c.lastRequestTime = now
+		next = now
+	}
+	c.mu.Unlock()
+
+	waitDur := time.Until(next)
+	if waitDur <= 0 {
+		return nil
+	}
+	select {
+	case <-time.After(waitDur):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 func (c *openAIClient) callAPI(ctx context.Context, req CompletionRequest, msgs []Message) (json.RawMessage, error) {
+	if err := c.throttle(ctx); err != nil {
+		return nil, err
+	}
+
 	model := req.Model
 	if model == "" {
 		model = c.cfg.Model

--- a/internal/script/llm/client_test.go
+++ b/internal/script/llm/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
@@ -247,6 +248,78 @@ func TestComplete_ExhaustsRetries(t *testing.T) {
 	}
 	if int(callCount.Load()) != maxRetries+1 {
 		t.Errorf("expected %d API calls, got %d", maxRetries+1, callCount.Load())
+	}
+}
+
+func TestComplete_ThrottlesRequests(t *testing.T) {
+	var receivedAt []time.Time
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAt = append(receivedAt, time.Now())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeAPIResponse(t, `{"value":"hello"}`))
+	}))
+	defer ts.Close()
+
+	const intervalMS = 50
+	c := llm.NewClient(llm.Config{
+		BaseURL:              ts.URL,
+		APIKey:               "test-key",
+		Model:                "test-model",
+		MinRequestIntervalMS: intervalMS,
+	})
+
+	req := llm.CompletionRequest{
+		Messages: []llm.Message{{Role: "user", Content: "hello"}},
+	}
+
+	_, err := c.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	_, err = c.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+
+	if len(receivedAt) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(receivedAt))
+	}
+	gap := receivedAt[1].Sub(receivedAt[0])
+	minGap := time.Duration(intervalMS) * time.Millisecond
+	if gap < minGap {
+		t.Errorf("requests too close: gap=%v, want >= %v", gap, minGap)
+	}
+}
+
+func TestComplete_ThrottleContextCancellation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeAPIResponse(t, `{"value":"hello"}`))
+	}))
+	defer ts.Close()
+
+	const intervalMS = 10000 // 10 seconds
+	c := llm.NewClient(llm.Config{
+		BaseURL:              ts.URL,
+		APIKey:               "test-key",
+		Model:                "test-model",
+		MinRequestIntervalMS: intervalMS,
+	})
+
+	req := llm.CompletionRequest{
+		Messages: []llm.Message{{Role: "user", Content: "hello"}},
+	}
+
+	if _, err := c.Complete(context.Background(), req); err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := c.Complete(ctx, req)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
 	}
 }
 

--- a/vox-radio.yaml
+++ b/vox-radio.yaml
@@ -4,6 +4,7 @@ llm:
   model: gemini-3.1-flash-lite
   temperature: 0.7
   max_retries: 3
+  min_request_interval_ms: 4500
   steps:
     summarize: { temperature: 0.2 }
     plan:      { temperature: 0.4 }


### PR DESCRIPTION
## Summary

- `vox-radio.yaml` に `llm.min_request_interval_ms`（ミリ秒単位の整数）設定を追加
- `LLMConfig` に `MinRequestIntervalMS *int` フィールドを追加（nil=未指定→デフォルト 4500ms、0 明示→スロットリング無効）
- `DefaultMinRequestIntervalMS = 4500` 定数を定義（gemini-3.1-flash-lite 無料枠 15 RPM に約 10% マージン）
- `openAIClient` に `throttle()` メソッドを実装し、`callAPI()` 送信直前でリクエスト間隔を制御
- `sync.Mutex` で `lastRequestTime` を保護（将来の並行呼び出しに備えた防御的実装）
- run/manifest/script コマンドの `llm.Config` 生成を `newLLMClient` ヘルパーに集約

## Test plan

- [x] `TestLLMConfig_EffectiveMinRequestIntervalMS_Unspecified` — nil → DefaultMinRequestIntervalMS
- [x] `TestLLMConfig_EffectiveMinRequestIntervalMS_Zero` — 0 明示 → スロットリング無効
- [x] `TestLLMConfig_EffectiveMinRequestIntervalMS_Custom` — 任意値 → そのまま返す
- [x] `TestLoadConfig_LLM_MinRequestIntervalMS` — YAML パースで min_request_interval_ms が読み込まれる
- [x] `TestComplete_ThrottlesRequests` — 50ms インターバル設定時、連続2リクエストの間隔が ≥ 50ms
- [x] `TestComplete_ThrottleContextCancellation` — 待機中にコンテキストキャンセルするとエラーを返す

Closes #91

---
🤖 Generated with [Claude Code](https://claude.ai/code)