### PR TITLE
feat: リリース用タグを自動付与する workflow_dispatch ワークフローを追加する

### DIFF
--- a/.github/scripts/create-version-tag.sh
+++ b/.github/scripts/create-version-tag.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# mainブランチにバージョンタグを付与するスクリプト
+# 最新リリースのパッチバージョンを1つ進めたタグを作成・push する
+set -euo pipefail
+
+DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run) DRY_RUN=true; shift ;;
+        *) echo "不明なオプション: $1" >&2; exit 1 ;;
+    esac
+done
+
+ALL_TAGS=$(git tag -l "v[0-9]*.[0-9]*.[0-9]*" --sort=-v:refname | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; })
+LATEST_TAG=$(echo "$ALL_TAGS" | head -n 1)
+
+if [[ -z "$LATEST_TAG" ]]; then
+    NEW_VERSION="v0.0.1"
+else
+    IFS='.' read -r MAJOR MINOR PATCH <<< "${LATEST_TAG#v}"
+    NEW_VERSION="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+fi
+echo "新しいバージョン: $NEW_VERSION"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "[ドライラン] タグの作成とプッシュをスキップします。"
+else
+    git tag "$NEW_VERSION"
+    git push origin "$NEW_VERSION"
+fi

--- a/.github/workflows/version-tagging.yml
+++ b/.github/workflows/version-tagging.yml
@@ -1,0 +1,31 @@
+name: version-tagging
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  create-version-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.create-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Create and push version tag
+        run: ./.github/scripts/create-version-tag.sh
+      - name: Get created tag
+        id: create-tag
+        run: echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+
+  # GITHUB_TOKENでpushしたタグはrelease.ymlをトリガーしないため、goreleaser.ymlを直接呼ぶ
+  release:
+    needs: create-version-tag
+    uses: ./.github/workflows/goreleaser.yml
+    with:
+      goreleaser-args: "release --clean"
+      checkout-ref: ${{ needs.create-version-tag.outputs.tag }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

- `.github/scripts/create-version-tag.sh` を追加
  - 最新 `vX.Y.Z` タグのパッチバージョン +1 のタグを作成・push する
  - タグが存在しない場合は `v0.0.1` から開始
  - `--dry-run` オプションで作成・push をスキップ可能
  - `set -euo pipefail` / SIGPIPE 回避（grep 結果を変数へ格納）
- `.github/workflows/version-tagging.yml` を追加
  - `workflow_dispatch` トリガーでタグを自動作成・push
  - GITHUB_TOKEN でのタグ push が `release.yml` をトリガーしないため、`goreleaser.yml` を直接呼び出してリリースまで実行

Closes #123

---
🤖 Generated with [Claude Code](https://claude.ai/code)