### PR TITLE
feat: タグ付与で GitHub Release を自動作成する (GoReleaser)

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,36 @@
+name: goreleaser
+
+on:
+  workflow_call:
+    inputs:
+      goreleaser-args:
+        required: true
+        type: string
+        description: "GoReleaserに渡す引数 (例: 'release --clean')"
+      checkout-ref:
+        required: false
+        type: string
+        default: ''
+        description: "チェックアウトするref (空の場合はデフォルトref)"
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.checkout-ref || github.ref }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: ${{ inputs.goreleaser-args }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ./.github/workflows/goreleaser.yml
+    with:
+      goreleaser-args: "release --clean"
+    secrets: inherit

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+version: 2
+
+builds:
+  - id: vox-radio
+    main: ./cmd/vox-radio
+    binary: vox-radio
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X github.com/canpok1/vox-radio/internal/cli.version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).


### PR DESCRIPTION
## Summary

- `.goreleaser.yaml` を追加: linux/darwin/windows × amd64/arm64 の6プラットフォームをCGO無効でクロスコンパイル、`internal/cli.version` へタグ由来バージョンを ldflags で注入
- `.github/workflows/goreleaser.yml` を追加: `workflow_call` で再利用可能なリリースジョブ（後続 Issue C からも呼び出し可能）
- `.github/workflows/release.yml` を追加: `v*.*.*` タグ push をトリガーに goreleaser.yml を呼び出してリリースを実行

## Test plan

- [ ] `.goreleaser.yaml` で6プラットフォーム（linux/darwin/windows × amd64/arm64）のビルド設定が含まれていること
- [ ] ldflags に `github.com/canpok1/vox-radio/internal/cli.version={{.Version}}` が設定されていること
- [ ] `.github/workflows/goreleaser.yml` が `workflow_call` で再利用可能な形になっていること
- [ ] `.github/workflows/release.yml` が `v[0-9]+.[0-9]+.[0-9]+` タグ push でトリガーされること
- [ ] 既存 `build.yml` の `tags-ignore: ['*']` により二重実行が発生しないこと

Closes #122

---
🤖 Generated with [Claude Code](https://claude.ai/code)