### PR TITLE
docs(adr): add ADR 0022 for Dify API LLM provider

### DIFF
--- a/docs/adr/0022-dify-api-llm-provider.md
+++ b/docs/adr/0022-dify-api-llm-provider.md
@@ -5,17 +5,17 @@
 
 ## コンテキスト
 
-ADR 0002 は LLM プロバイダ切替を **OpenAI 互換 1 実装 ＋ `base_url`/`model` 差し替え**に統一し、列挙型での分岐を却下した。一方で LLM を Dify アプリ経由でも利用したい要望が生じた。Dify のアプリ API（`chat-messages` 等）は OpenAI 互換ではなく、リクエストでは `query` 等の限られた項目しか受け取らず、`model`・`temperature`・`response_format`(JSON Schema) は **Dify アプリ側設定に固定**され送信できない。このため `base_url`/`model` 差し替えでは吸収できず、ADR 0002 の前提が崩れる。
+ADR 0002 は LLM プロバイダ切替を **OpenAI 互換 1 実装 ＋ `base_url`/`model` 差し替え**に統一し、列挙型での分岐を却下した。一方で LLM を Dify アプリ経由でも利用したい要望が生じた。Dify はアプリ種別ごとにエンドポイントと入出力が異なり、いずれも `model`/`temperature`/`json_schema` は **Dify アプリ側設定に固定**され送信できない。このため `base_url`/`model` 差し替えでは吸収できず、ADR 0002 の前提が崩れる。
 
 ## 決定
 
-`LLMConfig` に `provider` 列挙（`openai`/`dify`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify は **ゲートウェイ**として使い、vox-radio が組み立てた system+user プロンプトを `query` に渡す（プロンプトと JSON Schema 検証は vox-radio 側に温存）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` も標準パラメータでは送れないが、Dify の `inputs`（任意変数）経由で渡せる。`inputs` の値に `${temperature}` プレースホルダーを書くと per-step temperature に置換して送る（書かなければ渡さない）ことで、渡す変数を `inputs` に一元化する。実際に効かせるかは Dify アプリ側の変数バインド次第。Dify アプリは単一とし、HTTP は `safejob/dify-sdk-go`（依存ゼロ・MIT）の blocking 呼び出しを用いる。
+`LLMConfig` に `provider` 列挙（`openai`/`dify`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify は **ゲートウェイ**として使い、組み立てたプロンプトを渡してテキスト回答を得る（プロンプトと JSON Schema 検証は vox-radio 側に温存）。対象アプリ種別は `app_type`（`chat`/`workflow`、既定 `chat`）で選択し、エンドポイントと入出力を切り替える（chat=`chat-messages` の `query`/`answer`、workflow=`workflows/run` の `inputs`/`outputs`）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` も標準では送れないが、`inputs` の値に `${temperature}` プレースホルダーを書けば per-step 値に置換して渡せる（書かなければ渡さない）。渡す変数は `inputs` に一元化する。HTTP は `safejob/dify-sdk-go`（依存ゼロ・MIT）の blocking 呼び出しを用いる。
 
 ## 結果
 
 - 設定値 1 つで OpenAI 互換と Dify を切替でき、既定 `openai` で後方互換を維持できる。
 - `ScriptGenerator`/`Client` 境界は不変のため、ドメイン層と各ステップは影響を受けない。
-- ADR 0002 の「列挙型を持たない」原則は崩すが、対象は 2 値の限定的な分岐に留め、ワイヤープロトコルの統一思想は OpenAI 側で維持する。
+- ADR 0002 の「列挙型を持たない」原則は崩すが、ワイヤープロトコルの統一思想は OpenAI 側で維持する。Dify の chat/workflow 分岐は Dify 実装内に閉じる。
 - Dify 利用時は strict schema が効かず品質は検証＋リトライ依存。temperature は `inputs` 経由（オプトイン＋Dify 側バインド）でのみ反映できる。検証・修復ロジックは両実装で共有して重複を避ける。
 
 ## 検討した代替案

