### PR TITLE
feat: コーナー定義に演出専用フィールド direction を追加し direct ステップへ供給する

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ vox-radio assemble --in work/intermediate/04_script.json --clips work/clips --ou
 | フィールド | 型 | 必須/任意 | 説明 |
 |---|---|---|---|
 | `title` | string | 必須 | コーナータイトル |
-| `content` | string | 任意 | コーナーの内容説明（LLM への指示に使用） |
+| `content` | string | 任意 | コーナーの内容説明（台本生成 LLM への指示に使用） |
+| `direction` | string | 任意 | コーナーの演出説明（演出生成 LLM への指示に使用。ジングル・SE・BGM の挿入タイミングなど）。台本生成 LLM へは渡されない |
 | `cast` | map[string]string | 任意 | キャラID → 役割説明のマップ（キーは `vox-radio.yaml` の `characters` のキーと一致させること） |
 | `target_duration_sec` | int | 任意 | このコーナーの目標収録時間（秒）。台本生成時に文字数（≈7文字/秒）へ換算される |
 | `source` | SourceConfig | 任意 | データソース（省略するとこのコーナーの収集はスキップ） |

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -129,29 +129,22 @@ func runScriptWrite(ctx context.Context, in, workDir string, c llm.Client, cfg *
 	cornerMap := rundown.CornerMap()
 
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(cfg.LLM, "write"), cfg)
-	scriptLines := model.ScriptLines{Corners: make([]model.CornerLines, 0, len(p.Corners))}
-	for _, corner := range p.Corners {
+	allCornerLines := make([][]model.Line, len(p.Corners))
+	for i, corner := range p.Corners {
 		rc := cornerMap[corner.Title]
 		lines, err := w.Write(ctx, p.Program, corner, p.Corners, rc.Articles, rc.Flow, cfg.Characters)
 		if err != nil {
 			return fmt.Errorf("write corner %q: %w", corner.Title, err)
 		}
-		scriptLines.Corners = append(scriptLines.Corners, model.CornerLines{
-			Title:     corner.Title,
-			Direction: corner.Direction,
-			Lines:     lines,
-		})
+		allCornerLines[i] = lines
 	}
 
+	scriptLines := model.ScriptLines{Corners: script.BuildScriptLines(p.Corners, allCornerLines)}
 	outPath := filepath.Join(workDir, "03_lines.json")
 	if err := writeJSON(outPath, scriptLines); err != nil {
 		return err
 	}
-	totalLines := 0
-	for _, cl := range scriptLines.Corners {
-		totalLines += len(cl.Lines)
-	}
-	fmt.Printf("wrote %d lines to %s\n", totalLines, outPath)
+	fmt.Printf("wrote %d lines to %s\n", scriptLines.TotalLines(), outPath)
 	return nil
 }
 

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -129,21 +129,29 @@ func runScriptWrite(ctx context.Context, in, workDir string, c llm.Client, cfg *
 	cornerMap := rundown.CornerMap()
 
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(cfg.LLM, "write"), cfg)
-	allLines := make([]model.Line, 0)
+	scriptLines := model.ScriptLines{Corners: make([]model.CornerLines, 0, len(p.Corners))}
 	for _, corner := range p.Corners {
 		rc := cornerMap[corner.Title]
 		lines, err := w.Write(ctx, p.Program, corner, p.Corners, rc.Articles, rc.Flow, cfg.Characters)
 		if err != nil {
 			return fmt.Errorf("write corner %q: %w", corner.Title, err)
 		}
-		allLines = append(allLines, lines...)
+		scriptLines.Corners = append(scriptLines.Corners, model.CornerLines{
+			Title:     corner.Title,
+			Direction: corner.Direction,
+			Lines:     lines,
+		})
 	}
 
 	outPath := filepath.Join(workDir, "03_lines.json")
-	if err := writeJSON(outPath, model.Lines{Lines: allLines}); err != nil {
+	if err := writeJSON(outPath, scriptLines); err != nil {
 		return err
 	}
-	fmt.Printf("wrote %d lines to %s\n", len(allLines), outPath)
+	totalLines := 0
+	for _, cl := range scriptLines.Corners {
+		totalLines += len(cl.Lines)
+	}
+	fmt.Printf("wrote %d lines to %s\n", totalLines, outPath)
 	return nil
 }
 
