### PR TITLE
feat: LLM を Dify API 経由でも利用できるようにする（provider: dify-chat）

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,37 @@ vox-radio assemble --in work/intermediate/04_script.json --clips work/clips --ou
 
 | フィールド | 型 | 必須/任意 | 説明 |
 |---|---|---|---|
+| `provider` | string | 任意 | LLM プロバイダ。`openai`（デフォルト）または `dify-chat` |
+| `temperature` | float64 | 任意 | 生成のランダム性（0.0〜1.0）。デフォルト: 0（Go ゼロ値） |
+| `max_retries` | int | 任意 | APIリトライ回数。デフォルト: 0（Go ゼロ値） |
+| `min_request_interval_ms` | *int | 任意 | リクエスト間隔（ミリ秒）。省略時は 4500ms |
+| `steps` | map[string]LLMStepConfig | 任意 | ステップごとの設定（キー: ステップ名） |
+| `openai` | OpenAIConfig | `provider: openai` 時必須 | OpenAI 互換プロバイダの接続設定 |
+| `dify-chat` | DifyChatConfig | `provider: dify-chat` 時必須 | Dify chat-messages の接続設定 |
+
+##### `llm.openai` サブフィールド（`provider: openai` 時）
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
 | `base_url` | string | 必須 | LLM API のベースURL（OpenAI 互換エンドポイント） |
 | `api_key_env` | string | 必須 | APIキーを格納する環境変数名 |
 | `model` | string | 必須 | 使用するモデル名 |
-| `temperature` | float64 | 任意 | 生成のランダム性（0.0〜1.0）。デフォルト: 0（Go ゼロ値） |
-| `max_retries` | int | 任意 | APIリトライ回数。デフォルト: 0（Go ゼロ値） |
-| `steps` | map[string]LLMStepConfig | 任意 | ステップごとの設定（キー: ステップ名） |
+
+##### `llm.dify-chat` サブフィールド（`provider: dify-chat` 時）
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `base_url` | string | 必須 | Dify API サーバーURL（例: `https://api.dify.ai/v1`） |
+| `api_key_env` | string | 必須 | Dify API キーを格納する環境変数名 |
+| `user` | string | 任意 | 利用者識別子。省略時は `vox-radio` |
+| `inputs` | map[string]string | 任意 | Dify アプリに渡す変数。値に `${temperature}` プレースホルダーを書ける |
+
+`inputs` の `${temperature}` プレースホルダーについて:
+- 値が `"${temperature}"` だけの場合（完全一致）→ そのステップの temperature を **JSON 数値**で送信
+- 値に `${temperature}` が含まれる場合（部分一致）→ 文字列として補間
+- プレースホルダーを書かない場合 → temperature を inputs に含めない
+
+> **注意**: inputs に temperature を載せても、Dify アプリ側でその変数をモデルパラメータにバインドしない限り効果はありません。
 
 ##### `llm.steps.<step>` サブフィールド
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/mmcdole/gofeed v1.3.0
+	github.com/safejob/dify-sdk-go v1.7.0-rc.1
 	github.com/spf13/cobra v1.10.2
 	github.com/xeipuuv/gojsonschema v1.2.0
 	golang.org/x/net v0.55.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/safejob/dify-sdk-go v1.7.0-rc.1 h1:js6q04Trv7BEImx8xmWsLbRTI8gHFrBu/8A37l7ZoYc=
+github.com/safejob/dify-sdk-go v1.7.0-rc.1/go.mod h1:uOjNfuk/UUd+NI3nbkhNLzmYPR747Spqds1E2LznDPQ=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/internal/cli/templates/vox-radio.yaml
+++ b/internal/cli/templates/vox-radio.yaml
@@ -3,12 +3,8 @@
 
 # LLM（大規模言語モデル）の接続設定
 llm:
-  # LLM API のベースURL（OpenAI 互換エンドポイント）
-  base_url: https://generativelanguage.googleapis.com/v1beta/openai/
-  # APIキーを格納する環境変数名（export GEMINI_API_KEY=xxx などで設定）
-  api_key_env: GEMINI_API_KEY
-  # 使用するモデル名
-  model: gemini-3.1-flash-lite
+  # プロバイダ: openai（デフォルト）または dify-chat
+  provider: openai
   # 生成のランダム性（0.0〜1.0）。低いほど安定、高いほど多様な出力になる
   temperature: 0.7
   # APIリトライ回数
@@ -21,6 +17,22 @@ llm:
     plan:      { temperature: 0.4 }
     write:     { temperature: 0.8 }
     direct:    { temperature: 0.2 }