--- a/docs/adr/0022-dify-api-llm-provider.md
+++ b/docs/adr/0022-dify-api-llm-provider.md
@@ -9,7 +9,7 @@ ADR 0002 は LLM プロバイダ切替を **OpenAI 互換 1 実装 ＋ `base_url
 
 ## 決定
 
-`LLMConfig` に `provider` 列挙（`openai`/`dify`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify は **ゲートウェイ**として使い、vox-radio が組み立てた system+user プロンプトを `query` に渡す（プロンプトと JSON Schema 検証は vox-radio 側に温存）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` も標準パラメータでは送れないが、Dify の `inputs`（任意変数）経由で**オプトインで渡せる口**を設ける（注入キー未設定なら渡さない。静的な任意変数も `inputs` に載せられる）。実際に効かせるかは Dify アプリ側の変数バインド次第。Dify アプリは単一とし、HTTP は `safejob/dify-sdk-go`（依存ゼロ・blocking chat 対応・MIT）の `RunBlock` を用いる。
+`LLMConfig` に `provider` 列挙（`openai`/`dify`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify は **ゲートウェイ**として使い、vox-radio が組み立てた system+user プロンプトを `query` に渡す（プロンプトと JSON Schema 検証は vox-radio 側に温存）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` も標準パラメータでは送れないが、Dify の `inputs`（任意変数）経由で渡せる。`inputs` の値に `${temperature}` プレースホルダーを書くと per-step temperature に置換して送る（書かなければ渡さない）ことで、渡す変数を `inputs` に一元化する。実際に効かせるかは Dify アプリ側の変数バインド次第。Dify アプリは単一とし、HTTP は `safejob/dify-sdk-go`（依存ゼロ・MIT）の blocking 呼び出しを用いる。
 
 ## 結果
 

--- a/docs/adr/0022-dify-api-llm-provider.md
+++ b/docs/adr/0022-dify-api-llm-provider.md
@@ -9,17 +9,18 @@ ADR 0002 は LLM プロバイダ切替を **OpenAI 互換 1 実装 ＋ `base_url
 
 ## 決定
 
-`LLMConfig` に `provider` 列挙（`openai`/`dify`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify は **ゲートウェイ**として使い、組み立てたプロンプトを渡してテキスト回答を得る（プロンプトと JSON Schema 検証は vox-radio 側に温存）。対象アプリ種別は `app_type`（`chat`/`workflow`、既定 `chat`）で選択し、エンドポイントと入出力を切り替える（chat=`chat-messages` の `query`/`answer`、workflow=`workflows/run` の `inputs`/`outputs`）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` も標準では送れないが、`inputs` の値に `${temperature}` プレースホルダーを書けば per-step 値に置換して渡せる（書かなければ渡さない）。渡す変数は `inputs` に一元化する。HTTP は `safejob/dify-sdk-go`（依存ゼロ・MIT）の blocking 呼び出しを用いる。
+`LLMConfig` に `provider` 列挙（`openai`/`dify-chat`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify はアプリ種別でエンドポイントが異なるため **プロバイダ名に種別を含めて明示する**（`dify-chat` は `chat-messages` 専用。将来 workflow 対応時は `dify-workflow` を別実装で追加）。`dify-chat` は **ゲートウェイ**として使い、組み立てたプロンプトを `query` に渡し `answer` を得る（プロンプトと JSON Schema 検証は vox-radio 側に温存）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` も標準では送れないが、`dify-chat.inputs` の値に `${temperature}` プレースホルダーを書けば per-step 値に置換して渡せる（書かなければ渡さない）。HTTP は `safejob/dify-sdk-go`（依存ゼロ・MIT）の blocking 呼び出しを用いる。
 
 ## 結果
 
 - 設定値 1 つで OpenAI 互換と Dify を切替でき、既定 `openai` で後方互換を維持できる。
 - `ScriptGenerator`/`Client` 境界は不変のため、ドメイン層と各ステップは影響を受けない。
