### PR TITLE
feat: バイナリにバージョン情報を埋め込み --version フラグを追加する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 BINARY_NAME=vox-radio
+VERSION ?= dev
 
 setup:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
 
 build:
-	go build -o $(BINARY_NAME) ./cmd/vox-radio
+	go build -ldflags "-X github.com/canpok1/vox-radio/internal/cli.version=$(VERSION)" -o $(BINARY_NAME) ./cmd/vox-radio
 
 clean:
 	go clean

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 BINARY_NAME=vox-radio
 VERSION ?= dev
+LDFLAGS=-X github.com/canpok1/vox-radio/internal/cli.version=$(VERSION)
 
 setup:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
 
 build:
-	go build -ldflags "-X github.com/canpok1/vox-radio/internal/cli.version=$(VERSION)" -o $(BINARY_NAME) ./cmd/vox-radio
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/vox-radio
 
 clean:
 	go clean
@@ -21,7 +22,7 @@ lint:
 	golangci-lint run ./...
 
 install:
-	go install ./cmd/vox-radio
+	go install -ldflags "$(LDFLAGS)" ./cmd/vox-radio
 
 docs:
 	go run ./tools/gendocs

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@
 make build
 ```
 
+バージョンを埋め込む場合は `VERSION` を指定します。
+
+```bash
+make build VERSION=v0.1.0
+```
+
+ビルドしたバイナリのバージョンを確認するには `--version` フラグを使います。
+
+```bash
+vox-radio --version
+```
+
 ### パイプライン概要
 
 vox-radio は以下のパイプラインでポッドキャストを自動生成します。

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -122,6 +122,31 @@ func TestRootCmdDisableAutoGenTag(t *testing.T) {
 	}
 }
 
+func TestRootVersion(t *testing.T) {
+	cmd := cli.NewRootCmd()
+	if cmd.Version != "dev" {
+		t.Errorf("expected version %q, got %q", "dev", cmd.Version)
+	}
+}
+
+func TestRootVersionFlag(t *testing.T) {
+	cmd := cli.NewRootCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"--version"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "vox-radio") {
+		t.Errorf("--version output should contain %q, got %q", "vox-radio", out)
+	}
+	if !strings.Contains(out, "dev") {
+		t.Errorf("--version output should contain %q, got %q", "dev", out)
+	}
+}
+
 func TestSubcommandHelp(t *testing.T) {
 	for _, sub := range []string{"init", "collect", "synth", "assemble", "manifest", "script", "run"} {
 		t.Run(sub, func(t *testing.T) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -139,11 +139,8 @@ func TestRootVersionFlag(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	out := buf.String()
-	if !strings.Contains(out, "vox-radio") {
-		t.Errorf("--version output should contain %q, got %q", "vox-radio", out)
-	}
-	if !strings.Contains(out, "dev") {
-		t.Errorf("--version output should contain %q, got %q", "dev", out)
+	if !strings.Contains(out, "vox-radio version dev") {
+		t.Errorf("--version output should contain %q, got %q", "vox-radio version dev", out)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -4,10 +4,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ldflags で上書きされる。未指定時は "dev"
+var version = "dev"
+
 func NewRootCmd() *cobra.Command {
 	root := &cobra.Command{
-		Use:   "vox-radio",
-		Short: "AI を使ったポッドキャスト制作ツール",
+		Use:     "vox-radio",
+		Version: version,
+		Short:   "AI を使ったポッドキャスト制作ツール",
 		Long: `vox-radio は AI を活用したポッドキャストエピソード制作 CLI ツールです。
 
 記事収集・LLM による台本生成・音声合成・音声組み立て・コンテンツマニフェスト出力まで、


### PR DESCRIPTION
## Summary

- `internal/cli/root.go` に `var version = "dev"` を追加し、cobra の `Version` フィールドに配線
- `vox-radio --version` / `vox-radio -v` でバージョンを表示できるようになった
- `Makefile` に `VERSION ?= dev` と `LDFLAGS` マクロを追加し、`make build VERSION=v0.1.0` で ldflags 経由のバージョン注入が可能に
- `make install` にも `LDFLAGS` を追加し、`build` と対称化
- `TestRootVersion` / `TestRootVersionFlag` でバージョン配線を検証するテストを追加
- README にビルド時バージョン指定と `--version` フラグの説明を追記

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `internal/cli/root.go` | `var version = "dev"` 追加、cobra `Version` フィールドへ配線 |
| `internal/cli/cli_test.go` | `TestRootVersion` / `TestRootVersionFlag` 追加 |
| `Makefile` | `VERSION ?= dev`・`LDFLAGS` マクロ追加、`build`・`install` に ldflags 追加 |
| `README.md` | ビルド時バージョン指定・`--version` フラグの説明を追記 |

Closes #121

---
🤖 Generated with [Claude Code](https://claude.ai/code)