### PR TITLE
feat: 動作確認用に make run-sample で sample-profile を使った run を実行できるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 BINARY_NAME=vox-radio
 VERSION ?= dev
 LDFLAGS=-X github.com/canpok1/vox-radio/internal/cli.version=$(VERSION)
+PROFILE ?= sample-profiles/tech_profile.yaml
+OUT_DIR ?= output/$(shell date +%Y%m%d%H%M%S)
 
 setup:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
@@ -27,6 +29,9 @@ install:
 docs:
 	go run ./tools/gendocs
 
+run-sample: build
+	./$(BINARY_NAME) run --profile "$(PROFILE)" --out-dir "$(OUT_DIR)"
+
 check-samples: build
 	./$(BINARY_NAME) config check vox-radio.yaml
 	./$(BINARY_NAME) config check internal/cli/templates/vox-radio.yaml
@@ -35,4 +40,4 @@ check-samples: build
 
 all: build
 
-.PHONY: all setup build clean test fmt lint install docs check-samples
+.PHONY: all setup build clean test fmt lint install docs check-samples run-sample

--- a/README.md
+++ b/README.md
@@ -45,6 +45,28 @@ make build VERSION=v0.1.0
 vox-radio --version
 ```
 
+### 動作確認用サンプル実行
+
+`sample-profiles/tech_profile.yaml` を使ってパイプライン全体を試すには `make run-sample` を実行します。
+
+```bash
+make run-sample
+```
+
+出力先は `output/<YYYYMMDDHHMMSS>/` ディレクトリになります（例: `output/20260601053357/episode.mp3`）。
+
+プロファイルや出力先を変更する場合は `PROFILE` / `OUT_DIR` 変数で上書きできます。
+
+```bash
+# 別のプロファイルを使う
+make run-sample PROFILE=sample-profiles/other_profile.yaml
+
+# 出力先を指定する
+make run-sample OUT_DIR=output/test
+```
+
+> **前提条件:** `GEMINI_API_KEY` 環境変数と VOICEVOX Engine が必要です。
+
 ### パイプライン概要
 
 vox-radio は以下のパイプラインでポッドキャストを自動生成します。


### PR DESCRIPTION
## Summary

- `Makefile` に `run-sample` ターゲットを追加し、`make run-sample` で `sample-profiles/tech_profile.yaml` を使ったパイプライン全体の実行を可能にした
- `PROFILE` / `OUT_DIR` 変数でプロファイルと出力先を上書き可能
- 出力先は `output/<YYYYMMDDHHMMSS>/` 形式（例: `output/20260601053357/episode.mp3`）
- README に動作確認用サンプル実行の使い方を追記した

Closes #163

---
🤖 Generated with [Claude Code](https://claude.ai/code)