-- ADR 0002 の「列挙型を持たない」原則は崩すが、ワイヤープロトコルの統一思想は OpenAI 側で維持する。Dify の chat/workflow 分岐は Dify 実装内に閉じる。
-- Dify 利用時は strict schema が効かず品質は検証＋リトライ依存。temperature は `inputs` 経由（オプトイン＋Dify 側バインド）でのみ反映できる。検証・修復ロジックは両実装で共有して重複を避ける。
+- ADR 0002 の「列挙型を持たない」原則は崩すが、ワイヤープロトコルの統一思想は OpenAI 側で維持する。
+- Dify 利用時は strict schema が効かず品質は検証＋リトライ依存。temperature は `inputs` 経由（Dify 側バインド要）でのみ反映できる。検証・修復ロジックは両実装で共有する。
 
 ## 検討した代替案
 
 - **Dify の OpenAI 互換エンドポイントを使い ADR 0002 のまま吸収**: ライブラリ経由という要望に反し、Dify アプリ機能も活用できないため却下。
 - **ステップごとに Dify アプリを分け per-step 制御を維持**: API キー・アプリ運用が 6 倍に膨らみ割に合わないため却下（単一アプリで割り切る）。
 - **Dify 側にプロンプトを移管**: `prompts/*.md` と動的スキーマ生成の大規模な責務移動を伴い、変更範囲が過大なため却下。
+- **1 プロバイダ＋ `app_type` で chat/workflow 両対応**: 設定・実装が複雑化するため却下し、種別を provider 値で分けた。

--- a/docs/adr/0022-dify-api-llm-provider.md
+++ b/docs/adr/0022-dify-api-llm-provider.md
@@ -9,14 +9,14 @@ ADR 0002 は LLM プロバイダ切替を **OpenAI 互換 1 実装 ＋ `base_url
 
 ## 決定
 
-`LLMConfig` に `provider` 列挙（`openai`/`dify`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify は **ゲートウェイ**として使い、vox-radio が組み立てた system+user プロンプトを `query` に渡す（プロンプトと JSON Schema 検証は vox-radio 側に温存）。`model`/`temperature`/`json_schema` は送れないため per-step temperature は Dify 利用時は無効とし、構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。Dify アプリは単一とし、HTTP は `safejob/dify-sdk-go`（依存ゼロ・blocking chat 対応・MIT）の `RunBlock` を用いる。
+`LLMConfig` に `provider` 列挙（`openai`/`dify`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify は **ゲートウェイ**として使い、vox-radio が組み立てた system+user プロンプトを `query` に渡す（プロンプトと JSON Schema 検証は vox-radio 側に温存）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` も標準パラメータでは送れないが、Dify の `inputs`（任意変数）経由で**オプトインで渡せる口**を設ける（注入キー未設定なら渡さない。静的な任意変数も `inputs` に載せられる）。実際に効かせるかは Dify アプリ側の変数バインド次第。Dify アプリは単一とし、HTTP は `safejob/dify-sdk-go`（依存ゼロ・blocking chat 対応・MIT）の `RunBlock` を用いる。
 
 ## 結果
 
 - 設定値 1 つで OpenAI 互換と Dify を切替でき、既定 `openai` で後方互換を維持できる。
 - `ScriptGenerator`/`Client` 境界は不変のため、ドメイン層と各ステップは影響を受けない。
 - ADR 0002 の「列挙型を持たない」原則は崩すが、対象は 2 値の限定的な分岐に留め、ワイヤープロトコルの統一思想は OpenAI 側で維持する。
-- Dify 利用時は per-step temperature と strict schema が効かず、品質は検証＋リトライ依存になる。検証・修復ロジックは両実装で共有して重複を避ける。
+- Dify 利用時は strict schema が効かず品質は検証＋リトライ依存。temperature は `inputs` 経由（オプトイン＋Dify 側バインド）でのみ反映できる。検証・修復ロジックは両実装で共有して重複を避ける。
 
 ## 検討した代替案
 

