### PR TITLE
docs: CLIコマンド削除時の追加手順を cli-usage.md に追記する

### DIFF
--- a/.claude/rules/cli-usage.md
+++ b/.claude/rules/cli-usage.md
@@ -5,3 +5,11 @@
 1. cobra コマンドの `Short` / `Long` / フラグ usage 文言を更新する
 2. `make docs`（`go run ./tools/gendocs`）を実行して `docs/cli/` を再生成し、差分をコミットに含める
 3. ルート README の CLI 概要・パイプライン記述に変更を反映する
+
+## サブコマンドを削除した場合の追加手順
+
+サブコマンドを削除したときは、上記の共通手順に加えて以下を実施すること。
+
+4. `make docs` は削除したコマンドのドキュメントを自動削除しないため、`git rm docs/cli/{command}.md` を手動で実行する
+5. `grep -rn "{command}" internal/cli/` で `internal/cli/*_test.go` のサブコマンドリスト（`TestRootHelp` / `TestSubcommandHelp` 等）に削除コマンドへの参照が残っていないか確認し、残っていれば修正する
+6. `root.go` の親コマンドへの登録（`AddCommand`）と `Long` 説明文から削除コマンドの記述を除去する


### PR DESCRIPTION
## Summary

- `.claude/rules/cli-usage.md` にサブコマンド削除時の追加手順を追記
  - `make docs` は削除コマンドのドキュメントを自動削除しないため `git rm docs/cli/{command}.md` が必要なことを明記
  - `internal/cli/*_test.go` のサブコマンドリスト確認・修正手順を明記
  - `root.go` の `AddCommand` 登録と `Long` 説明文からの除去手順を明記

Closes #96

🤖 Generated with [Claude Code](https://claude.ai/code)