@@ -153,13 +161,13 @@ func runScriptDirect(ctx context.Context, workDir, out string, c llm.Client, llm
 	if err != nil {
 		return fmt.Errorf("read 03_lines.json: %w", err)
 	}
-	var linesWrapper model.Lines
-	if err := json.Unmarshal(data, &linesWrapper); err != nil {
+	var scriptLines model.ScriptLines
+	if err := json.Unmarshal(data, &scriptLines); err != nil {
 		return fmt.Errorf("parse 03_lines.json: %w", err)
 	}
 
 	d := direct.NewLLMDirector(c, prompts["direct"], stepTemp(llmCfg, "direct"))
-	scr, err := d.Direct(ctx, linesWrapper.Lines, assetCatalog)
+	scr, err := d.Direct(ctx, scriptLines.Corners, assetCatalog)
 	if err != nil {
 		return fmt.Errorf("direct: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,7 @@ type SourceConfig struct {
 type CornerConfig struct {
 	Title             string            `yaml:"title"`
 	Content           string            `yaml:"content"`
+	Direction         string            `yaml:"direction,omitempty"`
 	Cast              map[string]string `yaml:"cast"`
 	TargetDurationSec int               `yaml:"target_duration_sec"`
 	Source            *SourceConfig     `yaml:"source,omitempty"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -322,6 +322,27 @@ func TestLoadConfig_LLM_MinRequestIntervalMS(t *testing.T) {
 	}
 }
 
+func TestLoadProfile_CornerDirection(t *testing.T) {
+	profile, err := config.LoadProfile("testdata/profile.yaml")
+	if err != nil {
+		t.Fatalf("LoadProfile failed: %v", err)
+	}
+
+	var directionCorner *config.CornerConfig
+	for i := range profile.Corners {
+		if profile.Corners[i].Direction != "" {
+			directionCorner = &profile.Corners[i]
+			break
+		}
+	}
+	if directionCorner == nil {
+		t.Fatal("no corner with direction found")
+	}
+	if directionCorner.Direction != "冒頭でオープニングジングルを流す。" {
+		t.Errorf("Direction: got %q, want %q", directionCorner.Direction, "冒頭でオープニングジングルを流す。")
+	}
+}
+
 func TestValidateProfileCast_Valid(t *testing.T) {
 	p := &config.Profile{
 		Corners: []config.CornerConfig{

--- a/internal/config/testdata/profile.yaml
+++ b/internal/config/testdata/profile.yaml
@@ -9,6 +9,7 @@ program:
 corners:
   - title: "オープニング"
     content: "番組の挨拶とトピック紹介"
+    direction: "冒頭でオープニングジングルを流す。"
     cast:
       zundamon: "元気に挨拶する進行役"
     target_duration_sec: 45

--- a/internal/model/line.go
+++ b/internal/model/line.go
@@ -12,3 +12,15 @@ type Line struct {
 type Lines struct {
 	Lines []Line `json:"lines"`
 }
+
+// CornerLines holds the lines and direction for one corner.
+type CornerLines struct {
+	Title     string `json:"title"`
+	Direction string `json:"direction,omitempty"`
+	Lines     []Line `json:"lines"`
+}
+
+// ScriptLines is the root structure of 03_lines.json.
+type ScriptLines struct {
+	Corners []CornerLines `json:"corners"`
+}

--- a/internal/model/line.go
+++ b/internal/model/line.go
@@ -9,8 +9,18 @@ type Line struct {
 	Text        string `json:"text"`
 }
 
+// Lines is the LLM response envelope used by the write step.
 type Lines struct {
 	Lines []Line `json:"lines"`
+}
+
+// TotalLines returns the total number of lines across all corners.
+func (s ScriptLines) TotalLines() int {
+	total := 0
+	for _, c := range s.Corners {
+		total += len(c.Lines)
+	}
+	return total
 }
 
 // CornerLines holds the lines and direction for one corner.

--- a/internal/model/line.go
+++ b/internal/model/line.go
@@ -14,15 +14,6 @@ type Lines struct {
 	Lines []Line `json:"lines"`
 }
 
-// TotalLines returns the total number of lines across all corners.
-func (s ScriptLines) TotalLines() int {
-	total := 0
-	for _, c := range s.Corners {
-		total += len(c.Lines)
-	}
-	return total
-}
-
 // CornerLines holds the lines and direction for one corner.
 type CornerLines struct {
 	Title     string `json:"title"`
@@ -33,4 +24,13 @@ type CornerLines struct {
 // ScriptLines is the root structure of 03_lines.json.
 type ScriptLines struct {
 	Corners []CornerLines `json:"corners"`
+}
+
+// TotalLines returns the total number of lines across all corners.
+func (s ScriptLines) TotalLines() int {
+	total := 0
+	for _, c := range s.Corners {
+		total += len(c.Lines)
+	}
+	return total
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -132,6 +132,47 @@ func TestScriptLines_DirectionOmittedWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestScriptLines_TotalLines(t *testing.T) {
+	tests := []struct {
+		name string
+		sl   model.ScriptLines
+		want int
+	}{
+		{
+			name: "empty corners",
+			sl:   model.ScriptLines{},
+			want: 0,
+		},
+		{
+			name: "single corner with lines",
+			sl: model.ScriptLines{
+				Corners: []model.CornerLines{
+					{Title: "C1", Lines: []model.Line{{SpeakerRole: "a", Text: "x"}, {SpeakerRole: "b", Text: "y"}}},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "multiple corners",
+			sl: model.ScriptLines{
+				Corners: []model.CornerLines{
+					{Title: "C1", Lines: []model.Line{{SpeakerRole: "a", Text: "x"}}},
+					{Title: "C2", Lines: []model.Line{{SpeakerRole: "b", Text: "y"}, {SpeakerRole: "c", Text: "z"}}},
+				},
+			},
+			want: 3,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.sl.TotalLines()
+			if got != tt.want {
+				t.Errorf("TotalLines() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestArticles_CornerMap(t *testing.T) {
 	art1 := model.Article{URL: "https://example.com/1", Title: "T1", Body: "B1"}
 	art2 := model.Article{URL: "https://example.com/2", Title: "T2", Body: "B2"}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -71,6 +71,67 @@ func TestArticles_Fields(t *testing.T) {
 	}
 }
 
+func TestScriptLines_RoundTrip(t *testing.T) {
+	original := model.ScriptLines{
+		Corners: []model.CornerLines{
+			{
+				Title:     "オープニング",
+				Direction: "冒頭でジングルを流す。",
+				Lines: []model.Line{
+					{SpeakerRole: "zundamon", Text: "こんにちは"},
+				},
+			},
+			{
+				Title: "エンディング",
+				Lines: []model.Line{
+					{SpeakerRole: "metan", Text: "さようなら"},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var got model.ScriptLines
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if len(got.Corners) != 2 {
+		t.Fatalf("Corners: got %d, want 2", len(got.Corners))
+	}
+	if got.Corners[0].Title != "オープニング" {
+		t.Errorf("Corners[0].Title: got %q, want オープニング", got.Corners[0].Title)
+	}
+	if got.Corners[0].Direction != "冒頭でジングルを流す。" {
+		t.Errorf("Corners[0].Direction: got %q, want 冒頭でジングルを流す。", got.Corners[0].Direction)
+	}
+	if len(got.Corners[0].Lines) != 1 || got.Corners[0].Lines[0].Text != "こんにちは" {
+		t.Errorf("Corners[0].Lines: unexpected %+v", got.Corners[0].Lines)
+	}
+	if got.Corners[1].Direction != "" {
+		t.Errorf("Corners[1].Direction: got %q, want empty (omitempty)", got.Corners[1].Direction)
+	}
+}
+
+func TestScriptLines_DirectionOmittedWhenEmpty(t *testing.T) {
+	sl := model.ScriptLines{
+		Corners: []model.CornerLines{
+			{Title: "テスト", Lines: make([]model.Line, 0)},
+		},
+	}
+	data, err := json.Marshal(sl)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	if strings.Contains(string(data), `"direction"`) {
+		t.Errorf("direction field should be omitted when empty, got: %s", string(data))
+	}
+}
+
 func TestArticles_CornerMap(t *testing.T) {
 	art1 := model.Article{URL: "https://example.com/1", Title: "T1", Body: "B1"}
 	art2 := model.Article{URL: "https://example.com/2", Title: "T2", Body: "B2"}

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -131,11 +131,7 @@ func buildScript(corners []model.CornerLines, insertions []insertion, pauseInser
 		}
 	}
 
-	totalLines := 0
-	for _, c := range corners {
-		totalLines += len(c.Lines)
-	}
-	segments := make([]model.ScriptSegment, 0, totalLines+len(insertions)+len(pauseInsertions))
+	segments := make([]model.ScriptSegment, 0, len(insertions)+len(pauseInsertions))
 
 	for ci, corner := range corners {
 		for li, line := range corner.Lines {

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -18,8 +18,9 @@ var insertionsSchema = json.RawMessage(`{
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["after_line_index", "type", "asset_name"],
+        "required": ["corner_index", "after_line_index", "type", "asset_name"],
         "properties": {
+          "corner_index":     {"type": "integer", "minimum": 0},
           "after_line_index": {"type": "integer", "minimum": 0},
           "type":             {"type": "string", "enum": ["se", "bgm", "jingle"]},
           "asset_name":       {"type": "string"},
@@ -32,8 +33,9 @@ var insertionsSchema = json.RawMessage(`{
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["after_line_index", "duration_sec"],
+        "required": ["corner_index", "after_line_index", "duration_sec"],
         "properties": {
+          "corner_index":     {"type": "integer", "minimum": 0},
           "after_line_index": {"type": "integer", "minimum": 0},
           "duration_sec":     {"type": "number", "exclusiveMinimum": 0, "maximum": 5.0},
           "reason":           {"type": "string"}
@@ -46,10 +48,11 @@ var insertionsSchema = json.RawMessage(`{
 }`)
 
 type Director interface {
-	Direct(ctx context.Context, lines []model.Line, catalog model.AssetCatalog) (model.Script, error)
+	Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog) (model.Script, error)
 }
 
 type insertion struct {
+	CornerIndex    int               `json:"corner_index"`
 	AfterLineIndex int               `json:"after_line_index"`
 	Type           model.SegmentType `json:"type"`
 	AssetName      string            `json:"asset_name"`
@@ -57,6 +60,7 @@ type insertion struct {
 }
 
 type pauseInsertion struct {
+	CornerIndex    int     `json:"corner_index"`
 	AfterLineIndex int     `json:"after_line_index"`
 	DurationSec    float64 `json:"duration_sec"`
 	Reason         string  `json:"reason,omitempty"`
@@ -77,10 +81,10 @@ func NewLLMDirector(client llm.Client, promptTemplate string, temperature float6
 	return &LLMDirector{client: client, promptTemplate: promptTemplate, temperature: temperature}
 }
 
-func (d *LLMDirector) Direct(ctx context.Context, lines []model.Line, catalog model.AssetCatalog) (model.Script, error) {
-	linesJSON, err := json.Marshal(model.Lines{Lines: lines})
+func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog) (model.Script, error) {
+	cornersJSON, err := json.Marshal(corners)
 	if err != nil {
-		return model.Script{}, fmt.Errorf("marshal lines: %w", err)
+		return model.Script{}, fmt.Errorf("marshal corners: %w", err)
 	}
 
 	catalogJSON, err := json.Marshal(catalog)
@@ -89,7 +93,7 @@ func (d *LLMDirector) Direct(ctx context.Context, lines []model.Line, catalog mo
 	}
 
 	prompt := strings.NewReplacer(
-		"{{lines}}", string(linesJSON),
+		"{{corners}}", string(cornersJSON),
 		"{{asset_catalog}}", string(catalogJSON),
 	).Replace(d.promptTemplate)
 
@@ -107,44 +111,56 @@ func (d *LLMDirector) Direct(ctx context.Context, lines []model.Line, catalog mo
 		return model.Script{}, fmt.Errorf("unmarshal insertions: %w", err)
 	}
 
-	return buildScript(lines, resp.Insertions, resp.PauseInsertions), nil
+	return buildScript(corners, resp.Insertions, resp.PauseInsertions), nil
 }
 
-func buildScript(lines []model.Line, insertions []insertion, pauseInsertions []pauseInsertion) model.Script {
-	insertionMap := make(map[int][]insertion, len(insertions))
+type insertKey struct{ cornerIdx, lineIdx int }
+
+func buildScript(corners []model.CornerLines, insertions []insertion, pauseInsertions []pauseInsertion) model.Script {
+	insertionMap := make(map[insertKey][]insertion, len(insertions))
 	for _, ins := range insertions {
-		insertionMap[ins.AfterLineIndex] = append(insertionMap[ins.AfterLineIndex], ins)
+		key := insertKey{ins.CornerIndex, ins.AfterLineIndex}
+		insertionMap[key] = append(insertionMap[key], ins)
 	}
 
-	pauseMap := make(map[int][]pauseInsertion, len(pauseInsertions))
+	pauseMap := make(map[insertKey][]pauseInsertion, len(pauseInsertions))
 	for _, p := range pauseInsertions {
 		if p.DurationSec > 0 {
-			pauseMap[p.AfterLineIndex] = append(pauseMap[p.AfterLineIndex], p)
+			key := insertKey{p.CornerIndex, p.AfterLineIndex}
+			pauseMap[key] = append(pauseMap[key], p)
 		}
 	}
 
-	segments := make([]model.ScriptSegment, 0, len(lines)+len(insertions)+len(pauseInsertions))
-	for i, line := range lines {
-		segments = append(segments, model.ScriptSegment{
-			Type:        model.SegmentTypeSpeech,
-			SpeakerRole: line.SpeakerRole,
-			Style:       line.Style,
-			Intonation:  line.Intonation,
-			Pitch:       line.Pitch,
-			Speed:       line.Speed,
-			Text:        line.Text,
-		})
-		for _, ins := range insertionMap[i] {
+	totalLines := 0
+	for _, c := range corners {
+		totalLines += len(c.Lines)
+	}
+	segments := make([]model.ScriptSegment, 0, totalLines+len(insertions)+len(pauseInsertions))
+
+	for ci, corner := range corners {
+		for li, line := range corner.Lines {
 			segments = append(segments, model.ScriptSegment{
-				Type:      ins.Type,
-				AssetName: ins.AssetName,
+				Type:        model.SegmentTypeSpeech,
+				SpeakerRole: line.SpeakerRole,
+				Style:       line.Style,
+				Intonation:  line.Intonation,
+				Pitch:       line.Pitch,
+				Speed:       line.Speed,
+				Text:        line.Text,
 			})
-		}
-		for _, p := range pauseMap[i] {
-			segments = append(segments, model.ScriptSegment{
-				Type:        model.SegmentTypePause,
-				DurationSec: p.DurationSec,
-			})
+			key := insertKey{ci, li}
+			for _, ins := range insertionMap[key] {
+				segments = append(segments, model.ScriptSegment{
+					Type:      ins.Type,
+					AssetName: ins.AssetName,
+				})
+			}
+			for _, p := range pauseMap[key] {
+				segments = append(segments, model.ScriptSegment{
+					Type:        model.SegmentTypePause,
+					DurationSec: p.DurationSec,
+				})
+			}
 		}
 	}
 

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -33,23 +33,37 @@ func (c *capturingClient) Complete(_ context.Context, req llm.CompletionRequest)
 	return c.response, c.err
 }
 
+// helper: wrap lines into a single-corner CornerLines slice
+func oneCorner(title string, lines ...model.Line) []model.CornerLines {
+	return []model.CornerLines{{Title: title, Lines: lines}}
+}
+
+// helper: single empty catalog
+func emptyCatalog() model.AssetCatalog {
+	return model.AssetCatalog{
+		SE:     []model.AssetCatalogEntry{},
+		BGM:    []model.AssetCatalogEntry{},
+		Jingle: []model.AssetCatalogEntry{},
+	}
+}
+
 func TestLLMDirector_Direct_NoInsertions(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"insertions":[]}`),
 	}
-	d := direct.NewLLMDirector(mc, "lines={{lines}} catalog={{asset_catalog}}", 0)
+	d := direct.NewLLMDirector(mc, "corners={{corners}} catalog={{asset_catalog}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "こんにちは"},
-		{SpeakerRole: "guest", Text: "よろしく"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "こんにちは"},
+		model.Line{SpeakerRole: "guest", Text: "よろしく"},
+	)
 	catalog := model.AssetCatalog{
 		SE:     []model.AssetCatalogEntry{{Name: "chime"}},
 		BGM:    []model.AssetCatalogEntry{{Name: "talk_bgm"}},
 		Jingle: []model.AssetCatalogEntry{},
 	}
 
-	got, err := d.Direct(context.Background(), lines, catalog)
+	got, err := d.Direct(context.Background(), corners, catalog)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -65,21 +79,21 @@ func TestLLMDirector_Direct_NoInsertions(t *testing.T) {
 
 func TestLLMDirector_Direct_WithSEInsertion(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[{"after_line_index":0,"type":"se","asset_name":"chime","reason":"コーナー開始"}]}`),
+		response: json.RawMessage(`{"insertions":[{"corner_index":0,"after_line_index":0,"type":"se","asset_name":"chime","reason":"コーナー開始"}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "開始"},
-		{SpeakerRole: "guest", Text: "続き"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "開始"},
+		model.Line{SpeakerRole: "guest", Text: "続き"},
+	)
 	catalog := model.AssetCatalog{
 		SE:     []model.AssetCatalogEntry{{Name: "chime"}},
 		BGM:    []model.AssetCatalogEntry{},
 		Jingle: []model.AssetCatalogEntry{},
 	}
 
-	got, err := d.Direct(context.Background(), lines, catalog)
+	got, err := d.Direct(context.Background(), corners, catalog)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -103,21 +117,21 @@ func TestLLMDirector_Direct_WithSEInsertion(t *testing.T) {
 
 func TestLLMDirector_Direct_WithBGMInsertion(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[{"after_line_index":0,"type":"bgm","asset_name":"talk_bgm"},{"after_line_index":1,"type":"bgm","asset_name":""}]}`),
+		response: json.RawMessage(`{"insertions":[{"corner_index":0,"after_line_index":0,"type":"bgm","asset_name":"talk_bgm"},{"corner_index":0,"after_line_index":1,"type":"bgm","asset_name":""}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "BGM開始"},
-		{SpeakerRole: "guest", Text: "BGM停止"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "BGM開始"},
+		model.Line{SpeakerRole: "guest", Text: "BGM停止"},
+	)
 	catalog := model.AssetCatalog{
 		SE:     []model.AssetCatalogEntry{},
 		BGM:    []model.AssetCatalogEntry{{Name: "talk_bgm"}},
 		Jingle: []model.AssetCatalogEntry{},
 	}
 
-	got, err := d.Direct(context.Background(), lines, catalog)
+	got, err := d.Direct(context.Background(), corners, catalog)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -141,21 +155,21 @@ func TestLLMDirector_Direct_WithBGMInsertion(t *testing.T) {
 
 func TestLLMDirector_Direct_WithJingleInsertion(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[{"after_line_index":0,"type":"jingle","asset_name":"eyecatch"}]}`),
+		response: json.RawMessage(`{"insertions":[{"corner_index":0,"after_line_index":0,"type":"jingle","asset_name":"eyecatch"}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "コーナー1"},
-		{SpeakerRole: "guest", Text: "コーナー2"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "コーナー1"},
+		model.Line{SpeakerRole: "guest", Text: "コーナー2"},
+	)
 	catalog := model.AssetCatalog{
 		SE:     []model.AssetCatalogEntry{},
 		BGM:    []model.AssetCatalogEntry{},
 		Jingle: []model.AssetCatalogEntry{{Name: "eyecatch"}},
 	}
 
-	got, err := d.Direct(context.Background(), lines, catalog)
+	got, err := d.Direct(context.Background(), corners, catalog)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -173,21 +187,21 @@ func TestLLMDirector_Direct_WithJingleInsertion(t *testing.T) {
 
 func TestLLMDirector_Direct_InsertionAfterLastLine(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[{"after_line_index":1,"type":"se","asset_name":"transition"}]}`),
+		response: json.RawMessage(`{"insertions":[{"corner_index":0,"after_line_index":1,"type":"se","asset_name":"transition"}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "A"},
-		{SpeakerRole: "guest", Text: "B"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "A"},
+		model.Line{SpeakerRole: "guest", Text: "B"},
+	)
 	catalog := model.AssetCatalog{
 		SE:     []model.AssetCatalogEntry{{Name: "transition"}},
 		BGM:    []model.AssetCatalogEntry{},
 		Jingle: []model.AssetCatalogEntry{},
 	}
 
-	got, err := d.Direct(context.Background(), lines, catalog)
+	got, err := d.Direct(context.Background(), corners, catalog)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -204,14 +218,14 @@ func TestLLMDirector_Direct_StylePropagated(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"insertions":[]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "zundamon", Style: "なみだめ", Text: "ぐすん"},
-		{SpeakerRole: "metan", Style: "", Text: "大丈夫？"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "zundamon", Style: "なみだめ", Text: "ぐすん"},
+		model.Line{SpeakerRole: "metan", Style: "", Text: "大丈夫？"},
+	)
 
-	got, err := d.Direct(context.Background(), lines, model.AssetCatalog{SE: []model.AssetCatalogEntry{}, BGM: []model.AssetCatalogEntry{}, Jingle: []model.AssetCatalogEntry{}})
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,9 +242,9 @@ func TestLLMDirector_Direct_StylePropagated(t *testing.T) {
 
 func TestLLMDirector_Direct_LLMError(t *testing.T) {
 	mc := &mockClient{err: context.Canceled}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	_, err := d.Direct(context.Background(), nil, model.AssetCatalog{SE: []model.AssetCatalogEntry{}, BGM: []model.AssetCatalogEntry{}, Jingle: []model.AssetCatalogEntry{}})
+	_, err := d.Direct(context.Background(), nil, emptyCatalog())
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -240,13 +254,11 @@ func TestLLMDirector_Direct_SpeechSegmentFields(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"insertions":[]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "テストテキスト"},
-	}
+	corners := oneCorner("C1", model.Line{SpeakerRole: "host", Text: "テストテキスト"})
 
-	got, err := d.Direct(context.Background(), lines, model.AssetCatalog{SE: []model.AssetCatalogEntry{}, BGM: []model.AssetCatalogEntry{}, Jingle: []model.AssetCatalogEntry{}})
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -276,7 +288,7 @@ func TestLLMDirector_Direct_CatalogDescriptionPassedToPrompt(t *testing.T) {
 		Jingle: []model.AssetCatalogEntry{},
 	}
 
-	_, err := d.Direct(context.Background(), []model.Line{}, catalog)
+	_, err := d.Direct(context.Background(), []model.CornerLines{}, catalog)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -300,7 +312,7 @@ func TestLLMDirector_Direct_CatalogNoInternalFieldsInPrompt(t *testing.T) {
 		Jingle: []model.AssetCatalogEntry{},
 	}
 
-	_, err := d.Direct(context.Background(), []model.Line{}, catalog)
+	_, err := d.Direct(context.Background(), []model.CornerLines{}, catalog)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -316,14 +328,14 @@ func TestBuildScript_CopiesPresetFields(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"insertions":[]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "テスト", Intonation: "表現豊か", Pitch: "高め", Speed: "早口"},
-		{SpeakerRole: "guest", Text: "応答"}, // preset fields empty
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "テスト", Intonation: "表現豊か", Pitch: "高め", Speed: "早口"},
+		model.Line{SpeakerRole: "guest", Text: "応答"},
+	)
 
-	got, err := d.Direct(context.Background(), lines, model.AssetCatalog{SE: []model.AssetCatalogEntry{}, BGM: []model.AssetCatalogEntry{}, Jingle: []model.AssetCatalogEntry{}})
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -357,16 +369,16 @@ func TestBuildScript_CopiesPresetFields(t *testing.T) {
 
 func TestLLMDirector_Direct_WithPauseInsertion(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[],"pause_insertions":[{"after_line_index":0,"duration_sec":1.2,"reason":"オチの前の溜め"}]}`),
+		response: json.RawMessage(`{"insertions":[],"pause_insertions":[{"corner_index":0,"after_line_index":0,"duration_sec":1.2,"reason":"オチの前の溜め"}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "オチの前"},
-		{SpeakerRole: "guest", Text: "オチ"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "オチの前"},
+		model.Line{SpeakerRole: "guest", Text: "オチ"},
+	)
 
-	got, err := d.Direct(context.Background(), lines, model.AssetCatalog{SE: []model.AssetCatalogEntry{}, BGM: []model.AssetCatalogEntry{}, Jingle: []model.AssetCatalogEntry{}})
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -390,16 +402,16 @@ func TestLLMDirector_Direct_WithPauseInsertion(t *testing.T) {
 
 func TestLLMDirector_Direct_SEAndPauseAtSameIndex_SEFirst(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[{"after_line_index":0,"type":"se","asset_name":"chime"}],"pause_insertions":[{"after_line_index":0,"duration_sec":1.0}]}`),
+		response: json.RawMessage(`{"insertions":[{"corner_index":0,"after_line_index":0,"type":"se","asset_name":"chime"}],"pause_insertions":[{"corner_index":0,"after_line_index":0,"duration_sec":1.0}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "A"},
-		{SpeakerRole: "guest", Text: "B"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "A"},
+		model.Line{SpeakerRole: "guest", Text: "B"},
+	)
 
-	got, err := d.Direct(context.Background(), lines, model.AssetCatalog{SE: []model.AssetCatalogEntry{}, BGM: []model.AssetCatalogEntry{}, Jingle: []model.AssetCatalogEntry{}})
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -417,20 +429,19 @@ func TestLLMDirector_Direct_SEAndPauseAtSameIndex_SEFirst(t *testing.T) {
 
 func TestLLMDirector_Direct_PauseZeroDurationIgnored(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[],"pause_insertions":[{"after_line_index":0,"duration_sec":0}]}`),
+		response: json.RawMessage(`{"insertions":[],"pause_insertions":[{"corner_index":0,"after_line_index":0,"duration_sec":0}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "A"},
-		{SpeakerRole: "guest", Text: "B"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "A"},
+		model.Line{SpeakerRole: "guest", Text: "B"},
+	)
 
-	got, err := d.Direct(context.Background(), lines, model.AssetCatalog{SE: []model.AssetCatalogEntry{}, BGM: []model.AssetCatalogEntry{}, Jingle: []model.AssetCatalogEntry{}})
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// duration_sec=0 is ignored → only 2 speech segments
 	if len(got.Segments) != 2 {
 		t.Fatalf("Segments: got %d, want 2 (zero-duration pause should be ignored)", len(got.Segments))
 	}
@@ -438,21 +449,87 @@ func TestLLMDirector_Direct_PauseZeroDurationIgnored(t *testing.T) {
 
 func TestLLMDirector_Direct_PauseNegativeDurationIgnored(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[],"pause_insertions":[{"after_line_index":0,"duration_sec":-1.0}]}`),
+		response: json.RawMessage(`{"insertions":[],"pause_insertions":[{"corner_index":0,"after_line_index":0,"duration_sec":-1.0}]}`),
 	}
-	d := direct.NewLLMDirector(mc, "{{lines}}", 0)
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	lines := []model.Line{
-		{SpeakerRole: "host", Text: "A"},
-		{SpeakerRole: "guest", Text: "B"},
-	}
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "A"},
+		model.Line{SpeakerRole: "guest", Text: "B"},
+	)
 
-	got, err := d.Direct(context.Background(), lines, model.AssetCatalog{SE: []model.AssetCatalogEntry{}, BGM: []model.AssetCatalogEntry{}, Jingle: []model.AssetCatalogEntry{}})
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// negative duration_sec is ignored → only 2 speech segments
 	if len(got.Segments) != 2 {
 		t.Fatalf("Segments: got %d, want 2 (negative-duration pause should be ignored)", len(got.Segments))
+	}
+}
+
+// TestLLMDirector_Direct_MultiCorner verifies that corner_index routes insertions to the right corner.
+func TestLLMDirector_Direct_MultiCorner(t *testing.T) {
+	mc := &mockClient{
+		// Insert SE after line 0 of corner 1 (second corner)
+		response: json.RawMessage(`{"insertions":[{"corner_index":1,"after_line_index":0,"type":"se","asset_name":"chime"}]}`),
+	}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	corners := []model.CornerLines{
+		{Title: "C1", Lines: []model.Line{
+			{SpeakerRole: "host", Text: "コーナー1セリフ"},
+		}},
+		{Title: "C2", Lines: []model.Line{
+			{SpeakerRole: "guest", Text: "コーナー2セリフ"},
+		}},
+	}
+
+	got, err := d.Direct(context.Background(), corners, model.AssetCatalog{
+		SE:     []model.AssetCatalogEntry{{Name: "chime"}},
+		BGM:    []model.AssetCatalogEntry{},
+		Jingle: []model.AssetCatalogEntry{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [speech(C1), speech(C2), se(chime)]
+	if len(got.Segments) != 3 {
+		t.Fatalf("Segments: got %d, want 3", len(got.Segments))
+	}
+	if got.Segments[0].Text != "コーナー1セリフ" {
+		t.Errorf("Segment[0] should be C1 speech, got %+v", got.Segments[0])
+	}
+	if got.Segments[1].Text != "コーナー2セリフ" {
+		t.Errorf("Segment[1] should be C2 speech, got %+v", got.Segments[1])
+	}
+	if got.Segments[2].Type != model.SegmentTypeSE || got.Segments[2].AssetName != "chime" {
+		t.Errorf("Segment[2] should be SE chime, got %+v", got.Segments[2])
+	}
+}
+
+// TestLLMDirector_Direct_DirectionInPrompt verifies corner direction appears in the prompt.
+func TestLLMDirector_Direct_DirectionInPrompt(t *testing.T) {
+	var capturedPrompt string
+	mc := &capturingClient{
+		response:       json.RawMessage(`{"insertions":[]}`),
+		capturedPrompt: &capturedPrompt,
+	}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	corners := []model.CornerLines{
+		{
+			Title:     "オープニング",
+			Direction: "冒頭でオープニングジングルを流す。",
+			Lines:     []model.Line{{SpeakerRole: "host", Text: "こんにちは"}},
+		},
+	}
+
+	_, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(capturedPrompt, "冒頭でオープニングジングルを流す。") {
+		t.Errorf("direction value should appear in direct prompt, got: %s", capturedPrompt)
 	}
 }

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -70,7 +70,7 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 		return model.Script{}, err
 	}
 	cornerLines = g.regenIfNeeded(ctx, program, cornerLines, corners, cornerMap, chars)
-	scriptLines := buildScriptLines(corners, cornerLines)
+	scriptLines := BuildScriptLines(corners, cornerLines)
 	if err := g.saveIntermediate(fileio.FileLines, model.ScriptLines{Corners: scriptLines}); err != nil {
 		return model.Script{}, err
 	}
@@ -179,7 +179,8 @@ func (g *LLMScriptGenerator) saveIntermediate(filename string, v any) error {
 	return nil
 }
 
-func buildScriptLines(corners []config.CornerConfig, cornerLines [][]model.Line) []model.CornerLines {
+// BuildScriptLines converts per-corner config and line slices into a []model.CornerLines.
+func BuildScriptLines(corners []config.CornerConfig, cornerLines [][]model.Line) []model.CornerLines {
 	result := make([]model.CornerLines, len(corners))
 	for i, corner := range corners {
 		result[i] = model.CornerLines{

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -70,13 +70,13 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 		return model.Script{}, err
 	}
 	cornerLines = g.regenIfNeeded(ctx, program, cornerLines, corners, cornerMap, chars)
-	allLines := flatten(cornerLines)
-	if err := g.saveIntermediate(fileio.FileLines, model.Lines{Lines: allLines}); err != nil {
+	scriptLines := buildScriptLines(corners, cornerLines)
+	if err := g.saveIntermediate(fileio.FileLines, model.ScriptLines{Corners: scriptLines}); err != nil {
 		return model.Script{}, err
 	}
 
 	g.logger.With("step", "script/direct").Info("開始")
-	scr, err := g.director.Direct(ctx, allLines, g.assetCatalog)
+	scr, err := g.director.Direct(ctx, scriptLines, g.assetCatalog)
 	if err != nil {
 		return model.Script{}, fmt.Errorf("direct: %w", err)
 	}
@@ -179,14 +179,14 @@ func (g *LLMScriptGenerator) saveIntermediate(filename string, v any) error {
 	return nil
 }
 
-func flatten(lines [][]model.Line) []model.Line {
-	total := 0
-	for _, l := range lines {
-		total += len(l)
-	}
-	result := make([]model.Line, 0, total)
-	for _, l := range lines {
-		result = append(result, l...)
+func buildScriptLines(corners []config.CornerConfig, cornerLines [][]model.Line) []model.CornerLines {
+	result := make([]model.CornerLines, len(corners))
+	for i, corner := range corners {
+		result[i] = model.CornerLines{
+			Title:     corner.Title,
+			Direction: corner.Direction,
+			Lines:     cornerLines[i],
+		}
 	}
 	return result
 }

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -283,6 +283,40 @@ func TestLLMScriptGenerator_Generate_SavesLinesIntermediateFile(t *testing.T) {
 	}
 }
 
+func TestBuildScriptLines(t *testing.T) {
+	corners := []config.CornerConfig{
+		{Title: "C1", Direction: "演出1", Content: "内容1"},
+		{Title: "C2", Direction: "", Content: "内容2"},
+	}
+	lines1 := []model.Line{{SpeakerRole: "zundamon", Text: "line1"}}
+	lines2 := []model.Line{{SpeakerRole: "metan", Text: "line2"}, {SpeakerRole: "metan", Text: "line3"}}
+	cornerLines := [][]model.Line{lines1, lines2}
+
+	got := script.BuildScriptLines(corners, cornerLines)
+
+	if len(got) != 2 {
+		t.Fatalf("len: got %d, want 2", len(got))
+	}
+	if got[0].Title != "C1" {
+		t.Errorf("got[0].Title: got %q, want C1", got[0].Title)
+	}
+	if got[0].Direction != "演出1" {
+		t.Errorf("got[0].Direction: got %q, want 演出1", got[0].Direction)
+	}
+	if len(got[0].Lines) != 1 || got[0].Lines[0].Text != "line1" {
+		t.Errorf("got[0].Lines: unexpected %+v", got[0].Lines)
+	}
+	if got[1].Title != "C2" {
+		t.Errorf("got[1].Title: got %q, want C2", got[1].Title)
+	}
+	if got[1].Direction != "" {
+		t.Errorf("got[1].Direction: got %q, want empty", got[1].Direction)
+	}
+	if len(got[1].Lines) != 2 {
+		t.Errorf("got[1].Lines: got %d lines, want 2", len(got[1].Lines))
+	}
+}
+
 func TestLLMScriptGenerator_Generate_LinesFileUsesCornerStructure(t *testing.T) {
 	workDir := t.TempDir()
 	rundown := corneredRundown("AIコーナー",

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -2,6 +2,7 @@ package script_test
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -41,16 +42,18 @@ type mockDirector struct {
 	err    error
 }
 
-func (m *mockDirector) Direct(_ context.Context, lines []model.Line, _ model.AssetCatalog) (model.Script, error) {
+func (m *mockDirector) Direct(_ context.Context, corners []model.CornerLines, _ model.AssetCatalog) (model.Script, error) {
 	if m.err != nil {
 		return model.Script{}, m.err
 	}
 	if m.script.Segments != nil {
 		return m.script, nil
 	}
-	segs := make([]model.ScriptSegment, len(lines))
-	for i, l := range lines {
-		segs[i] = model.ScriptSegment{Type: model.SegmentTypeSpeech, SpeakerRole: l.SpeakerRole, Text: l.Text}
+	segs := make([]model.ScriptSegment, 0)
+	for _, corner := range corners {
+		for _, l := range corner.Lines {
+			segs = append(segs, model.ScriptSegment{Type: model.SegmentTypeSpeech, SpeakerRole: l.SpeakerRole, Text: l.Text})
+		}
 	}
 	return model.Script{Segments: segs}, nil
 }
@@ -277,6 +280,48 @@ func TestLLMScriptGenerator_Generate_SavesLinesIntermediateFile(t *testing.T) {
 	path := filepath.Join(workDir, fileio.FileLines)
 	if _, err := os.Stat(path); err != nil {
 		t.Errorf("expected intermediate file %q to exist: %v", fileio.FileLines, err)
+	}
+}
+
+func TestLLMScriptGenerator_Generate_LinesFileUsesCornerStructure(t *testing.T) {
+	workDir := t.TempDir()
+	rundown := corneredRundown("AIコーナー",
+		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
+	)
+	lines := []model.Line{{SpeakerRole: "zundamon", Text: "テスト"}}
+
+	corners := []config.CornerConfig{
+		{Title: "AIコーナー", Content: "AI紹介", Direction: "冒頭でSEを流す。", Cast: map[string]string{"zundamon": "司会"}, TargetDurationSec: 15},
+	}
+	gen := script.NewLLMScriptGenerator(
+		&mockWriter{lines: lines},
+		&mockDirector{},
+		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0), BGM: make([]model.AssetCatalogEntry, 0), Jingle: make([]model.AssetCatalogEntry, 0)},
+		workDir,
+	)
+
+	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path := filepath.Join(workDir, fileio.FileLines)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected intermediate file to exist: %v", err)
+	}
+
+	var sl model.ScriptLines
+	if err := json.Unmarshal(data, &sl); err != nil {
+		t.Fatalf("03_lines.json must be ScriptLines structure: %v\nContent: %s", err, data)
+	}
+	if len(sl.Corners) != 1 {
+		t.Fatalf("ScriptLines.Corners: got %d, want 1", len(sl.Corners))
+	}
+	if sl.Corners[0].Title != "AIコーナー" {
+		t.Errorf("Corners[0].Title: got %q, want AIコーナー", sl.Corners[0].Title)
+	}
+	if sl.Corners[0].Direction != "冒頭でSEを流す。" {
+		t.Errorf("Corners[0].Direction: got %q, want 冒頭でSEを流す。", sl.Corners[0].Direction)
 	}
 }
 

--- a/internal/script/write/write_test.go
+++ b/internal/script/write/write_test.go
@@ -291,6 +291,31 @@ func TestLLMWriter_Write_PromptContainsConvertedTargetChars(t *testing.T) {
 	}
 }
 
+func TestLLMWriter_Write_DirectionNotInPrompt(t *testing.T) {
+	mc := &mockClient{response: linesJSON}
+	w := write.NewLLMWriter(mc, "c={{corner}} p={{program}}", 0, nil)
+
+	corner := config.CornerConfig{
+		Title:     "オープニング",
+		Content:   "番組の挨拶",
+		Direction: "冒頭でジングルを流す演出をする。",
+		Cast:      map[string]string{"zundamon": "司会"},
+	}
+	allCorners := []config.CornerConfig{corner}
+	_, _ = w.Write(context.Background(), config.ProgramConfig{}, corner, allCorners, nil, "", nil)
+
+	if len(mc.captured) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	prompt := mc.captured[0].Messages[0].Content
+	if strings.Contains(prompt, "冒頭でジングルを流す演出をする。") {
+		t.Errorf("direction value must not appear in write prompt, got: %s", prompt)
+	}
+	if strings.Contains(prompt, "direction") {
+		t.Errorf("direction key must not appear in write prompt, got: %s", prompt)
+	}
+}
+
 func TestLLMWriter_Write_PromptContainsProgramInfo(t *testing.T) {
 	mc := &mockClient{response: linesJSON}
 	w := write.NewLLMWriter(mc, "program={{program}}", 0, nil)

--- a/prompts/direct.md
+++ b/prompts/direct.md
@@ -1,14 +1,19 @@
 # [C] 演出プロンプト（アセット挿入位置の判定）
 
-以下のセリフ列と使用可能なアセット一覧を元に、SE（効果音）・BGM・中間ジングル（アイキャッチ）を挿入する位置を判定してください。
+以下のコーナー別セリフ列と使用可能なアセット一覧を元に、SE（効果音）・BGM・中間ジングル（アイキャッチ）を挿入する位置を判定してください。
 
 OP/EDジングルはscript生成時にコードが台本へ埋め込み済みのため、ここでは中間アイキャッチ用ジングル・SEの挿入位置とBGMの開始/停止のみを判定してください。
 
-## セリフ列
+## コーナー別セリフ列
 
 ```json
-{{lines}}
+{{corners}}
 ```
+
+各コーナーのフィールド:
+- `title`: コーナー名
+- `direction`（省略可）: このコーナーの演出意図（ジングル・SE・BGMの挿入タイミングに関する指示）。**挿入位置の判断に積極的に活用すること**
+- `lines`: セリフの配列（インデックスは0始まり）
 
 ## 使用可能なアセット一覧
 
@@ -33,25 +38,29 @@ OP/EDジングルはscript生成時にコードが台本へ埋め込み済みの
 {
   "insertions": [
     {
+      "corner_index": 0,
       "after_line_index": 0,
       "type": "se",
       "asset_name": "chime",
       "reason": "コーナー開始のため"
     },
     {
+      "corner_index": 0,
       "after_line_index": 0,
       "type": "bgm",
       "asset_name": "talk_bgm",
       "reason": "BGM開始"
     },
     {
+      "corner_index": 0,
       "after_line_index": 3,
       "type": "bgm",
       "asset_name": "",
       "reason": "BGM停止"
     },
     {
-      "after_line_index": 5,
+      "corner_index": 1,
+      "after_line_index": 0,
       "type": "jingle",
       "asset_name": "eyecatch",
       "reason": "コーナー区切り"
@@ -59,6 +68,7 @@ OP/EDジングルはscript生成時にコードが台本へ埋め込み済みの
   ],
   "pause_insertions": [
     {
+      "corner_index": 0,
       "after_line_index": 4,
       "duration_sec": 1.0,
       "reason": "オチの前の溜め"
@@ -71,7 +81,7 @@ OP/EDジングルはscript生成時にコードが台本へ埋め込み済みの
 
 ### 間（pause）
 - オチの前の溜め、しんみりした余韻など、**意図的な空白**が演出として必要な場合のみ使用する
-- `after_line_index` のセリフの直後に指定秒数の無音が入る（BGMは途切れず継続）
+- 指定コーナーの `after_line_index` のセリフの直後に指定秒数の無音が入る（BGMは途切れず継続）
 - `duration_sec` は **0.3〜2.0秒** を目安とし、最大5.0秒まで指定可能
 - 過剰な「間」は dead air になるため、**全体で0〜2回まで**を目安に控えめに使う
 - 通常のトーク進行・セリフの切れ目には使わない（デフォルトのポーズで十分）
@@ -79,7 +89,7 @@ OP/EDジングルはscript生成時にコードが台本へ埋め込み済みの
 ### SE（効果音）
 - トピックの転換点など、効果的な場所にのみ挿入する
 - 使いすぎると煩わしくなるので、厳選して挿入する（全体で0〜3回程度）
-- `after_line_index` のセリフの直後に再生される（overlayのため本編と同時）
+- 指定コーナーの `after_line_index` のセリフの直後に再生される（overlayのため本編と同時）
 
 ### BGM
 - 番組の雰囲気に合わせて開始・停止を制御する
@@ -95,7 +105,9 @@ OP/EDジングルはscript生成時にコードが台本へ埋め込み済みの
 
 ## 注意事項
 
-- `after_line_index` は0始まりのインデックスです（0 = 最初のセリフの後に挿入）
+- `corner_index` は0始まりのコーナーインデックスです（コーナー別セリフ列の配列インデックスと一致）
+- `after_line_index` は各コーナー内での0始まりのセリフインデックスです（**コーナーをまたいだ通し番号ではありません**）
 - `asset_name` は対応するアセット一覧のキー名を使用してください（BGM停止は空文字列）
 - 挿入が不要な場合は `insertions` / `pause_insertions` をそれぞれ空配列にしてください
-- 同一 `after_line_index` に SE と pause が両方ある場合、SE → pause の順で再生されます
+- 同一コーナー・同一 `after_line_index` に SE と pause が両方ある場合、SE → pause の順で再生されます
+- BGMはコーナーをまたいで継続できます（停止しない限り次のコーナーでも流れ続けます）

--- a/sample-profiles/README.md
+++ b/sample-profiles/README.md
@@ -41,6 +41,7 @@ program:
 corners:                  # 固定コーナーのリスト
   - title: "オープニング"
     content: "番組の挨拶と本日のトピック紹介"
+    direction: "冒頭でオープニングジングルを流す。"  # 演出説明（省略可）
     cast:
       zundamon: "元気に挨拶する進行役"  # キャラID: そのコーナーの役割指示
     target_duration_sec: 30  # コーナーの目標再生時間（秒）
@@ -75,6 +76,8 @@ assets:
   - `target_duration_sec`: 番組全体の目標再生時間（秒）
 - `corners`: 固定コーナーのリスト（旧 `show` を再設計）
   - `cast`: キャラID→役割指示のマップ（`vox-radio.yaml` の `characters` のキーを参照）
+  - `content`（省略可）: コーナーの内容説明。台本生成（write）LLM への指示に使用される。演出指示は含めないこと
+  - `direction`（省略可）: コーナーの演出説明（ジングル・SE・BGMの挿入タイミングなど）。演出生成（direct）LLM のみに渡される。台本生成 LLM へは渡されないため、キャラクターがセリフとして口走ることがない
   - `target_duration_sec`: コーナーの目標再生時間（秒）。台本生成時に文字数係数（≈7文字/秒）で換算される
   - `source`（省略可）: コーナーのデータソース。省略したコーナーは収集をスキップ
     - `feeds`: RSS フィードのリスト（`url` / `max_items`）

--- a/sample-profiles/tech_profile.yaml
+++ b/sample-profiles/tech_profile.yaml
@@ -7,7 +7,8 @@ program:
 
 corners:
   - title: "オープニング"
-    content: "openingジングルを流したあとに元気に挨拶と自己紹介。ずんだもんからプライベートな出来事を1つ話し、ちょっとした雑談をする。"
+    content: "元気に挨拶と自己紹介。ずんだもんからプライベートな出来事を1つ話し、ちょっとした雑談をする。"
+    direction: "冒頭でオープニングジングルを流す。"
     cast:
       zundamon: "MC。元気に挨拶する進行役。ボケ担当。"
       metan: "MC。ずんだもんの相棒。ツッコミ担当。"
@@ -25,7 +26,8 @@ corners:
         - url: https://qiita.com/popular-items/feed
           max_items: 5
   - title: "エンディング"
-    content: "次回も聴いて欲しいという宣伝をして最後にジングルを流す。"
+    content: "次回も聴いて欲しいという宣伝をする。"
+    direction: "最後にエンディングジングルを流す。"
     cast:
       zundamon: "MC。進行役。ボケ担当。"
       metan: "MC。相棒。ツッコミ担当。"


### PR DESCRIPTION
## Summary

- `CornerConfig` に `direction` フィールド（yaml: `direction`, omitempty）を追加
- `model.CornerLines` / `model.ScriptLines` 型を追加し、`03_lines.json` のスキーマをコーナー単位のネスト構造 `{ corners: [{ title, direction, lines }] }` へ変更
- `Director.Direct` シグネチャを `[]model.Line` から `[]model.CornerLines` に変更し、`insertionsSchema` に `corner_index` を追加
- `buildScript` をコーナー内ローカルインデックスで処理するよう更新
- `script.BuildScriptLines` を export して重複実装を排除; `model.ScriptLines.TotalLines()` メソッドを追加
- `prompts/direct.md` を `{{corners}}` 入力・`corner_index` 出力に更新
- `sample-profiles/tech_profile.yaml` の演出指示を `content` から `direction` へ分離
- `README.md` / `sample-profiles/README.md` に `direction` フィールドの説明を追加
- write ステップが `direction` を LLM プロンプトに漏らさないことをテストで保証（write.go 変更不要を確認）

## 背景

`content` に演出指示（「ジングルを流す」など）が混在していたため、write ステップが LLM へそのまま渡す結果、キャラクターが演出内容をセリフとして口走る問題があった。`direction` フィールドで台本生成用と演出生成用の情報を分離することで問題を解消する。

Closes #135

---
🤖 Generated with [Claude Code](https://claude.ai/code)