+  # OpenAI 互換プロバイダの接続設定（provider: openai 時に必須）
+  openai:
+    # LLM API のベースURL（OpenAI 互換エンドポイント）
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+    # APIキーを格納する環境変数名（export GEMINI_API_KEY=xxx などで設定）
+    api_key_env: GEMINI_API_KEY
+    # 使用するモデル名
+    model: gemini-3.1-flash-lite
+  # Dify chat-messages の接続設定（provider: dify-chat 時に必須）
+  # dify-chat:
+  #   base_url: https://api.dify.ai/v1
+  #   api_key_env: DIFY_API_KEY
+  #   user: vox-radio            # 利用者識別子（省略時は vox-radio）
+  #   inputs:                    # Dify アプリに渡す変数（省略可）
+  #     temperature: "${temperature}"   # 完全一致なので数値で送信
+  #     lang: ja
 
 # VOICEVOX 音声合成エンジンの接続設定
 voicevox:

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -44,15 +44,36 @@ func setupLogger(commandName string, logDir string) (*slog.Logger, *os.File, err
 }
 
 func newLLMClient(cfg *config.Config) llm.Client {
-	apiKey := os.Getenv(cfg.LLM.APIKeyEnv)
-	return llm.NewClient(llm.Config{
-		BaseURL:              cfg.LLM.BaseURL,
-		APIKey:               apiKey,
-		Model:                cfg.LLM.Model,
+	llmCfg := llm.Config{
+		Provider:             cfg.LLM.EffectiveProvider(),
 		Temperature:          cfg.LLM.Temperature,
 		MaxRetries:           cfg.LLM.MaxRetries,
 		MinRequestIntervalMS: cfg.LLM.EffectiveMinRequestIntervalMS(),
-	})
+	}
+
+	switch llmCfg.Provider {
+	case config.ProviderDifyChat:
+		if dc := cfg.LLM.DifyChat; dc != nil {
+			user := dc.User
+			if user == "" {
+				user = config.DefaultDifyUser
+			}
+			llmCfg.DifyChat = &llm.DifyChatClientConfig{
+				BaseURL: dc.BaseURL,
+				APIKey:  os.Getenv(dc.APIKeyEnv),
+				User:    user,
+				Inputs:  dc.Inputs,
+			}
+		}
+	default: // openai
+		if oa := cfg.LLM.OpenAI; oa != nil {
+			llmCfg.BaseURL = oa.BaseURL
+			llmCfg.APIKey = os.Getenv(oa.APIKeyEnv)
+			llmCfg.Model = oa.Model
+		}
+	}
+
+	return llm.NewClient(llmCfg)
 }
 
 func loadConfigAndProfile(profilePath string) (*config.Config, *config.Profile, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,18 +58,53 @@ type AssetsConfig struct {
 	BGM    map[string]BGMEntry    `yaml:"bgm"`
 }
 
+const (
+	// DefaultProvider is the default LLM provider when none is specified.
+	DefaultProvider = "openai"
+	// ProviderDifyChat selects the Dify chat-messages endpoint.
+	ProviderDifyChat = "dify-chat"
+	// DefaultDifyUser is the default user identifier sent to Dify when not configured.
+	DefaultDifyUser = "vox-radio"
+	// DifyTemperaturePlaceholder is the placeholder in inputs values replaced with the effective temperature.
+	DifyTemperaturePlaceholder = "${temperature}"
+)
+
 type LLMStepConfig struct {
 	Temperature *float64 `yaml:"temperature,omitempty"`
 }
 
+// OpenAIConfig holds connection settings for the OpenAI-compatible provider.
+type OpenAIConfig struct {
+	BaseURL   string `yaml:"base_url"`
+	APIKeyEnv string `yaml:"api_key_env"`
+	Model     string `yaml:"model"`
+}
+
+// DifyChatConfig holds connection settings for the Dify chat-messages provider.
+type DifyChatConfig struct {
+	BaseURL   string            `yaml:"base_url"`
+	APIKeyEnv string            `yaml:"api_key_env"`
+	User      string            `yaml:"user,omitempty"`
+	Inputs    map[string]string `yaml:"inputs,omitempty"`
+}
+
 type LLMConfig struct {
-	BaseURL              string                   `yaml:"base_url"`
-	APIKeyEnv            string                   `yaml:"api_key_env"`
-	Model                string                   `yaml:"model"`
+	Provider             string                   `yaml:"provider"`
 	Temperature          float64                  `yaml:"temperature"`
 	MaxRetries           int                      `yaml:"max_retries"`
 	MinRequestIntervalMS *int                     `yaml:"min_request_interval_ms,omitempty"`
 	Steps                map[string]LLMStepConfig `yaml:"steps"`
+	OpenAI               *OpenAIConfig            `yaml:"openai,omitempty"`
+	DifyChat             *DifyChatConfig          `yaml:"dify-chat,omitempty"`
+}
+
+// EffectiveProvider returns the resolved provider name.
+// Empty string defaults to DefaultProvider ("openai").
+func (c LLMConfig) EffectiveProvider() string {
+	if c.Provider == "" {
+		return DefaultProvider
+	}
+	return c.Provider
 }
 
 // EffectiveMinRequestIntervalMS returns the resolved minimum request interval in milliseconds.
@@ -310,6 +345,37 @@ func validateConfig(cfg *Config) error {
 	}
 	if err := validateVoicevoxPresets(cfg.Voicevox.Presets); err != nil {
 		return err
+	}
+	if err := validateLLMConfig(&cfg.LLM); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateLLMConfig(cfg *LLMConfig) error {
+	switch cfg.EffectiveProvider() {
+	case DefaultProvider:
+		if cfg.OpenAI == nil {
+			return fmt.Errorf("llm.openai block is required when provider is %q", DefaultProvider)
+		}
+		if cfg.OpenAI.BaseURL == "" {
+			return fmt.Errorf("llm.openai.base_url is required")
+		}
+		if cfg.OpenAI.APIKeyEnv == "" {
+			return fmt.Errorf("llm.openai.api_key_env is required")
+		}
+	case ProviderDifyChat:
+		if cfg.DifyChat == nil {
+			return fmt.Errorf("llm.dify-chat block is required when provider is %q", ProviderDifyChat)
+		}
+		if cfg.DifyChat.BaseURL == "" {
+			return fmt.Errorf("llm.dify-chat.base_url is required")
+		}
+		if cfg.DifyChat.APIKeyEnv == "" {
+			return fmt.Errorf("llm.dify-chat.api_key_env is required")
+		}
+	default:
+		return fmt.Errorf("unknown llm.provider %q", cfg.Provider)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -32,14 +32,20 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	t.Run("LLM", func(t *testing.T) {
-		if cfg.LLM.BaseURL == "" {
-			t.Error("LLM.BaseURL must not be empty")
+		if cfg.LLM.EffectiveProvider() == "" {
+			t.Error("LLM.EffectiveProvider() must not be empty")
 		}
-		if cfg.LLM.APIKeyEnv == "" {
-			t.Error("LLM.APIKeyEnv must not be empty")
+		if cfg.LLM.OpenAI == nil {
+			t.Fatal("LLM.OpenAI block must not be nil")
 		}
-		if cfg.LLM.Model == "" {
-			t.Error("LLM.Model must not be empty")
+		if cfg.LLM.OpenAI.BaseURL == "" {
+			t.Error("LLM.OpenAI.BaseURL must not be empty")
+		}
+		if cfg.LLM.OpenAI.APIKeyEnv == "" {
+			t.Error("LLM.OpenAI.APIKeyEnv must not be empty")
+		}
+		if cfg.LLM.OpenAI.Model == "" {
+			t.Error("LLM.OpenAI.Model must not be empty")
 		}
 		if cfg.LLM.MaxRetries <= 0 {
 			t.Error("LLM.MaxRetries must be positive")
@@ -737,5 +743,65 @@ func TestLoadProfile_AssetsDescription(t *testing.T) {
 	}
 	if jingle.Description == "" {
 		t.Error("Jingle[\"opening\"].Description must not be empty (testdata should include description)")
+	}
+}
+
+func TestLLMConfig_EffectiveProvider_Empty(t *testing.T) {
+	c := config.LLMConfig{}
+	if got := c.EffectiveProvider(); got != config.DefaultProvider {
+		t.Errorf("EffectiveProvider() = %q, want %q", got, config.DefaultProvider)
+	}
+}
+
+func TestLLMConfig_EffectiveProvider_OpenAI(t *testing.T) {
+	c := config.LLMConfig{Provider: "openai"}
+	if got := c.EffectiveProvider(); got != "openai" {
+		t.Errorf("EffectiveProvider() = %q, want %q", got, "openai")
+	}
+}
+
+func TestLLMConfig_EffectiveProvider_DifyChat(t *testing.T) {
+	c := config.LLMConfig{Provider: config.ProviderDifyChat}
+	if got := c.EffectiveProvider(); got != config.ProviderDifyChat {
+		t.Errorf("EffectiveProvider() = %q, want %q", got, config.ProviderDifyChat)
+	}
+}
+
+func TestLoadConfig_DifyChat(t *testing.T) {
+	cfg, err := config.LoadConfig("testdata/config_dify_chat.yaml")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.LLM.EffectiveProvider() != config.ProviderDifyChat {
+		t.Errorf("provider = %q, want %q", cfg.LLM.EffectiveProvider(), config.ProviderDifyChat)
+	}
+	if cfg.LLM.DifyChat == nil {
+		t.Fatal("LLM.DifyChat must not be nil")
+	}
+	if cfg.LLM.DifyChat.BaseURL == "" {
+		t.Error("LLM.DifyChat.BaseURL must not be empty")
+	}
+	if cfg.LLM.DifyChat.APIKeyEnv == "" {
+		t.Error("LLM.DifyChat.APIKeyEnv must not be empty")
+	}
+	if cfg.LLM.DifyChat.User != "vox-radio" {
+		t.Errorf("LLM.DifyChat.User = %q, want %q", cfg.LLM.DifyChat.User, "vox-radio")
+	}
+	if len(cfg.LLM.DifyChat.Inputs) == 0 {
+		t.Error("LLM.DifyChat.Inputs must not be empty")
+	}
+}
+
+func TestLoadConfig_ValidationError_MissingOpenAIBlock(t *testing.T) {
+	_, err := config.LoadConfig("testdata/config_missing_openai_block.yaml")
+	if err == nil {
+		t.Error("expected error when openai provider has no openai block")
+	}
+}
+
+func TestLoadConfig_ValidationError_MissingDifyChatBlock(t *testing.T) {
+	_, err := config.LoadConfig("testdata/config_missing_dify_block.yaml")
+	if err == nil {
+		t.Error("expected error when dify-chat provider has no dify-chat block")
 	}
 }

--- a/internal/config/testdata/config_dify_chat.yaml
+++ b/internal/config/testdata/config_dify_chat.yaml
@@ -1,16 +1,17 @@
 llm:
-  provider: openai
+  provider: dify-chat
   temperature: 0.7
   max_retries: 3
   steps:
     summarize: { temperature: 0.2 }
-    plan:      { temperature: 0.4 }
     write:     { temperature: 0.8 }
-    direct:    { temperature: 0.2 }
-  openai:
-    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
-    api_key_env: GEMINI_API_KEY
-    model: gemini-3.1-flash-lite
+  dify-chat:
+    base_url: https://api.dify.ai/v1
+    api_key_env: DIFY_API_KEY
+    user: vox-radio
+    inputs:
+      temperature: "${temperature}"
+      lang: ja
 
 voicevox:
   url: http://localhost:50021
@@ -20,9 +21,7 @@ characters:
     name: ずんだもん
     pronoun: ボク
     speech_suffix: ["〜のだ", "〜なのだ"]
-    personality: ["元気", "明るい", "素直", "前向き"]
+    personality: ["元気", "明るい"]
     default_style: ノーマル
     styles:
       ノーマル: 3
-      あまあま: 1
-      なみだめ: 76

--- a/internal/config/testdata/config_invalid_default_style.yaml
+++ b/internal/config/testdata/config_invalid_default_style.yaml
@@ -1,11 +1,13 @@
 llm:
-  base_url: https://example.com
-  api_key_env: TEST_KEY
-  model: test-model
+  provider: openai
   temperature: 0.7
   max_retries: 3
   steps:
     summarize: { temperature: 0.2 }
+  openai:
+    base_url: https://example.com
+    api_key_env: TEST_KEY
+    model: test-model
 
 voicevox:
   url: http://localhost:50021

--- a/internal/config/testdata/config_missing_dify_block.yaml
+++ b/internal/config/testdata/config_missing_dify_block.yaml
@@ -1,19 +1,12 @@
 llm:
-  provider: openai
+  provider: dify-chat
   temperature: 0.7
   max_retries: 3
   steps:
     write: { temperature: 0.8 }
-  openai:
-    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
-    api_key_env: GEMINI_API_KEY
-    model: gemini-3.1-flash-lite
 
 voicevox:
   url: http://localhost:50021
-  presets:
-    pitch:
-      超高め: 0.5  # out of range [-0.15, 0.15]
 
 characters:
   zundamon:

--- a/internal/config/testdata/config_missing_openai_block.yaml
+++ b/internal/config/testdata/config_missing_openai_block.yaml
@@ -4,16 +4,9 @@ llm:
   max_retries: 3
   steps:
     write: { temperature: 0.8 }
-  openai:
-    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
-    api_key_env: GEMINI_API_KEY
-    model: gemini-3.1-flash-lite
 
 voicevox:
   url: http://localhost:50021
-  presets:
-    pitch:
-      超高め: 0.5  # out of range [-0.15, 0.15]
 
 characters:
   zundamon:

--- a/internal/config/testdata/config_unknown_key.yaml
+++ b/internal/config/testdata/config_unknown_key.yaml
@@ -1,7 +1,5 @@
 llm:
-  base_url: https://generativelanguage.googleapis.com/v1beta/openai/
-  api_key_env: GEMINI_API_KEY
-  model: gemini-3.1-flash-lite
+  provider: openai
   temperature: 0.7
   max_retries: 3
   steps:
@@ -10,6 +8,10 @@ llm:
     write:     { temperature: 0.8 }
     direct:    { temperature: 0.2 }
   typo_unknown_field: should_cause_strict_error
+  openai:
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+    api_key_env: GEMINI_API_KEY
+    model: gemini-3.1-flash-lite
 
 voicevox:
   url: http://localhost:50021

--- a/internal/config/testdata/config_with_interval.yaml
+++ b/internal/config/testdata/config_with_interval.yaml
@@ -1,7 +1,5 @@
 llm:
-  base_url: https://generativelanguage.googleapis.com/v1beta/openai/
-  api_key_env: GEMINI_API_KEY
-  model: gemini-3.1-flash-lite
+  provider: openai
   temperature: 0.7
   max_retries: 3
   min_request_interval_ms: 2000
@@ -10,6 +8,10 @@ llm:
     plan:      { temperature: 0.4 }
     write:     { temperature: 0.8 }
     direct:    { temperature: 0.2 }
+  openai:
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+    api_key_env: GEMINI_API_KEY
+    model: gemini-3.1-flash-lite
 
 voicevox:
   url: http://localhost:50021

--- a/internal/config/testdata/config_with_presets.yaml
+++ b/internal/config/testdata/config_with_presets.yaml
@@ -1,13 +1,15 @@
 llm:
-  base_url: https://generativelanguage.googleapis.com/v1beta/openai/
-  api_key_env: GEMINI_API_KEY
-  model: gemini-3.1-flash-lite
+  provider: openai
   temperature: 0.7
   max_retries: 3
   steps:
     summarize: { temperature: 0.2 }
     write:     { temperature: 0.8 }
     direct:    { temperature: 0.2 }
+  openai:
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+    api_key_env: GEMINI_API_KEY
+    model: gemini-3.1-flash-lite
 
 voicevox:
   url: http://localhost:50021

--- a/internal/script/llm/client.go
+++ b/internal/script/llm/client.go
@@ -39,13 +39,6 @@ type Config struct {
 	DifyChat             *DifyChatClientConfig
 }
 
-func (c Config) effectiveProvider() string {
-	if c.Provider == "" {
-		return "openai"
-	}
-	return c.Provider
-}
-
 // throttler manages rate limiting for LLM API calls.
 type throttler struct {
 	minIntervalMS int
@@ -88,8 +81,9 @@ type openAIClient struct {
 }
 
 // NewClient creates a new LLM client, selecting the implementation based on Config.Provider.
+// Empty Provider defaults to the OpenAI-compatible implementation.
 func NewClient(cfg Config) Client {
-	switch cfg.effectiveProvider() {
+	switch cfg.Provider {
 	case "dify-chat":
 		return newDifyChatClient(cfg)
 	default:
@@ -201,14 +195,17 @@ func (c *openAIClient) callAPI(ctx context.Context, req CompletionRequest, msgs 
 		Temperature: temperature,
 	}
 
-	apiReq.ResponseFormat = &responseFormat{Type: "json_object"}
 	if len(req.JSONSchema) > 0 {
-		apiReq.ResponseFormat.Type = "json_schema"
-		apiReq.ResponseFormat.JSONSchema = &schemaSpec{
-			Name:   "output",
-			Schema: req.JSONSchema,
-			Strict: true,
+		apiReq.ResponseFormat = &responseFormat{
+			Type: "json_schema",
+			JSONSchema: &schemaSpec{
+				Name:   "output",
+				Schema: req.JSONSchema,
+				Strict: true,
+			},
 		}
+	} else {
+		apiReq.ResponseFormat = &responseFormat{Type: "json_object"}
 	}
 
 	body, err := json.Marshal(apiReq)

--- a/internal/script/llm/client.go
+++ b/internal/script/llm/client.go
@@ -19,26 +19,85 @@ const (
 	DefaultModel   = "gemini-3.1-flash-lite"
 )
 
-// Config holds the settings for the OpenAI-compatible LLM client.
+// DifyChatClientConfig holds connection settings for the Dify chat-messages provider.
+type DifyChatClientConfig struct {
+	BaseURL string
+	APIKey  string
+	User    string
+	Inputs  map[string]string
+}
+
+// Config holds the settings for the LLM client factory.
 type Config struct {
+	Provider             string
 	BaseURL              string
 	APIKey               string
 	Model                string
 	MaxRetries           int
 	Temperature          float64
 	MinRequestIntervalMS int
+	DifyChat             *DifyChatClientConfig
+}
+
+func (c Config) effectiveProvider() string {
+	if c.Provider == "" {
+		return "openai"
+	}
+	return c.Provider
+}
+
+// throttler manages rate limiting for LLM API calls.
+type throttler struct {
+	minIntervalMS int
+	mu            sync.Mutex
+	lastTime      time.Time
+}
+
+func (t *throttler) throttle(ctx context.Context) error {
+	if t.minIntervalMS <= 0 {
+		return nil
+	}
+	interval := time.Duration(t.minIntervalMS) * time.Millisecond
+
+	t.mu.Lock()
+	now := time.Now()
+	next := t.lastTime.Add(interval)
+	if next.Before(now) {
+		next = now
+	}
+	t.lastTime = next
+	t.mu.Unlock()
+
+	waitDur := time.Until(next)
+	if waitDur <= 0 {
+		return nil
+	}
+	select {
+	case <-time.After(waitDur):
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 type openAIClient struct {
-	cfg             Config
-	hc              *http.Client
-	endpoint        string
-	mu              sync.Mutex
-	lastRequestTime time.Time
+	cfg      Config
+	hc       *http.Client
+	endpoint string
+	throttler
 }
 
-// NewClient creates a new OpenAI-compatible LLM client.
+// NewClient creates a new LLM client, selecting the implementation based on Config.Provider.
 func NewClient(cfg Config) Client {
+	switch cfg.effectiveProvider() {
+	case "dify-chat":
+		return newDifyChatClient(cfg)
+	default:
+		return newOpenAIClient(cfg)
+	}
+}
+
+func newOpenAIClient(cfg Config) Client {
 	if cfg.BaseURL == "" {
 		cfg.BaseURL = DefaultBaseURL
 	}
@@ -46,9 +105,10 @@ func NewClient(cfg Config) Client {
 		cfg.Model = DefaultModel
 	}
 	return &openAIClient{
-		cfg:      cfg,
-		hc:       &http.Client{Timeout: 60 * time.Second},
-		endpoint: strings.TrimRight(cfg.BaseURL, "/") + "/chat/completions",
+		cfg:       cfg,
+		hc:        &http.Client{Timeout: 60 * time.Second},
+		endpoint:  strings.TrimRight(cfg.BaseURL, "/") + "/chat/completions",
+		throttler: throttler{minIntervalMS: cfg.MinRequestIntervalMS},
 	}
 }
 
@@ -118,36 +178,6 @@ func (c *openAIClient) Complete(ctx context.Context, req CompletionRequest) (jso
 	}
 
 	return nil, fmt.Errorf("validation failed after %d retries", c.cfg.MaxRetries)
-}
-
-// throttle ensures the minimum interval between requests is respected.
-// It reserves a time slot under the mutex and waits outside of it,
-// respecting context cancellation.
-func (c *openAIClient) throttle(ctx context.Context) error {
-	if c.cfg.MinRequestIntervalMS <= 0 {
-		return nil
-	}
-	interval := time.Duration(c.cfg.MinRequestIntervalMS) * time.Millisecond
-
-	c.mu.Lock()
-	now := time.Now()
-	next := c.lastRequestTime.Add(interval)
-	if next.Before(now) {
-		next = now
-	}
-	c.lastRequestTime = next
-	c.mu.Unlock()
-
-	waitDur := time.Until(next)
-	if waitDur <= 0 {
-		return nil
-	}
-	select {
-	case <-time.After(waitDur):
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
 }
 
 func (c *openAIClient) callAPI(ctx context.Context, req CompletionRequest, msgs []Message) (json.RawMessage, error) {

--- a/internal/script/llm/dify_chat.go
+++ b/internal/script/llm/dify_chat.go
@@ -93,7 +93,7 @@ func (c *difyChatClient) Complete(ctx context.Context, req CompletionRequest) (j
 	return nil, fmt.Errorf("validation failed after %d retries", c.cfg.MaxRetries)
 }
 
-func (c *difyChatClient) callDify(ctx context.Context, query, conversationID string, inputs map[string]interface{}) (json.RawMessage, string, error) {
+func (c *difyChatClient) callDify(ctx context.Context, query, conversationID string, inputs map[string]any) (json.RawMessage, string, error) {
 	if err := c.throttle(ctx); err != nil {
 		return nil, "", err
 	}
@@ -129,8 +129,8 @@ func buildDifyQuery(msgs []Message) string {
 
 // buildDifyInputs resolves ${temperature} placeholders in input values and returns map[string]any.
 // Exact match → float64 (JSON number); partial match → string interpolation; no match → original string.
-func buildDifyInputs(inputs map[string]string, temperature float64) map[string]interface{} {
-	result := make(map[string]interface{}, len(inputs))
+func buildDifyInputs(inputs map[string]string, temperature float64) map[string]any {
+	result := make(map[string]any, len(inputs))
 	tempStr := strconv.FormatFloat(temperature, 'f', -1, 64)
 	for k, v := range inputs {
 		if v == difyTemperaturePlaceholder {

--- a/internal/script/llm/dify_chat.go
+++ b/internal/script/llm/dify_chat.go
@@ -31,23 +31,17 @@ func newDifyChatClient(cfg Config) Client {
 	if user == "" {
 		user = "vox-radio"
 	}
-	dcCfg := DifyChatClientConfig{
-		BaseURL: dc.BaseURL,
-		APIKey:  dc.APIKey,
-		User:    user,
-		Inputs:  dc.Inputs,
-	}
 
 	bc, _ := dify.NewClient(dify.ClientConfig{
-		ApiServer: dcCfg.BaseURL,
-		ApiKey:    dcCfg.APIKey,
-		User:      dcCfg.User,
+		ApiServer: dc.BaseURL,
+		ApiKey:    dc.APIKey,
+		User:      user,
 		Timeout:   60 * time.Second,
 	})
 
 	return &difyChatClient{
 		cfg:        cfg,
-		dcCfg:      dcCfg,
+		dcCfg:      DifyChatClientConfig{BaseURL: dc.BaseURL, APIKey: dc.APIKey, User: user, Inputs: dc.Inputs},
 		baseClient: bc,
 		throttler:  throttler{minIntervalMS: cfg.MinRequestIntervalMS},
 	}

--- a/internal/script/llm/dify_chat.go
+++ b/internal/script/llm/dify_chat.go
@@ -1,0 +1,151 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	dify "github.com/safejob/dify-sdk-go"
+	"github.com/safejob/dify-sdk-go/base"
+	"github.com/safejob/dify-sdk-go/types"
+)
+
+const difyTemperaturePlaceholder = "${temperature}"
+
+type difyChatClient struct {
+	cfg        Config
+	dcCfg      DifyChatClientConfig
+	baseClient *base.Client
+	throttler
+}
+
+func newDifyChatClient(cfg Config) Client {
+	dc := cfg.DifyChat
+	if dc == nil {
+		dc = &DifyChatClientConfig{}
+	}
+	user := dc.User
+	if user == "" {
+		user = "vox-radio"
+	}
+	dcCfg := DifyChatClientConfig{
+		BaseURL: dc.BaseURL,
+		APIKey:  dc.APIKey,
+		User:    user,
+		Inputs:  dc.Inputs,
+	}
+
+	bc, _ := dify.NewClient(dify.ClientConfig{
+		ApiServer: dcCfg.BaseURL,
+		ApiKey:    dcCfg.APIKey,
+		User:      dcCfg.User,
+		Timeout:   60 * time.Second,
+	})
+
+	return &difyChatClient{
+		cfg:        cfg,
+		dcCfg:      dcCfg,
+		baseClient: bc,
+		throttler:  throttler{minIntervalMS: cfg.MinRequestIntervalMS},
+	}
+}
+
+func (c *difyChatClient) Complete(ctx context.Context, req CompletionRequest) (json.RawMessage, error) {
+	temperature := req.Temperature
+	if temperature == 0 {
+		temperature = c.cfg.Temperature
+	}
+
+	query := buildDifyQuery(req.Messages)
+	inputs := buildDifyInputs(c.dcCfg.Inputs, temperature)
+
+	if len(req.JSONSchema) == 0 {
+		raw, _, err := c.callDify(ctx, query, "", inputs)
+		return raw, err
+	}
+
+	maxRetries := c.cfg.MaxRetries
+	if maxRetries < 0 {
+		maxRetries = 0
+	}
+
+	conversationID := ""
+	currentQuery := query
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		raw, convID, err := c.callDify(ctx, currentQuery, conversationID, inputs)
+		if err != nil {
+			return nil, err
+		}
+		if conversationID == "" {
+			conversationID = convID
+		}
+
+		errs, err := validateAgainstSchema(raw, req.JSONSchema)
+		if err != nil {
+			return nil, fmt.Errorf("validate schema: %w", err)
+		}
+		if len(errs) == 0 {
+			return raw, nil
+		}
+
+		if attempt < maxRetries {
+			currentQuery = buildRepairPrompt(errs)
+		}
+	}
+
+	return nil, fmt.Errorf("validation failed after %d retries", c.cfg.MaxRetries)
+}
+
+func (c *difyChatClient) callDify(ctx context.Context, query, conversationID string, inputs map[string]interface{}) (json.RawMessage, string, error) {
+	if err := c.throttle(ctx); err != nil {
+		return nil, "", err
+	}
+
+	if c.baseClient == nil {
+		return nil, "", fmt.Errorf("dify base client not initialized")
+	}
+
+	app := c.baseClient.ChatbotApp()
+	resp, err := app.RunBlock(ctx, types.ChatRequest{
+		Query:          query,
+		Inputs:         inputs,
+		ConversationId: conversationID,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("dify run block: %w", err)
+	}
+
+	raw := json.RawMessage(resp.Answer)
+	return raw, resp.ConversationId, nil
+}
+
+// buildDifyQuery joins all message contents into a single query string.
+func buildDifyQuery(msgs []Message) string {
+	parts := make([]string, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Content != "" {
+			parts = append(parts, m.Content)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// buildDifyInputs resolves ${temperature} placeholders in input values and returns map[string]any.
+// Exact match → float64 (JSON number); partial match → string interpolation; no match → original string.
+func buildDifyInputs(inputs map[string]string, temperature float64) map[string]interface{} {
+	result := make(map[string]interface{}, len(inputs))
+	tempStr := strconv.FormatFloat(temperature, 'f', -1, 64)
+	for k, v := range inputs {
+		if v == difyTemperaturePlaceholder {
+			result[k] = temperature
+		} else if strings.Contains(v, difyTemperaturePlaceholder) {
+			result[k] = strings.ReplaceAll(v, difyTemperaturePlaceholder, tempStr)
+		} else {
+			result[k] = v
+		}
+	}
+	return result
+}

--- a/internal/script/llm/dify_chat_test.go
+++ b/internal/script/llm/dify_chat_test.go
@@ -1,0 +1,367 @@
+package llm_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// makeDifyResponse builds a minimal Dify chat-messages blocking response JSON.
+func makeDifyResponse(t *testing.T, answer, conversationID string) []byte {
+	t.Helper()
+	type resp struct {
+		Event          string `json:"event"`
+		Answer         string `json:"answer"`
+		ConversationId string `json:"conversation_id,omitempty"`
+		MessageId      string `json:"message_id"`
+		TaskId         string `json:"task_id"`
+		CreatedAt      int64  `json:"created_at"`
+	}
+	r := resp{
+		Event:          "message",
+		Answer:         answer,
+		ConversationId: conversationID,
+		MessageId:      "msg-001",
+		TaskId:         "task-001",
+		CreatedAt:      1700000000,
+	}
+	b, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal dify response: %v", err)
+	}
+	return b
+}
+
+func newDifyTestConfig(ts *httptest.Server, intervalMS int) llm.Config {
+	return llm.Config{
+		Provider: "dify-chat",
+		DifyChat: &llm.DifyChatClientConfig{
+			BaseURL: ts.URL,
+			APIKey:  "test-key",
+			User:    "test-user",
+			Inputs:  nil,
+		},
+		MaxRetries:           3,
+		MinRequestIntervalMS: intervalMS,
+	}
+}
+
+func TestDifyChatComplete_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeDifyResponse(t, `{"name":"hello"}`, "conv-001"))
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(newDifyTestConfig(ts, 0))
+	result, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{
+			{Role: "system", Content: "You are helpful."},
+			{Role: "user", Content: "Say hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != `{"name":"hello"}` {
+		t.Errorf("result = %s, want %s", string(result), `{"name":"hello"}`)
+	}
+}
+
+func TestDifyChatComplete_WithSchema_Success(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeDifyResponse(t, `{"name":"hello"}`, "conv-001"))
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(newDifyTestConfig(ts, 0))
+	result, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
+		JSONSchema: testRequiredNameSchema,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(result, &got); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if got["name"] != "hello" {
+		t.Errorf("name = %q, want %q", got["name"], "hello")
+	}
+}
+
+func TestDifyChatComplete_SchemaRetry_ConversationIDCarried(t *testing.T) {
+	var callCount atomic.Int32
+	var receivedConvIDs []string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		n := callCount.Add(1)
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+			if convID, ok := body["conversation_id"].(string); ok {
+				receivedConvIDs = append(receivedConvIDs, convID)
+			} else {
+				receivedConvIDs = append(receivedConvIDs, "")
+			}
+		}
+
+		if n == 1 {
+			_, _ = w.Write(makeDifyResponse(t, `{"wrong":"value"}`, "conv-abc"))
+		} else {
+			_, _ = w.Write(makeDifyResponse(t, `{"name":"hello"}`, "conv-abc"))
+		}
+	}))
+	defer ts.Close()
+
+	cfg := newDifyTestConfig(ts, 0)
+	cfg.MaxRetries = 3
+	c := llm.NewClient(cfg)
+
+	result, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
+		JSONSchema: testRequiredNameSchema,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(result, &got); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if got["name"] != "hello" {
+		t.Errorf("name = %q, want %q", got["name"], "hello")
+	}
+	if callCount.Load() != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount.Load())
+	}
+	// Second call should carry the conversation_id from the first response.
+	if len(receivedConvIDs) >= 2 && receivedConvIDs[1] != "conv-abc" {
+		t.Errorf("second call conversation_id = %q, want %q", receivedConvIDs[1], "conv-abc")
+	}
+}
+
+func TestDifyChatComplete_ExhaustsRetries(t *testing.T) {
+	var callCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		callCount.Add(1)
+		_, _ = w.Write(makeDifyResponse(t, `{"wrong":"value"}`, "conv-001"))
+	}))
+	defer ts.Close()
+
+	maxRetries := 2
+	cfg := newDifyTestConfig(ts, 0)
+	cfg.MaxRetries = maxRetries
+	c := llm.NewClient(cfg)
+
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: "hello"}},
+		JSONSchema: testRequiredNameSchema,
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if int(callCount.Load()) != maxRetries+1 {
+		t.Errorf("expected %d calls, got %d", maxRetries+1, callCount.Load())
+	}
+}
+
+func TestDifyChatComplete_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"code":"internal_server_error","message":"Internal server error","status":500}`))
+	}))
+	defer ts.Close()
+
+	cfg := newDifyTestConfig(ts, 0)
+	cfg.MaxRetries = 0
+	c := llm.NewClient(cfg)
+
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestDifyChatComplete_Inputs_TemperatureExact(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		_, _ = w.Write(makeDifyResponse(t, `{}`, "conv-001"))
+	}))
+	defer ts.Close()
+
+	cfg := llm.Config{
+		Provider: "dify-chat",
+		DifyChat: &llm.DifyChatClientConfig{
+			BaseURL: ts.URL,
+			APIKey:  "test-key",
+			User:    "test-user",
+			Inputs:  map[string]string{"temperature": "${temperature}", "lang": "ja"},
+		},
+		MaxRetries:           0,
+		MinRequestIntervalMS: 0,
+	}
+	c := llm.NewClient(cfg)
+
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:    []llm.Message{{Role: "user", Content: "hello"}},
+		Temperature: 0.7,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inputs, ok := receivedBody["inputs"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("inputs not found in request body")
+	}
+	// Exact match: should be float64
+	tempVal, ok := inputs["temperature"]
+	if !ok {
+		t.Fatal("temperature not found in inputs")
+	}
+	if _, ok := tempVal.(float64); !ok {
+		t.Errorf("temperature should be float64 (JSON number), got %T", tempVal)
+	}
+	if tempVal.(float64) != 0.7 {
+		t.Errorf("temperature = %v, want 0.7", tempVal)
+	}
+	// lang should be string
+	if inputs["lang"] != "ja" {
+		t.Errorf("lang = %v, want %q", inputs["lang"], "ja")
+	}
+}
+
+func TestDifyChatComplete_Inputs_TemperaturePartial(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		_, _ = w.Write(makeDifyResponse(t, `{}`, "conv-001"))
+	}))
+	defer ts.Close()
+
+	cfg := llm.Config{
+		Provider: "dify-chat",
+		DifyChat: &llm.DifyChatClientConfig{
+			BaseURL: ts.URL,
+			APIKey:  "test-key",
+			User:    "test-user",
+			Inputs:  map[string]string{"param": "temp=${temperature}"},
+		},
+		MaxRetries:           0,
+		MinRequestIntervalMS: 0,
+	}
+	c := llm.NewClient(cfg)
+
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:    []llm.Message{{Role: "user", Content: "hello"}},
+		Temperature: 0.5,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inputs, ok := receivedBody["inputs"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("inputs not found in request body")
+	}
+	// Partial match: should be string with interpolation
+	paramVal, ok := inputs["param"]
+	if !ok {
+		t.Fatal("param not found in inputs")
+	}
+	if _, ok := paramVal.(string); !ok {
+		t.Errorf("param should be string, got %T", paramVal)
+	}
+	if paramVal.(string) != "temp=0.5" {
+		t.Errorf("param = %q, want %q", paramVal.(string), "temp=0.5")
+	}
+}
+
+func TestDifyChatComplete_Inputs_NoTemperaturePlaceholder(t *testing.T) {
+	var receivedBody map[string]interface{}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		_, _ = w.Write(makeDifyResponse(t, `{}`, "conv-001"))
+	}))
+	defer ts.Close()
+
+	cfg := llm.Config{
+		Provider: "dify-chat",
+		DifyChat: &llm.DifyChatClientConfig{
+			BaseURL: ts.URL,
+			APIKey:  "test-key",
+			User:    "test-user",
+			Inputs:  map[string]string{"lang": "ja"},
+		},
+		MaxRetries:           0,
+		MinRequestIntervalMS: 0,
+	}
+	c := llm.NewClient(cfg)
+
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages:    []llm.Message{{Role: "user", Content: "hello"}},
+		Temperature: 0.7,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	inputs, ok := receivedBody["inputs"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("inputs not found in request body")
+	}
+	// No temperature placeholder: temperature should not be in inputs
+	if _, ok := inputs["temperature"]; ok {
+		t.Error("temperature should not be in inputs when no placeholder")
+	}
+	if inputs["lang"] != "ja" {
+		t.Errorf("lang = %v, want %q", inputs["lang"], "ja")
+	}
+}
+
+func TestDifyChatComplete_Throttle(t *testing.T) {
+	var callCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeDifyResponse(t, `{}`, "conv-001"))
+	}))
+	defer ts.Close()
+
+	cfg := newDifyTestConfig(ts, 50)
+	c := llm.NewClient(cfg)
+
+	req := llm.CompletionRequest{Messages: []llm.Message{{Role: "user", Content: "hello"}}}
+
+	_, err := c.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("first request failed: %v", err)
+	}
+	_, err = c.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("second request failed: %v", err)
+	}
+
+	if callCount.Load() != 2 {
+		t.Errorf("expected 2 requests, got %d", callCount.Load())
+	}
+}

--- a/internal/script/llm/dify_chat_test.go
+++ b/internal/script/llm/dify_chat_test.go
@@ -105,7 +105,7 @@ func TestDifyChatComplete_SchemaRetry_ConversationIDCarried(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		n := callCount.Add(1)
 
-		var body map[string]interface{}
+		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
 			if convID, ok := body["conversation_id"].(string); ok {
 				receivedConvIDs = append(receivedConvIDs, convID)
@@ -195,7 +195,7 @@ func TestDifyChatComplete_APIError(t *testing.T) {
 }
 
 func TestDifyChatComplete_Inputs_TemperatureExact(t *testing.T) {
-	var receivedBody map[string]interface{}
+	var receivedBody map[string]any
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -225,7 +225,7 @@ func TestDifyChatComplete_Inputs_TemperatureExact(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	inputs, ok := receivedBody["inputs"].(map[string]interface{})
+	inputs, ok := receivedBody["inputs"].(map[string]any)
 	if !ok {
 		t.Fatalf("inputs not found in request body")
 	}
@@ -247,7 +247,7 @@ func TestDifyChatComplete_Inputs_TemperatureExact(t *testing.T) {
 }
 
 func TestDifyChatComplete_Inputs_TemperaturePartial(t *testing.T) {
-	var receivedBody map[string]interface{}
+	var receivedBody map[string]any
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -277,7 +277,7 @@ func TestDifyChatComplete_Inputs_TemperaturePartial(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	inputs, ok := receivedBody["inputs"].(map[string]interface{})
+	inputs, ok := receivedBody["inputs"].(map[string]any)
 	if !ok {
 		t.Fatalf("inputs not found in request body")
 	}
@@ -295,7 +295,7 @@ func TestDifyChatComplete_Inputs_TemperaturePartial(t *testing.T) {
 }
 
 func TestDifyChatComplete_Inputs_NoTemperaturePlaceholder(t *testing.T) {
-	var receivedBody map[string]interface{}
+	var receivedBody map[string]any
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -325,7 +325,7 @@ func TestDifyChatComplete_Inputs_NoTemperaturePlaceholder(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	inputs, ok := receivedBody["inputs"].(map[string]interface{})
+	inputs, ok := receivedBody["inputs"].(map[string]any)
 	if !ok {
 		t.Fatalf("inputs not found in request body")
 	}
@@ -335,6 +335,38 @@ func TestDifyChatComplete_Inputs_NoTemperaturePlaceholder(t *testing.T) {
 	}
 	if inputs["lang"] != "ja" {
 		t.Errorf("lang = %v, want %q", inputs["lang"], "ja")
+	}
+}
+
+func TestDifyChatComplete_QueryBuildsFromMessages(t *testing.T) {
+	var receivedQuery string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+			if q, ok := body["query"].(string); ok {
+				receivedQuery = q
+			}
+		}
+		_, _ = w.Write(makeDifyResponse(t, `{}`, "conv-001"))
+	}))
+	defer ts.Close()
+
+	c := llm.NewClient(newDifyTestConfig(ts, 0))
+	_, err := c.Complete(context.Background(), llm.CompletionRequest{
+		Messages: []llm.Message{
+			{Role: "system", Content: "You are helpful."},
+			{Role: "user", Content: "Say hello"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := "You are helpful.\n\nSay hello"
+	if receivedQuery != want {
+		t.Errorf("query = %q, want %q", receivedQuery, want)
 	}
 }
 

--- a/vox-radio.yaml
+++ b/vox-radio.yaml
@@ -5,9 +5,7 @@ cache:
   llm_context_entries: 10  # LLM へ渡す直近エピソード件数
 
 llm:
-  base_url: https://generativelanguage.googleapis.com/v1beta/openai/
-  api_key_env: GEMINI_API_KEY
-  model: gemini-3.1-flash-lite
+  provider: openai            # or dify-chat
   temperature: 0.7
   max_retries: 3
   min_request_interval_ms: 4500
@@ -16,6 +14,17 @@ llm:
     plan:      { temperature: 0.4 }
     write:     { temperature: 0.8 }
     direct:    { temperature: 0.2 }
+  openai:
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+    api_key_env: GEMINI_API_KEY
+    model: gemini-3.1-flash-lite
+  # dify-chat:
+  #   base_url: https://api.dify.ai/v1
+  #   api_key_env: DIFY_API_KEY
+  #   user: vox-radio            # 利用者識別子（省略時は vox-radio）
+  #   inputs:
+  #     temperature: "${temperature}"   # 完全一致なので数値で送信
+  #     lang: ja
 
 voicevox:
   url: http://voicevox:50021


### PR DESCRIPTION
## Summary

- `LLMConfig` を provider 別ブロック構成（`openai` / `dify-chat`）に再編（破壊的変更、既存設定は `openai` ブロックへ移行）
- `provider: dify-chat` 設定時に `safejob/dify-sdk-go` 経由で Dify chat-messages エンドポイントを呼び出す `difyChatClient` を追加
- `inputs` の `${temperature}` プレースホルダーで per-step 温度を渡す（完全一致→JSON数値、部分一致→文字列補間）
- スキーマ検証失敗時は `conversation_id` 引き継ぎで修復リトライ（既存の `validateAgainstSchema`/`buildRepairPrompt` を共有）
- `throttler` を共通埋め込み struct として OpenAI/Dify 両実装で共有
- `vox-radio.yaml`・init テンプレート・README を新ブロック構成に合わせて更新

## Test plan

- [ ] `go test ./...` が全パス（CI 確認）
- [ ] `internal/config` — `EffectiveProvider`/バリデーション（openai・dify-chat・欠落ブロック）
- [ ] `internal/script/llm` — `difyChatClient`: 成功・スキーマ検証+リトライ・API エラー・`${temperature}` 各パターン・スロットル・クエリ結合
- [ ] `provider: openai`（既定）で従来どおり動作することを既存テストで確認

Closes #161

---
🤖 Generated with [Claude Code](https://claude.ai/code)