--- a/docs/adr/0022-dify-api-llm-provider.md
+++ b/docs/adr/0022-dify-api-llm-provider.md
@@ -1,0 +1,25 @@
+# 0022. LLM プロバイダに Dify API 経由の利用を追加する
+
+- ステータス: 採用
+- 日付: 2026-06-01
+
+## コンテキスト
+
+ADR 0002 は LLM プロバイダ切替を **OpenAI 互換 1 実装 ＋ `base_url`/`model` 差し替え**に統一し、列挙型での分岐を却下した。一方で LLM を Dify アプリ経由でも利用したい要望が生じた。Dify のアプリ API（`chat-messages` 等）は OpenAI 互換ではなく、リクエストでは `query` 等の限られた項目しか受け取らず、`model`・`temperature`・`response_format`(JSON Schema) は **Dify アプリ側設定に固定**され送信できない。このため `base_url`/`model` 差し替えでは吸収できず、ADR 0002 の前提が崩れる。
+
+## 決定
+
+`LLMConfig` に `provider` 列挙（`openai`/`dify`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify は **ゲートウェイ**として使い、vox-radio が組み立てた system+user プロンプトを `query` に渡す（プロンプトと JSON Schema 検証は vox-radio 側に温存）。`model`/`temperature`/`json_schema` は送れないため per-step temperature は Dify 利用時は無効とし、構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。Dify アプリは単一とし、HTTP は `safejob/dify-sdk-go`（依存ゼロ・blocking chat 対応・MIT）の `RunBlock` を用いる。
+
+## 結果
+
+- 設定値 1 つで OpenAI 互換と Dify を切替でき、既定 `openai` で後方互換を維持できる。
+- `ScriptGenerator`/`Client` 境界は不変のため、ドメイン層と各ステップは影響を受けない。
+- ADR 0002 の「列挙型を持たない」原則は崩すが、対象は 2 値の限定的な分岐に留め、ワイヤープロトコルの統一思想は OpenAI 側で維持する。
+- Dify 利用時は per-step temperature と strict schema が効かず、品質は検証＋リトライ依存になる。検証・修復ロジックは両実装で共有して重複を避ける。
+
+## 検討した代替案
+
+- **Dify の OpenAI 互換エンドポイントを使い ADR 0002 のまま吸収**: ライブラリ経由という要望に反し、Dify アプリ機能も活用できないため却下。
+- **ステップごとに Dify アプリを分け per-step 制御を維持**: API キー・アプリ運用が 6 倍に膨らみ割に合わないため却下（単一アプリで割り切る）。
+- **Dify 側にプロンプトを移管**: `prompts/*.md` と動的スキーマ生成の大規模な責務移動を伴い、変更範囲が過大なため却下。

--- a/docs/adr/0022-dify-api-llm-provider.md
+++ b/docs/adr/0022-dify-api-llm-provider.md
@@ -5,18 +5,18 @@
 
 ## コンテキスト
 
-ADR 0002 は LLM プロバイダ切替を **OpenAI 互換 1 実装 ＋ `base_url`/`model` 差し替え**に統一し、列挙型での分岐を却下した。一方で LLM を Dify アプリ経由でも利用したい要望が生じた。Dify はアプリ種別ごとにエンドポイントと入出力が異なり、いずれも `model`/`temperature`/`json_schema` は **Dify アプリ側設定に固定**され送信できない。このため `base_url`/`model` 差し替えでは吸収できず、ADR 0002 の前提が崩れる。
+ADR 0002 は LLM プロバイダ切替を **OpenAI 互換 1 実装 ＋ `base_url`/`model` 差し替え**に統一し、列挙型での分岐を却下した。一方で LLM を Dify アプリ経由でも利用したい要望が生じた。Dify はアプリ種別ごとにエンドポイントと入出力が異なり、いずれも `model`/`temperature`/`json_schema` は **Dify アプリ側設定に固定**され送信できない。このため `base_url`/`model` 差し替えでは吸収できない。
 
 ## 決定
 
