### PR TITLE
feat: run の中間ファイル名に生成順の連番プレフィックスを付与する

### DIFF
--- a/docs/adr/0004-file-based-intermediate-artifacts.md
+++ b/docs/adr/0004-file-based-intermediate-artifacts.md
@@ -13,7 +13,7 @@
 
 - 個別サブコマンドは**入出力パスを明示指定**する（`--in`/`--out`、synth は `--out-dir`、assemble は `--clips` 等）。
 - 指定ディレクトリが存在しなければ**自動生成**する。
-- 一括 `run` は**出力ディレクトリのみ指定**（`--out-dir`、既定 `output/`）。**最終成果物 `episode.mp3` は直下**、**中間生成物は `<out-dir>/intermediate/` 配下**にまとめ、ファイル名は正準固定（articles.json / summaries.json / rundown.json / lines.json / script.json, clips/clip_NNN.wav）。
+- 一括 `run` は**出力ディレクトリのみ指定**（`--out-dir`、既定 `output/`）。**最終成果物 `episode.mp3` は直下**、**中間生成物は `<out-dir>/intermediate/` 配下**にまとめ、ファイル名は生成順の連番プレフィックス付きで正準固定（01_articles.json / 02_summaries.json / 03_lines.json / 04_script.json / 05_clips/clip_NNN.wav）。
 - **日付固定ディレクトリは作らない**（複数回実行に対応。ディレクトリ名は呼び出し側が決める）。掃除はディレクトリ単位で `rm -rf`。
 
 Podcast の guid/pubDate（`episode-<date>`）は publish 側で日付指定（既定=実行日）から決め、作業ディレクトリ構成からは独立させる。

--- a/docs/cli/vox-radio_manifest.md
+++ b/docs/cli/vox-radio_manifest.md
@@ -15,8 +15,8 @@ LLM が生成した要約をマニフェストに追加します。
 
 例:
   vox-radio manifest --profile sample-profiles/tech_profile.yaml --audio output/episode.mp3 --out output/manifest.json
