### PR TITLE
feat: opening/ending ジングルを program 設定からコードで直列挿入する

### DIFF
--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -83,12 +83,14 @@ func (a *Assembler) Run(ctx context.Context, script model.Script, clips model.Cl
 	}
 
 	bctx := BuildContext{
-		Script:   script,
-		Clips:    clips,
-		ClipsDir: clipsDir,
-		Assets:   a.AssetsConfig,
-		PauseSec: pauseSec,
-		OutPath:  outPath,
+		Script:        script,
+		Clips:         clips,
+		ClipsDir:      clipsDir,
+		Assets:        a.AssetsConfig,
+		PauseSec:      pauseSec,
+		OutPath:       outPath,
+		OpeningJingle: a.Program.OpeningJingle,
+		EndingJingle:  a.Program.EndingJingle,
 	}
 
 	ffArgs, err := BuildFFmpegArgs(bctx)

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -9,22 +9,24 @@ import (
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
-// speechNormFilter normalizes speech to EBU R128 before BGM mixing.
-// The TP ceiling (-1.5 dB) must match outputLimiterLimit so the two stages are calibrated together.
 const (
-	speechNormFilter = "loudnorm=I=-16:TP=-1.5:LRA=11"
-	// outputLimiterLimit is the linear equivalent of the TP ceiling used in speechNormFilter (10^(-1.5/20) ≈ 0.841).
+	// outputNormFilter normalizes the assembled output to EBU R128 before peak limiting.
+	// Applied once to the full mix (speech + SE + BGM + jingles) after serial concat.
+	outputNormFilter = "loudnorm=I=-16:TP=-1.5:LRA=11"
+	// outputLimiterLimit is the linear equivalent of the TP ceiling used in outputNormFilter (10^(-1.5/20) ≈ 0.841).
 	outputLimiterLimit = 0.841
 )
 
 // BuildContext holds all data needed to build the ffmpeg command.
 type BuildContext struct {
-	Script   model.Script
-	Clips    model.ClipsMeta
-	ClipsDir string
-	Assets   config.AssetsConfig
-	PauseSec float64
-	OutPath  string
+	Script        model.Script
+	Clips         model.ClipsMeta
+	ClipsDir      string
+	Assets        config.AssetsConfig
+	PauseSec      float64
+	OutPath       string
+	OpeningJingle string // key into Assets.Jingle; empty = no OP jingle
+	EndingJingle  string // key into Assets.Jingle; empty = no ED jingle
 }
 
 // FFmpegArgs holds the complete set of arguments for an ffmpeg call.
@@ -59,7 +61,7 @@ type seEvent struct {
 
 // BuildFFmpegArgs constructs the complete ffmpeg argument list for audio assembly.
 // It builds a single filter_complex covering speech concat, SE placement, BGM ducking,
-// OP/ED jingles, and loudness normalization.
+// OP/ED jingles (serial concat), and loudness normalization.
 func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 	if len(bctx.Clips.Clips) == 0 {
 		return nil, fmt.Errorf("no speech clips to assemble")
@@ -75,14 +77,9 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 
 	// Build speech track (concat with silence between clips)
 	speechLabel := buildSpeechConcat(b, bctx.Clips.Clips, clipInputIdx, bctx.PauseSec)
+	currentLabel := speechLabel
 
-	// Normalize speech before any mixing.
-	// This keeps BGM/SE/jingle levels independent of speech amplitude across episodes.
-	b.addFilter(fmt.Sprintf("%s%s[speech_norm]", speechLabel, speechNormFilter))
-	currentLabel := "[speech_norm]"
-
-	// If BGM is configured, split normalized speech so it can be used as sidechain.
-	// Using normalized speech as sidechain prevents per-episode variation in ducking depth.
+	// If BGM is configured, split speech for sidechain ducking.
 	hasBGM := len(bctx.Assets.BGM) > 0
 	if hasBGM {
 		b.addFilter(fmt.Sprintf("%sasplit=2[speech_mix][speech_duck]", currentLabel))
@@ -104,43 +101,6 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 			seIdx, entry.Volume, ev.offsetMs, ev.offsetMs, delayedLabel))
 		b.addFilter(fmt.Sprintf("%s%samix=inputs=2:duration=first:normalize=0%s",
 			currentLabel, delayedLabel, nextLabel))
-		currentLabel = nextLabel
-	}
-
-	// OP jingle: afade in, mix with speech (duration=longest so speech continues after jingle)
-	if opEntry, ok := bctx.Assets.Jingle["op"]; ok {
-		opIdx := b.addInput(opEntry.File)
-		opLabel := fmt.Sprintf("[op%d]", opIdx)
-		if opEntry.FadeIn > 0 {
-			b.addFilter(fmt.Sprintf("[%d:a]afade=t=in:d=%.3f%s", opIdx, opEntry.FadeIn, opLabel))
-		} else {
-			opLabel = fmt.Sprintf("[%d:a]", opIdx)
-		}
-		nextLabel := "[after_op]"
-		b.addFilter(fmt.Sprintf("%s%samix=inputs=2:duration=longest:normalize=0%s",
-			opLabel, currentLabel, nextLabel))
-		currentLabel = nextLabel
-	}
-
-	// ED jingle: afade out (reverse trick), mix with speech
-	if edEntry, ok := bctx.Assets.Jingle["ed"]; ok {
-		edIdx := b.addInput(edEntry.File)
-		edLabel := fmt.Sprintf("[ed%d]", edIdx)
-		if edEntry.FadeOut > 0 {
-			// Reverse → fade in → reverse = fade out from end
-			b.addFilter(fmt.Sprintf("[%d:a]areverse,afade=t=in:d=%.3f,areverse%s",
-				edIdx, edEntry.FadeOut, edLabel))
-		} else {
-			edLabel = fmt.Sprintf("[%d:a]", edIdx)
-		}
-		if edEntry.FadeIn > 0 {
-			fadedLabel := fmt.Sprintf("[ed%d_fi]", edIdx)
-			b.addFilter(fmt.Sprintf("%safade=t=in:d=%.3f%s", edLabel, edEntry.FadeIn, fadedLabel))
-			edLabel = fadedLabel
-		}
-		nextLabel := "[after_ed]"
-		b.addFilter(fmt.Sprintf("%s%samix=inputs=2:duration=longest:normalize=0%s",
-			currentLabel, edLabel, nextLabel))
 		currentLabel = nextLabel
 	}
 
@@ -171,9 +131,15 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 		currentLabel = "[after_bgm]"
 	}
 
