### PR TITLE
fix: assemble BGM音量ポンピングを解消（speech先正規化 + 最終段alimiter化）

### DIFF
--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -10,11 +10,11 @@ import (
 )
 
 // speechNormFilter normalizes speech to EBU R128 before BGM mixing.
-// The TP ceiling (-1.5 dB) must match outputLimiterTP so the two stages are calibrated together.
+// The TP ceiling (-1.5 dB) must match outputLimiterLimit so the two stages are calibrated together.
 const (
 	speechNormFilter = "loudnorm=I=-16:TP=-1.5:LRA=11"
-	// outputLimiterTP is the linear equivalent of the TP ceiling used in speechNormFilter (10^(-1.5/20) ≈ 0.841).
-	outputLimiterTP = 0.841
+	// outputLimiterLimit is the linear equivalent of the TP ceiling used in speechNormFilter (10^(-1.5/20) ≈ 0.841).
+	outputLimiterLimit = 0.841
 )
 
 // BuildContext holds all data needed to build the ffmpeg command.
@@ -173,7 +173,7 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 
 	// Peak limiter: prevents clipping after BGM mix without dynamic re-normalization.
 	// level=0 disables auto gain equalization.
-	b.addFilter(fmt.Sprintf("%salimiter=limit=%.3f:level=0[out]", currentLabel, outputLimiterTP))
+	b.addFilter(fmt.Sprintf("%salimiter=limit=%.3f:level=0[out]", currentLabel, outputLimiterLimit))
 
 	return &FFmpegArgs{
 		Inputs:        b.inputs,

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -9,6 +9,14 @@ import (
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
+// speechNormFilter normalizes speech to EBU R128 before BGM mixing.
+// The TP ceiling (-1.5 dB) must match outputLimiterTP so the two stages are calibrated together.
+const (
+	speechNormFilter = "loudnorm=I=-16:TP=-1.5:LRA=11"
+	// outputLimiterTP is the linear equivalent of the TP ceiling used in speechNormFilter (10^(-1.5/20) ≈ 0.841).
+	outputLimiterTP = 0.841
+)
+
 // BuildContext holds all data needed to build the ffmpeg command.
 type BuildContext struct {
 	Script   model.Script
@@ -70,7 +78,7 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 
 	// Normalize speech before any mixing.
 	// This keeps BGM/SE/jingle levels independent of speech amplitude across episodes.
-	b.addFilter(fmt.Sprintf("%sloudnorm=I=-16:TP=-1.5:LRA=11[speech_norm]", speechLabel))
+	b.addFilter(fmt.Sprintf("%s%s[speech_norm]", speechLabel, speechNormFilter))
 	currentLabel := "[speech_norm]"
 
 	// If BGM is configured, split normalized speech so it can be used as sidechain.
@@ -164,8 +172,8 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 	}
 
 	// Peak limiter: prevents clipping after BGM mix without dynamic re-normalization.
-	// limit=0.841 ≈ -1.5 dB TP; level=0 disables auto gain equalization.
-	b.addFilter(fmt.Sprintf("%salimiter=limit=0.841:level=0[out]", currentLabel))
+	// level=0 disables auto gain equalization.
+	b.addFilter(fmt.Sprintf("%salimiter=limit=%.3f:level=0[out]", currentLabel, outputLimiterTP))
 
 	return &FFmpegArgs{
 		Inputs:        b.inputs,

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -68,12 +68,16 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 	// Build speech track (concat with silence between clips)
 	speechLabel := buildSpeechConcat(b, bctx.Clips.Clips, clipInputIdx, bctx.PauseSec)
 
-	// If BGM is configured, split speech so it can be used as sidechain
-	hasBGM := len(bctx.Assets.BGM) > 0
-	currentLabel := speechLabel
+	// Normalize speech before any mixing.
+	// This keeps BGM/SE/jingle levels independent of speech amplitude across episodes.
+	b.addFilter(fmt.Sprintf("%sloudnorm=I=-16:TP=-1.5:LRA=11[speech_norm]", speechLabel))
+	currentLabel := "[speech_norm]"
 
+	// If BGM is configured, split normalized speech so it can be used as sidechain.
+	// Using normalized speech as sidechain prevents per-episode variation in ducking depth.
+	hasBGM := len(bctx.Assets.BGM) > 0
 	if hasBGM {
-		b.addFilter(fmt.Sprintf("%sasplit=2[speech_mix][speech_duck]", speechLabel))
+		b.addFilter(fmt.Sprintf("%sasplit=2[speech_mix][speech_duck]", currentLabel))
 		currentLabel = "[speech_mix]"
 	}
 
@@ -159,8 +163,9 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 		currentLabel = "[after_bgm]"
 	}
 
-	// Loudnorm (EBU R128)
-	b.addFilter(fmt.Sprintf("%sloudnorm=I=-16:TP=-1.5:LRA=11[out]", currentLabel))
+	// Peak limiter: prevents clipping after BGM mix without dynamic re-normalization.
+	// limit=0.841 ≈ -1.5 dB TP; level=0 disables auto gain equalization.
+	b.addFilter(fmt.Sprintf("%salimiter=limit=0.841:level=0[out]", currentLabel))
 
 	return &FFmpegArgs{
 		Inputs:        b.inputs,

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -438,11 +438,14 @@ func TestBuildFFmpegArgs_LoudnormBeforeBGMMix(t *testing.T) {
 	loudnormIdx := -1
 	bgmFilterIdx := -1
 	for i, f := range filters {
-		if strings.Contains(f, "loudnorm") && loudnormIdx == -1 {
+		if loudnormIdx == -1 && strings.Contains(f, "loudnorm") {
 			loudnormIdx = i
 		}
-		if (strings.Contains(f, "aloop") || strings.Contains(f, "sidechaincompress")) && bgmFilterIdx == -1 {
+		if bgmFilterIdx == -1 && (strings.Contains(f, "aloop") || strings.Contains(f, "sidechaincompress")) {
 			bgmFilterIdx = i
+		}
+		if loudnormIdx != -1 && bgmFilterIdx != -1 {
+			break
 		}
 	}
 	if loudnormIdx == -1 {
@@ -461,7 +464,6 @@ func TestBuildFFmpegArgs_LoudnormBeforeBGMMix(t *testing.T) {
 // alimiter (peak protection), not a dynamic loudnorm that would cause BGM pumping.
 func TestBuildFFmpegArgs_FinalOutputIsAlimiter(t *testing.T) {
 	for _, name := range []string{"no BGM", "with BGM"} {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			assets := config.AssetsConfig{}
 			if name == "with BGM" {

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -404,3 +404,106 @@ func TestComputeSEEvents_NoSE(t *testing.T) {
 		t.Errorf("expected 0 SE events, got %d", len(events))
 	}
 }
+
+// TestBuildFFmpegArgs_LoudnormBeforeBGMMix verifies that loudnorm is applied to speech
+// BEFORE BGM mixing, so BGM levels are unaffected by speech-driven AGC.
+func TestBuildFFmpegArgs_LoudnormBeforeBGMMix(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			BGM: map[string]config.BGMEntry{
+				"main": {File: "/assets/bgm.mp3", Volume: 0.3, DuckRatio: 4.0, Loop: true},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	filters := strings.Split(args.FilterComplex, ";")
+	loudnormIdx := -1
+	bgmFilterIdx := -1
+	for i, f := range filters {
+		if strings.Contains(f, "loudnorm") && loudnormIdx == -1 {
+			loudnormIdx = i
+		}
+		if (strings.Contains(f, "aloop") || strings.Contains(f, "sidechaincompress")) && bgmFilterIdx == -1 {
+			bgmFilterIdx = i
+		}
+	}
+	if loudnormIdx == -1 {
+		t.Fatal("loudnorm not found in filter_complex")
+	}
+	if bgmFilterIdx == -1 {
+		t.Fatal("BGM filter (aloop or sidechaincompress) not found in filter_complex")
+	}
+	if loudnormIdx >= bgmFilterIdx {
+		t.Errorf("loudnorm (filter index %d) must appear before BGM mix filter (index %d); filter_complex:\n%s",
+			loudnormIdx, bgmFilterIdx, args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_FinalOutputIsAlimiter verifies that the final [out] stage uses
+// alimiter (peak protection), not a dynamic loudnorm that would cause BGM pumping.
+func TestBuildFFmpegArgs_FinalOutputIsAlimiter(t *testing.T) {
+	for _, name := range []string{"no BGM", "with BGM"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			assets := config.AssetsConfig{}
+			if name == "with BGM" {
+				assets.BGM = map[string]config.BGMEntry{
+					"main": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true},
+				}
+			}
+			ctx := BuildContext{
+				Script: model.Script{
+					Segments: []model.ScriptSegment{
+						{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+					},
+				},
+				Clips: model.ClipsMeta{
+					Clips: []model.ClipMeta{
+						{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+					},
+				},
+				ClipsDir: "/clips",
+				Assets:   assets,
+				PauseSec: 0.5,
+				OutPath:  "/out.mp3",
+			}
+
+			args, err := BuildFFmpegArgs(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			filters := strings.Split(args.FilterComplex, ";")
+			for _, f := range filters {
+				if strings.Contains(f, "[out]") {
+					if strings.Contains(f, "loudnorm") {
+						t.Errorf("final [out] must not use loudnorm (causes BGM pumping): %s", f)
+					}
+					if !strings.Contains(f, "alimiter") {
+						t.Errorf("final [out] must use alimiter for peak protection: %s", f)
+					}
+					return
+				}
+			}
+			t.Error("[out] label not found in filter_complex")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/assemble/filter.go` の `BuildFFmpegArgs` で、最終段の dynamic loudnorm（BGMミックス後に適用）を廃止し、**speech 先正規化 + 最終 alimiter** の構成に変更した

### 変更前の問題

| 症状 | 原因 |
|---|---|
| 同一ファイル内でBGMが約5.6 dB揺れる（ポンピング） | BGMミックス後に loudnorm の AGC がセリフに反応 |
| エピソード間でBGM絶対レベルが約5.8 dBブレる | セリフ振幅によって最終loudnormのゲインが変化 |
| 回・話者ごとにダッキング深さが変わる | sidechain が正規化前の生TTS |

### フィルタグラフの変更

**Before:**
```
speech連結 → asplit → SE/OP/ED amix → BGM amix → loudnorm[out]
```

**After:**
```
speech連結 → loudnorm[speech_norm] → asplit → SE/OP/ED amix → BGM amix → alimiter[out]
```

- `speechNormFilter` / `outputLimiterLimit` 定数を抽出し、TP上限値（-1.5 dB ↔ 0.841 linear）の結合を明示化

### テスト追加

- `TestBuildFFmpegArgs_LoudnormBeforeBGMMix`: loudnorm が BGMフィルターより前段に来ることを検証
- `TestBuildFFmpegArgs_FinalOutputIsAlimiter`: 最終 `[out]` が alimiter であることを検証（BGM有無の両ケース）

Closes #93

---
🤖 Generated with [Claude Code](https://claude.ai/code)