-  vox-radio manifest --profile sample-profiles/tech_profile.yaml --articles output/intermediate/articles.json --audio output/episode.mp3 --out output/manifest.json
-  vox-radio manifest --profile sample-profiles/tech_profile.yaml --script output/intermediate/script.json --audio output/episode.mp3 --out output/manifest.json
+  vox-radio manifest --profile sample-profiles/tech_profile.yaml --articles output/intermediate/01_articles.json --audio output/episode.mp3 --out output/manifest.json
+  vox-radio manifest --profile sample-profiles/tech_profile.yaml --script output/intermediate/04_script.json --audio output/episode.mp3 --out output/manifest.json
 
 ```
 vox-radio manifest [flags]

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -36,8 +36,8 @@ LLM が生成した要約をマニフェストに追加します。
 
 例:
   vox-radio manifest --profile sample-profiles/tech_profile.yaml --audio output/episode.mp3 --out output/manifest.json
-  vox-radio manifest --profile sample-profiles/tech_profile.yaml --articles output/intermediate/articles.json --audio output/episode.mp3 --out output/manifest.json
-  vox-radio manifest --profile sample-profiles/tech_profile.yaml --script output/intermediate/script.json --audio output/episode.mp3 --out output/manifest.json`,
+  vox-radio manifest --profile sample-profiles/tech_profile.yaml --articles output/intermediate/01_articles.json --audio output/episode.mp3 --out output/manifest.json
+  vox-radio manifest --profile sample-profiles/tech_profile.yaml --script output/intermediate/04_script.json --audio output/episode.mp3 --out output/manifest.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger, logFile, err := setupLogger("manifest", "")
 			if err != nil {

--- a/internal/fileio/paths.go
+++ b/internal/fileio/paths.go
@@ -8,16 +8,16 @@ import (
 )
 
 const (
-	FileArticles  = "articles.json"
-	FileSummaries = "summaries.json"
+	FileArticles  = "01_articles.json"
+	FileSummaries = "02_summaries.json"
 	FileRundown   = "rundown.json"
-	FileLines     = "lines.json"
-	FileScript    = "script.json"
+	FileLines     = "03_lines.json"
+	FileScript    = "04_script.json"
 	FileEpisode   = "episode.mp3"
 	FileManifest  = "manifest.json"
 
 	DirIntermediate = "intermediate"
-	DirClips        = "clips"
+	DirClips        = "05_clips"
 )
 
 func ClipFileName(n int) string {

--- a/internal/fileio/paths_test.go
+++ b/internal/fileio/paths_test.go
@@ -34,12 +34,12 @@ func TestPaths(t *testing.T) {
 		want string
 	}{
 		{"IntermediateDir", fileio.IntermediateDir(outDir), filepath.Join(outDir, "intermediate")},
-		{"ClipsDir", fileio.ClipsDir(outDir), filepath.Join(outDir, "intermediate", "clips")},
-		{"ArticlesPath", fileio.ArticlesPath(outDir), filepath.Join(outDir, "intermediate", "articles.json")},
-		{"SummariesPath", fileio.SummariesPath(outDir), filepath.Join(outDir, "intermediate", "summaries.json")},
+		{"ClipsDir", fileio.ClipsDir(outDir), filepath.Join(outDir, "intermediate", "05_clips")},
+		{"ArticlesPath", fileio.ArticlesPath(outDir), filepath.Join(outDir, "intermediate", "01_articles.json")},
+		{"SummariesPath", fileio.SummariesPath(outDir), filepath.Join(outDir, "intermediate", "02_summaries.json")},
 		{"RundownPath", fileio.RundownPath(outDir), filepath.Join(outDir, "intermediate", "rundown.json")},
-		{"LinesPath", fileio.LinesPath(outDir), filepath.Join(outDir, "intermediate", "lines.json")},
-		{"ScriptPath", fileio.ScriptPath(outDir), filepath.Join(outDir, "intermediate", "script.json")},
+		{"LinesPath", fileio.LinesPath(outDir), filepath.Join(outDir, "intermediate", "03_lines.json")},
+		{"ScriptPath", fileio.ScriptPath(outDir), filepath.Join(outDir, "intermediate", "04_script.json")},
 		{"EpisodePath", fileio.EpisodePath(outDir), filepath.Join(outDir, "episode.mp3")},
 	}
 	for _, tt := range tests {

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script/direct"
 	"github.com/canpok1/vox-radio/internal/script/summarize"
@@ -98,7 +99,7 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, articles model.Articl
 	sumLogger.Info(fmt.Sprintf("完了 (%.1fs)", time.Since(sumStart).Seconds()))
 
 	allSummaries := model.Summaries{Corners: cornerSummaries}
-	if err := g.saveIntermediate("summaries.json", allSummaries); err != nil {
+	if err := g.saveIntermediate(fileio.FileSummaries, allSummaries); err != nil {
 		return model.Script{}, err
 	}
 
@@ -109,7 +110,7 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, articles model.Articl
 	}
 	cornerLines = g.regenIfNeeded(ctx, cornerLines, corners, allSummaries, chars)
 	allLines := flatten(cornerLines)
-	if err := g.saveIntermediate("lines.json", model.Lines{Lines: allLines}); err != nil {
+	if err := g.saveIntermediate(fileio.FileLines, model.Lines{Lines: allLines}); err != nil {
 		return model.Script{}, err
 	}
 

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script"
 )
@@ -311,7 +312,7 @@ func TestLLMScriptGenerator_Generate_SavesNumberedIntermediateFiles(t *testing.T
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, name := range []string{"02_summaries.json", "03_lines.json"} {
+	for _, name := range []string{fileio.FileSummaries, fileio.FileLines} {
 		path := filepath.Join(workDir, name)
 		if _, err := os.Stat(path); err != nil {
 			t.Errorf("expected intermediate file %q to exist: %v", name, err)

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -3,6 +3,8 @@ package script_test
 import (
 	"context"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -287,5 +289,32 @@ func TestLLMScriptGenerator_Generate_LogsProgress(t *testing.T) {
 	logs := buf.String()
 	if !strings.Contains(logs, "完了") {
 		t.Errorf("should log complete: %q", logs)
+	}
+}
+
+func TestLLMScriptGenerator_Generate_SavesNumberedIntermediateFiles(t *testing.T) {
+	workDir := t.TempDir()
+	articles := corneredArticles("AIコーナー",
+		model.Article{URL: "https://example.com/1", Title: "AI", Body: "本文"},
+	)
+	lines := []model.Line{{SpeakerRole: "zundamon", Text: "テスト"}}
+
+	gen := script.NewLLMScriptGenerator(
+		&mockSummarizer{},
+		&mockWriter{lines: lines},
+		&mockDirector{},
+		model.SECatalog{},
+		workDir,
+	)
+
+	if _, err := gen.Generate(context.Background(), articles, testCorners, testChars); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, name := range []string{"02_summaries.json", "03_lines.json"} {
+		path := filepath.Join(workDir, name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("expected intermediate file %q to exist: %v", name, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- `intermediate/` 配下の中間ファイル名に連番プレフィックスを付与し、辞書順 = 生成順となるよう可読性を向上させる
- `fileio/paths.go` の定数を更新（`01_articles.json` / `02_summaries.json` / `03_lines.json` / `04_script.json` / `05_clips`）
- `script/script.go` の `saveIntermediate` 呼び出しをハードコード文字列から `fileio` 定数参照に変更
- 個別サブコマンド（`--step summarize|write|direct`）のファイル名は変更なし（Issue スコープ外）
- `docs/cli/vox-radio_manifest.md` および ADR-0004 のファイル名記述を更新

## Changes

| 変更前 | 変更後 |
|---|---|
| `articles.json` | `01_articles.json` |
| `summaries.json` | `02_summaries.json` |
| `lines.json` | `03_lines.json` |
| `script.json` | `04_script.json` |
| `clips/` | `05_clips/` |

Closes #90

---
🤖 Generated with [Claude Code](https://claude.ai/code)