-	// Peak limiter: prevents clipping after BGM mix without dynamic re-normalization.
-	// level=0 disables auto gain equalization.
-	b.addFilter(fmt.Sprintf("%salimiter=limit=%.3f:level=0[out]", currentLabel, outputLimiterLimit))
+	// Build serial jingle concat: [OP jingle][pause][main content][pause][ED jingle]
+	// Each jingle is a distinct segment played before/after main content (not overlaid).
+	currentLabel = buildJingleConcat(b, bctx, currentLabel)
+
+	// loudnorm: applied once to the full assembled mix (speech + SE + BGM + jingles).
+	b.addFilter(fmt.Sprintf("%s%s[norm_out]", currentLabel, outputNormFilter))
+
+	// Peak limiter: prevents clipping after loudnorm. level=0 disables auto gain equalization.
+	b.addFilter(fmt.Sprintf("[norm_out]alimiter=limit=%.3f:level=0[out]", outputLimiterLimit))
 
 	return &FFmpegArgs{
 		Inputs:        b.inputs,
@@ -181,6 +147,74 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 		OutputArgs:    []string{"-map", "[out]", "-c:a", "libmp3lame", "-q:a", "2"},
 		OutputPath:    bctx.OutPath,
 	}, nil
+}
+
+// buildJingleConcat inserts OP/ED jingles around mainLabel using ffmpeg concat.
+// Returns the label of the final stream (either a new [full_mix] label or mainLabel unchanged).
+func buildJingleConcat(b *filterBuilder, bctx BuildContext, mainLabel string) string {
+	opEntry, hasOP := bctx.Assets.Jingle[bctx.OpeningJingle]
+	if bctx.OpeningJingle == "" {
+		hasOP = false
+	}
+	edEntry, hasED := bctx.Assets.Jingle[bctx.EndingJingle]
+	if bctx.EndingJingle == "" {
+		hasED = false
+	}
+	if !hasOP && !hasED {
+		return mainLabel
+	}
+
+	var parts []string
+	count := 0
+
+	if hasOP {
+		opIdx := b.addInput(opEntry.File)
+		opLabel := buildJingleFadeIn(b, opIdx, opEntry)
+		b.addFilter(fmt.Sprintf("anullsrc=cl=stereo:r=44100,atrim=duration=%.3f[pause_op]", bctx.PauseSec))
+		parts = append(parts, opLabel, "[pause_op]")
+		count += 2
+	}
+
+	parts = append(parts, mainLabel)
+	count++
+
+	if hasED {
+		b.addFilter(fmt.Sprintf("anullsrc=cl=stereo:r=44100,atrim=duration=%.3f[pause_ed]", bctx.PauseSec))
+		edIdx := b.addInput(edEntry.File)
+		edLabel := buildJingleFadeOut(b, edIdx, edEntry)
+		parts = append(parts, "[pause_ed]", edLabel)
+		count += 2
+	}
+
+	b.addFilter(fmt.Sprintf("%sconcat=n=%d:v=0:a=1[full_mix]", strings.Join(parts, ""), count))
+	return "[full_mix]"
+}
+
+// buildJingleFadeIn applies fade-in to a jingle input and returns the resulting label.
+func buildJingleFadeIn(b *filterBuilder, idx int, entry config.JingleEntry) string {
+	if entry.FadeIn > 0 {
+		label := fmt.Sprintf("[jingle%d_fi]", idx)
+		b.addFilter(fmt.Sprintf("[%d:a]afade=t=in:d=%.3f%s", idx, entry.FadeIn, label))
+		return label
+	}
+	return fmt.Sprintf("[%d:a]", idx)
+}
+
+// buildJingleFadeOut applies fade-out (and optional fade-in) to a jingle input and returns the resulting label.
+func buildJingleFadeOut(b *filterBuilder, idx int, entry config.JingleEntry) string {
+	label := fmt.Sprintf("[%d:a]", idx)
+	if entry.FadeOut > 0 {
+		// Reverse → fade in → reverse = fade out from end
+		fadedLabel := fmt.Sprintf("[jingle%d_fo]", idx)
+		b.addFilter(fmt.Sprintf("%sareverse,afade=t=in:d=%.3f,areverse%s", label, entry.FadeOut, fadedLabel))
+		label = fadedLabel
+	}
+	if entry.FadeIn > 0 {
+		fadedLabel := fmt.Sprintf("[jingle%d_fi]", idx)
+		b.addFilter(fmt.Sprintf("%safade=t=in:d=%.3f%s", label, entry.FadeIn, fadedLabel))
+		label = fadedLabel
+	}
+	return label
 }
 
 // buildSpeechConcat generates filter entries for concatenating clips with silence between them.

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -54,6 +54,11 @@ func (b *filterBuilder) addFilter(f string) {
 	b.filters = append(b.filters, f)
 }
 
