### PR TITLE
test: TestComplete_ThrottlesRequests のタイミング依存 flaky を解消する

### DIFF
--- a/internal/script/llm/client_test.go
+++ b/internal/script/llm/client_test.go
@@ -288,8 +288,7 @@ func TestComplete_ThrottlesRequests(t *testing.T) {
 	minGap := time.Duration(intervalMS) * time.Millisecond
 	// Server-side timestamps include TCP connection overhead for the first request
 	// but not the second (keep-alive reuse), so allow a small tolerance.
-	const toleranceMS = 5
-	tolerance := time.Duration(toleranceMS) * time.Millisecond
+	const tolerance = 5 * time.Millisecond
 	if gap < minGap-tolerance {
 		t.Errorf("requests too close: gap=%v, want >= %v", gap, minGap-tolerance)
 	}

--- a/internal/script/llm/client_test.go
+++ b/internal/script/llm/client_test.go
@@ -286,8 +286,12 @@ func TestComplete_ThrottlesRequests(t *testing.T) {
 	}
 	gap := receivedAt[1].Sub(receivedAt[0])
 	minGap := time.Duration(intervalMS) * time.Millisecond
-	if gap < minGap {
-		t.Errorf("requests too close: gap=%v, want >= %v", gap, minGap)
+	// Server-side timestamps include TCP connection overhead for the first request
+	// but not the second (keep-alive reuse), so allow a small tolerance.
+	const toleranceMS = 5
+	tolerance := time.Duration(toleranceMS) * time.Millisecond
+	if gap < minGap-tolerance {
+		t.Errorf("requests too close: gap=%v, want >= %v", gap, minGap-tolerance)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `TestComplete_ThrottlesRequests` がサーバー側受信時刻を計測点としており、1回目のTCP接続確立オーバーヘッドと2回目のkeep-alive再利用の非対称性により `gap < minGap` の偽陰性が発生していた（実測差0.52ms）。
- サーバー側計測に 5ms の許容誤差 (`const tolerance = 5 * time.Millisecond`) を導入し、flaky を解消した。
- throttle ロジックの検証意図（最小間隔の担保）は維持している。

## Changes

- `internal/script/llm/client_test.go`: `gap < minGap` を `gap < minGap - 5ms` に変更

Closes #116

---
🤖 Generated with [Claude Code](https://claude.ai/code)