-`LLMConfig` に `provider` 列挙（`openai`/`dify-chat`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。`Client` インターフェース（`Complete`）は変更しない。Dify はアプリ種別でエンドポイントが異なるため **プロバイダ名に種別を含めて明示する**（`dify-chat` は `chat-messages` 専用。将来 workflow 対応時は `dify-workflow` を別実装で追加）。`dify-chat` は **ゲートウェイ**として使い、組み立てたプロンプトを `query` に渡し `answer` を得る（プロンプトと JSON Schema 検証は vox-radio 側に温存）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` も標準では送れないが、`dify-chat.inputs` の値に `${temperature}` プレースホルダーを書けば per-step 値に置換して渡せる（書かなければ渡さない）。HTTP は `safejob/dify-sdk-go`（依存ゼロ・MIT）の blocking 呼び出しを用いる。
+`LLMConfig` に `provider` 列挙（`openai`/`dify-chat`、既定 `openai`）を追加し、`llm` パッケージ内の factory で実装を選択する。接続情報（`base_url`/`api_key_env`）と `model` は provider 別ブロックへ分離し、温度・`steps` 等は共通に保つ。`Client` インターフェース（`Complete`）は変更しない。Dify はアプリ種別でエンドポイントが異なるため **プロバイダ名に種別を含めて明示する**（`dify-chat` は `chat-messages` 専用。将来は `dify-workflow` を別実装で追加）。`dify-chat` は **ゲートウェイ**として使い、プロンプトを `query` に渡し `answer` を得る（JSON Schema 検証は vox-radio 側に温存）。`json_schema` は送れないため構造化出力は既存のスキーマ検証＋自己修復リトライで担保する。`temperature` は `dify-chat.inputs` の `${temperature}` プレースホルダーで per-step 値を渡せる（任意）。HTTP は `safejob/dify-sdk-go`（依存ゼロ・MIT）の blocking 呼び出しを用いる。
 
 ## 結果
 
-- 設定値 1 つで OpenAI 互換と Dify を切替でき、既定 `openai` で後方互換を維持できる。
-- `ScriptGenerator`/`Client` 境界は不変のため、ドメイン層と各ステップは影響を受けない。
+- `provider` で OpenAI/Dify を切替える。接続情報・`model` は provider 別ブロックに再編し、既存 yaml は移行要。
+- `Client` 境界は不変のため、ドメイン層と各ステップは影響を受けない。
 - ADR 0002 の「列挙型を持たない」原則は崩すが、ワイヤープロトコルの統一思想は OpenAI 側で維持する。
-- Dify 利用時は strict schema が効かず品質は検証＋リトライ依存。temperature は `inputs` 経由（Dify 側バインド要）でのみ反映できる。検証・修復ロジックは両実装で共有する。
+- Dify 利用時は strict schema が効かず品質は検証＋リトライ依存。温度は Dify アプリ側で変数バインドした場合のみ効く。検証・修復ロジックは両実装で共有する。
 
 ## 検討した代替案
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,3 +27,4 @@
 | [0019](0019-conversation-notes-in-manifest.md) | 番組構成外の会話情報を会話メモとして manifest に残し履歴へ集約する | 採用 | 2026-06-01 |
 | [0020](0020-corner-level-bgm-jingle-provenance.md) | BGM・ジングルの挿入をprofile.yamlのコーナー設定駆動へ移行し、program OP/ED指定を廃止する | 採用 | 2026-06-01 |
 | [0021](0021-intra-episode-corner-context.md) | コーナー台本生成に同一回の生成済みセリフを文脈として渡す | 採用 | 2026-06-01 |
+| [0022](0022-dify-api-llm-provider.md) | LLM プロバイダに Dify API 経由の利用を追加する | 採用 | 2026-06-01 |


### PR DESCRIPTION
LLM プロバイダに Dify API 経由の利用を追加する判断を記録。
ADR 0002 の方針を部分転換し provider 列挙を導入する。

https://claude.ai/code/session_011EzV2xMs9ncUjasnjmjRnS