+// addSilence emits an anullsrc silence segment with the given label.
+func (b *filterBuilder) addSilence(durationSec float64, label string) {
+	b.addFilter(fmt.Sprintf("anullsrc=cl=stereo:r=44100,atrim=duration=%.3f%s", durationSec, label))
+}
+
 type seEvent struct {
 	seName   string
 	offsetMs int
@@ -152,52 +157,46 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 // buildJingleConcat inserts OP/ED jingles around mainLabel using ffmpeg concat.
 // Returns the label of the final stream (either a new [full_mix] label or mainLabel unchanged).
 func buildJingleConcat(b *filterBuilder, bctx BuildContext, mainLabel string) string {
-	opEntry, hasOP := bctx.Assets.Jingle[bctx.OpeningJingle]
-	if bctx.OpeningJingle == "" {
-		hasOP = false
+	var opEntry config.JingleEntry
+	var hasOP bool
+	if bctx.OpeningJingle != "" {
+		opEntry, hasOP = bctx.Assets.Jingle[bctx.OpeningJingle]
 	}
-	edEntry, hasED := bctx.Assets.Jingle[bctx.EndingJingle]
-	if bctx.EndingJingle == "" {
-		hasED = false
+	var edEntry config.JingleEntry
+	var hasED bool
+	if bctx.EndingJingle != "" {
+		edEntry, hasED = bctx.Assets.Jingle[bctx.EndingJingle]
 	}
 	if !hasOP && !hasED {
 		return mainLabel
 	}
 
 	var parts []string
-	count := 0
 
 	if hasOP {
 		opIdx := b.addInput(opEntry.File)
 		opLabel := buildJingleFadeIn(b, opIdx, opEntry)
-		b.addFilter(fmt.Sprintf("anullsrc=cl=stereo:r=44100,atrim=duration=%.3f[pause_op]", bctx.PauseSec))
+		b.addSilence(bctx.PauseSec, "[pause_op]")
 		parts = append(parts, opLabel, "[pause_op]")
-		count += 2
 	}
 
 	parts = append(parts, mainLabel)
-	count++
 
 	if hasED {
-		b.addFilter(fmt.Sprintf("anullsrc=cl=stereo:r=44100,atrim=duration=%.3f[pause_ed]", bctx.PauseSec))
+		b.addSilence(bctx.PauseSec, "[pause_ed]")
 		edIdx := b.addInput(edEntry.File)
 		edLabel := buildJingleFadeOut(b, edIdx, edEntry)
 		parts = append(parts, "[pause_ed]", edLabel)
-		count += 2
 	}
 
-	b.addFilter(fmt.Sprintf("%sconcat=n=%d:v=0:a=1[full_mix]", strings.Join(parts, ""), count))
+	b.addFilter(fmt.Sprintf("%sconcat=n=%d:v=0:a=1[full_mix]", strings.Join(parts, ""), len(parts)))
 	return "[full_mix]"
 }
 
 // buildJingleFadeIn applies fade-in to a jingle input and returns the resulting label.
 func buildJingleFadeIn(b *filterBuilder, idx int, entry config.JingleEntry) string {
-	if entry.FadeIn > 0 {
-		label := fmt.Sprintf("[jingle%d_fi]", idx)
-		b.addFilter(fmt.Sprintf("[%d:a]afade=t=in:d=%.3f%s", idx, entry.FadeIn, label))
-		return label
-	}
-	return fmt.Sprintf("[%d:a]", idx)
+	rawLabel := fmt.Sprintf("[%d:a]", idx)
+	return applyFadeIn(b, rawLabel, idx, entry.FadeIn)
 }
 
 // buildJingleFadeOut applies fade-out (and optional fade-in) to a jingle input and returns the resulting label.
@@ -209,12 +208,18 @@ func buildJingleFadeOut(b *filterBuilder, idx int, entry config.JingleEntry) str
 		b.addFilter(fmt.Sprintf("%sareverse,afade=t=in:d=%.3f,areverse%s", label, entry.FadeOut, fadedLabel))
 		label = fadedLabel
 	}
-	if entry.FadeIn > 0 {
-		fadedLabel := fmt.Sprintf("[jingle%d_fi]", idx)
-		b.addFilter(fmt.Sprintf("%safade=t=in:d=%.3f%s", label, entry.FadeIn, fadedLabel))
-		label = fadedLabel
+	return applyFadeIn(b, label, idx, entry.FadeIn)
+}
+
+// applyFadeIn applies an afade=t=in filter to currentLabel and returns the output label.
+// Returns currentLabel unchanged when fadeSec <= 0.
+func applyFadeIn(b *filterBuilder, currentLabel string, idx int, fadeSec float64) string {
+	if fadeSec <= 0 {
+		return currentLabel
 	}
-	return label
+	outLabel := fmt.Sprintf("[jingle%d_fi]", idx)
+	b.addFilter(fmt.Sprintf("%safade=t=in:d=%.3f%s", currentLabel, fadeSec, outLabel))
+	return outLabel
 }
 
 // buildSpeechConcat generates filter entries for concatenating clips with silence between them.
@@ -227,7 +232,7 @@ func buildSpeechConcat(b *filterBuilder, clips []model.ClipMeta, inputIdx []int,
 	for i := range clips {
 		parts = append(parts, fmt.Sprintf("[%d:a]", inputIdx[i]))
 		if i < len(clips)-1 {
-			b.addFilter(fmt.Sprintf("anullsrc=cl=stereo:r=44100,atrim=duration=%.3f[p%d]", pauseSec, i))
+			b.addSilence(pauseSec, fmt.Sprintf("[p%d]", i))
 			parts = append(parts, fmt.Sprintf("[p%d]", i))
 		}
 	}

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -250,7 +250,7 @@ func TestBuildFFmpegArgs_OPJingle(t *testing.T) {
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			Jingle: map[string]config.JingleEntry{
-				"opening": {File: "/assets/opening.wav", FadeIn: 0.5, FadeOut: 1.0},
+				"opening": {File: "/assets/opening.wav", FadeIn: 0.5},
 			},
 		},
 		OpeningJingle: "opening",
@@ -383,6 +383,39 @@ func TestBuildFFmpegArgs_BothJingles_WithPauses(t *testing.T) {
 	// Both jingles in serial concat
 	if !strings.Contains(args.FilterComplex, "concat") {
 		t.Errorf("filter_complex missing concat: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_JingleKeyMissing_SilentSkip verifies that configuring OpeningJingle
+// with a key that does not exist in Assets.Jingle does not cause an error — it is silently skipped.
+func TestBuildFFmpegArgs_JingleKeyMissing_SilentSkip(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir:      "/clips",
+		Assets:        config.AssetsConfig{},
+		OpeningJingle: "missing_key",
+		PauseSec:      0.5,
+		OutPath:       "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// No jingle file should appear in inputs
+	for _, inp := range args.Inputs {
+		if strings.Contains(inp, "jingle") {
+			t.Errorf("unexpected jingle input when key is missing: %s", inp)
+		}
 	}
 }
 

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -233,6 +233,8 @@ func TestBuildFFmpegArgs_BGM(t *testing.T) {
 	}
 }
 
+// TestBuildFFmpegArgs_OPJingle verifies that the opening jingle is prepended as a serial
+// segment (concat) before the main content, not overlaid via amix.
 func TestBuildFFmpegArgs_OPJingle(t *testing.T) {
 	ctx := BuildContext{
 		Script: model.Script{
@@ -248,11 +250,12 @@ func TestBuildFFmpegArgs_OPJingle(t *testing.T) {
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			Jingle: map[string]config.JingleEntry{
-				"op": {File: "/assets/op.wav", FadeIn: 0.5, FadeOut: 1.0},
+				"opening": {File: "/assets/opening.wav", FadeIn: 0.5, FadeOut: 1.0},
 			},
 		},
-		PauseSec: 0.5,
-		OutPath:  "/out.mp3",
+		OpeningJingle: "opening",
+		PauseSec:      0.5,
+		OutPath:       "/out.mp3",
 	}
 
 	args, err := BuildFFmpegArgs(ctx)
@@ -262,7 +265,7 @@ func TestBuildFFmpegArgs_OPJingle(t *testing.T) {
 
 	foundOP := false
 	for _, inp := range args.Inputs {
-		if inp == "/assets/op.wav" {
+		if inp == "/assets/opening.wav" {
 			foundOP = true
 		}
 	}
@@ -272,8 +275,14 @@ func TestBuildFFmpegArgs_OPJingle(t *testing.T) {
 	if !strings.Contains(args.FilterComplex, "afade") {
 		t.Errorf("filter_complex missing afade for OP jingle: %s", args.FilterComplex)
 	}
+	// Jingle must be serial (concat), not overlaid (amix=duration=longest)
+	if !strings.Contains(args.FilterComplex, "concat") {
+		t.Errorf("filter_complex missing concat for serial jingle: %s", args.FilterComplex)
+	}
 }
 
+// TestBuildFFmpegArgs_EDJingle verifies that the ending jingle is appended as a serial
+// segment (concat) after the main content, not overlaid via amix.
 func TestBuildFFmpegArgs_EDJingle(t *testing.T) {
 	ctx := BuildContext{
 		Script: model.Script{
@@ -289,11 +298,12 @@ func TestBuildFFmpegArgs_EDJingle(t *testing.T) {
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			Jingle: map[string]config.JingleEntry{
-				"ed": {File: "/assets/ed.wav", FadeIn: 0.3, FadeOut: 1.5},
+				"ending": {File: "/assets/ending.wav", FadeIn: 0.3, FadeOut: 1.5},
 			},
 		},
-		PauseSec: 0.5,
-		OutPath:  "/out.mp3",
+		EndingJingle: "ending",
+		PauseSec:     0.5,
+		OutPath:      "/out.mp3",
 	}
 
 	args, err := BuildFFmpegArgs(ctx)
@@ -303,7 +313,7 @@ func TestBuildFFmpegArgs_EDJingle(t *testing.T) {
 
 	foundED := false
 	for _, inp := range args.Inputs {
-		if inp == "/assets/ed.wav" {
+		if inp == "/assets/ending.wav" {
 			foundED = true
 		}
 	}
@@ -312,6 +322,67 @@ func TestBuildFFmpegArgs_EDJingle(t *testing.T) {
 	}
 	if !strings.Contains(args.FilterComplex, "afade") {
 		t.Errorf("filter_complex missing afade for ED jingle: %s", args.FilterComplex)
+	}
+	// Jingle must be serial (concat), not overlaid (amix=duration=longest)
+	if !strings.Contains(args.FilterComplex, "concat") {
+		t.Errorf("filter_complex missing concat for serial jingle: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_BothJingles_WithPauses verifies that OP+ED jingles are both inserted
+// with pause gaps between jingle and main content.
+func TestBuildFFmpegArgs_BothJingles_WithPauses(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			Jingle: map[string]config.JingleEntry{
+				"opening": {File: "/assets/opening.wav", FadeIn: 0.5},
+				"ending":  {File: "/assets/ending.wav", FadeOut: 1.0},
+			},
+		},
+		OpeningJingle: "opening",
+		EndingJingle:  "ending",
+		PauseSec:      0.5,
+		OutPath:       "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	foundOP, foundED := false, false
+	for _, inp := range args.Inputs {
+		if inp == "/assets/opening.wav" {
+			foundOP = true
+		}
+		if inp == "/assets/ending.wav" {
+			foundED = true
+		}
+	}
+	if !foundOP {
+		t.Errorf("OP jingle not in inputs: %v", args.Inputs)
+	}
+	if !foundED {
+		t.Errorf("ED jingle not in inputs: %v", args.Inputs)
+	}
+	// Pauses between jingle and main content
+	if !strings.Contains(args.FilterComplex, "anullsrc") {
+		t.Errorf("filter_complex missing anullsrc (pause) for jingle gaps: %s", args.FilterComplex)
+	}
+	// Both jingles in serial concat
+	if !strings.Contains(args.FilterComplex, "concat") {
+		t.Errorf("filter_complex missing concat: %s", args.FilterComplex)
 	}
 }
 
@@ -405,9 +476,9 @@ func TestComputeSEEvents_NoSE(t *testing.T) {
 	}
 }
 
-// TestBuildFFmpegArgs_LoudnormBeforeBGMMix verifies that loudnorm is applied to speech
-// BEFORE BGM mixing, so BGM levels are unaffected by speech-driven AGC.
-func TestBuildFFmpegArgs_LoudnormBeforeBGMMix(t *testing.T) {
+// TestBuildFFmpegArgs_LoudnormAfterMainContent verifies that loudnorm is applied AFTER
+// the full main content (speech+BGM) is assembled, so it normalizes the whole output once.
+func TestBuildFFmpegArgs_LoudnormAfterMainContent(t *testing.T) {
 	ctx := BuildContext{
 		Script: model.Script{
 			Segments: []model.ScriptSegment{
@@ -454,8 +525,8 @@ func TestBuildFFmpegArgs_LoudnormBeforeBGMMix(t *testing.T) {
 	if bgmFilterIdx == -1 {
 		t.Fatal("BGM filter (aloop or sidechaincompress) not found in filter_complex")
 	}
-	if loudnormIdx >= bgmFilterIdx {
-		t.Errorf("loudnorm (filter index %d) must appear before BGM mix filter (index %d); filter_complex:\n%s",
+	if loudnormIdx <= bgmFilterIdx {
+		t.Errorf("loudnorm (filter index %d) must appear AFTER BGM mix filter (index %d); filter_complex:\n%s",
 			loudnormIdx, bgmFilterIdx, args.FilterComplex)
 	}
 }

--- a/internal/cli/templates/profile.yaml
+++ b/internal/cli/templates/profile.yaml
@@ -12,6 +12,9 @@ program:
   segment_pause_sec: 0.3
   # 番組全体の目標収録時間（秒）
   target_duration_sec: 240
+  # OP/ED ジングルキー（assets.jingle のキー名を指定。不要な場合は行ごと削除）
+  # opening_jingle: opening
+  # ending_jingle: ending
 
 # コーナー定義（番組を構成する各コーナーを順番に記述）
 corners:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,8 @@ type ProgramConfig struct {
 	Description       string  `yaml:"description"`
 	SegmentPauseSec   float64 `yaml:"segment_pause_sec"`
 	TargetDurationSec int     `yaml:"target_duration_sec"`
+	OpeningJingle     string  `yaml:"opening_jingle,omitempty"`
+	EndingJingle      string  `yaml:"ending_jingle,omitempty"`
 }
 
 // SourceConfig defines the data sources for a corner (feeds and individual article URLs).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -70,6 +70,12 @@ func TestLoadProfile(t *testing.T) {
 		if profile.Program.SegmentPauseSec <= 0 {
 			t.Error("Program.SegmentPauseSec must be positive")
 		}
+		if profile.Program.OpeningJingle == "" {
+			t.Error("Program.OpeningJingle must not be empty")
+		}
+		if profile.Program.EndingJingle == "" {
+			t.Error("Program.EndingJingle must not be empty")
+		}
 	})
 
 	t.Run("Corners", func(t *testing.T) {
@@ -188,6 +194,46 @@ func TestLoadProfile_MissingFile(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for missing file")
 	}
+}
+
+// TestLoadProfile_OpeningJingleKeyMatchesAssets verifies that Program.OpeningJingle
+// references a key that actually exists in Assets.Jingle, preventing silent misconfiguration.
+func TestLoadProfile_OpeningJingleKeyMatchesAssets(t *testing.T) {
+	profile, err := config.LoadProfile("testdata/profile.yaml")
+	if err != nil {
+		t.Fatalf("LoadProfile failed: %v", err)
+	}
+	if profile.Program.OpeningJingle == "" {
+		t.Skip("no opening_jingle configured")
+	}
+	if _, ok := profile.Assets.Jingle[profile.Program.OpeningJingle]; !ok {
+		t.Errorf("Program.OpeningJingle %q not found in Assets.Jingle (keys: %v)",
+			profile.Program.OpeningJingle, jingleKeys(profile.Assets.Jingle))
+	}
+}
+
+// TestLoadProfile_EndingJingleKeyMatchesAssets verifies that Program.EndingJingle
+// references a key that actually exists in Assets.Jingle.
+func TestLoadProfile_EndingJingleKeyMatchesAssets(t *testing.T) {
+	profile, err := config.LoadProfile("testdata/profile.yaml")
+	if err != nil {
+		t.Fatalf("LoadProfile failed: %v", err)
+	}
+	if profile.Program.EndingJingle == "" {
+		t.Skip("no ending_jingle configured")
+	}
+	if _, ok := profile.Assets.Jingle[profile.Program.EndingJingle]; !ok {
+		t.Errorf("Program.EndingJingle %q not found in Assets.Jingle (keys: %v)",
+			profile.Program.EndingJingle, jingleKeys(profile.Assets.Jingle))
+	}
+}
+
+func jingleKeys(m map[string]config.JingleEntry) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestLoadConfig_Voicevox(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,9 @@
 package config_test
 
 import (
+	"maps"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/config"
@@ -208,7 +210,7 @@ func TestLoadProfile_OpeningJingleKeyMatchesAssets(t *testing.T) {
 	}
 	if _, ok := profile.Assets.Jingle[profile.Program.OpeningJingle]; !ok {
 		t.Errorf("Program.OpeningJingle %q not found in Assets.Jingle (keys: %v)",
-			profile.Program.OpeningJingle, jingleKeys(profile.Assets.Jingle))
+			profile.Program.OpeningJingle, slices.Sorted(maps.Keys(profile.Assets.Jingle)))
 	}
 }
 
@@ -224,16 +226,8 @@ func TestLoadProfile_EndingJingleKeyMatchesAssets(t *testing.T) {
 	}
 	if _, ok := profile.Assets.Jingle[profile.Program.EndingJingle]; !ok {
 		t.Errorf("Program.EndingJingle %q not found in Assets.Jingle (keys: %v)",
-			profile.Program.EndingJingle, jingleKeys(profile.Assets.Jingle))
+			profile.Program.EndingJingle, slices.Sorted(maps.Keys(profile.Assets.Jingle)))
 	}
-}
-
-func jingleKeys(m map[string]config.JingleEntry) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
 }
 
 func TestLoadConfig_Voicevox(t *testing.T) {

--- a/internal/config/testdata/profile.yaml
+++ b/internal/config/testdata/profile.yaml
@@ -3,6 +3,8 @@ program:
   description: "テスト用"
   segment_pause_sec: 0.3
   target_duration_sec: 75
+  opening_jingle: opening
+  ending_jingle: ending
 
 corners:
   - title: "オープニング"
@@ -25,6 +27,7 @@ corners:
 assets:
   jingle:
     opening: { file: assets/jingle/opening.mp3, fade_in: 0.5, fade_out: 0.5 }
+    ending:  { file: assets/jingle/ending.mp3,  fade_in: 0.5, fade_out: 1.0 }
   se:
     chime: { file: assets/se/chime.wav, volume: 0.8 }
   bgm:

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -225,6 +225,10 @@ func TestScript_Fields(t *testing.T) {
 			if seg.SEName == "" {
 				t.Errorf("segment[%d]: SEName must not be empty for se", i)
 			}
+		case model.SegmentTypeJingle:
+			if seg.AssetName == "" {
+				t.Errorf("segment[%d]: AssetName must not be empty for jingle", i)
+			}
 		}
 	}
 }

--- a/internal/model/script.go
+++ b/internal/model/script.go
@@ -5,6 +5,7 @@ type SegmentType string
 const (
 	SegmentTypeSpeech SegmentType = "speech"
 	SegmentTypeSE     SegmentType = "se"
+	SegmentTypeJingle SegmentType = "jingle"
 )
 
 type ScriptSegment struct {
@@ -13,6 +14,7 @@ type ScriptSegment struct {
 	Style       string      `json:"style,omitempty"`
 	Text        string      `json:"text,omitempty"`
 	SEName      string      `json:"se_name,omitempty"`
+	AssetName   string      `json:"asset_name,omitempty"`
 }
 
 type Script struct {

--- a/internal/model/testdata/script.json
+++ b/internal/model/testdata/script.json
@@ -1,6 +1,10 @@
 {
   "segments": [
     {
+      "type": "jingle",
+      "asset_name": "opening"
+    },
+    {
       "type": "speech",
       "speaker_role": "host",
       "text": "今日のテックニュースを始めましょう。"
@@ -22,6 +26,10 @@
       "type": "speech",
       "speaker_role": "host",
       "text": "本日のニュースは以上です。また明日！"
+    },
+    {
+      "type": "jingle",
+      "asset_name": "ending"
     }
   ]
 }

--- a/sample-profiles/tech_profile.yaml
+++ b/sample-profiles/tech_profile.yaml
@@ -3,6 +3,7 @@ program:
   description: "毎日5分のニュースラジオ"
   segment_pause_sec: 0.3
   target_duration_sec: 240
+  opening_jingle: opening
 
 corners:
   - title: "オープニング"


### PR DESCRIPTION
## Summary

- `ProgramConfig` に `opening_jingle` / `ending_jingle` フィールドを追加し、`assets.jingle` のキーを参照することで OP/ED ジングルを program 設定から指定できるようにした
- `filter.go` の旧 `amix=duration=longest` 方式を廃止し、ffmpeg `concat` フィルターによる直列合成（[OP jingle][pause][main content][pause][ED jingle]）に再構成
- `loudnorm` を全体 concat 後の1回適用に変更（旧: 音声のみに事前適用）
- `SegmentTypeJingle` / `AssetName` を `model.ScriptSegment` に追加（将来の jingle セグメント対応の準備）
- `sample-profiles/tech_profile.yaml` に `opening_jingle: opening` を追加し、tech_profile の opening が鳴るようにした
- サイレント無効化の再発防止として、program 設定のジングルキーが `assets.jingle` に存在することを検証するテストを追加

## 変更ファイル

- `internal/model/script.go`: `SegmentTypeJingle` / `AssetName` 追加
- `internal/config/config.go`: `ProgramConfig.OpeningJingle` / `EndingJingle` 追加
- `internal/assemble/filter.go`: concat 方式に再構成、`buildJingleConcat` / `applyFadeIn` / `addSilence` 抽出
- `internal/assemble/assemble.go`: `OpeningJingle` / `EndingJingle` を `BuildContext` に渡すよう修正
- `sample-profiles/tech_profile.yaml`: `opening_jingle: opening` 追加
- `internal/config/testdata/profile.yaml`: `opening_jingle` / `ending_jingle` + ending アセット追加
- `internal/cli/templates/profile.yaml`: OP/ED ジングルのコメント例を追加

Closes #105

---
🤖 Generated with [Claude Code](https://claude.ai/code)