### PR TITLE
feat: ログ出力先のデフォルトを .vox-radio/logs に変更する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,8 @@ go.work.sum
 # vox-radio キャッシュ
 .vox-radio/
 
-# 生成物（中間生成物・最終成果物・ログ）
+# 生成物（中間生成物・最終成果物）
 output/
-logs/
 
 # Claudeのスケジュールされたタスクのロックファイル
 .claude/scheduled_tasks.lock

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -33,12 +33,14 @@ func readJSON[T any](path string) (T, error) {
 	return v, nil
 }
 
+const defaultLogDir = ".vox-radio/logs"
+
 // setupLogger creates a fan-out logger (stderr INFO+, logFile DEBUG+) and returns it with the
 // log file handle. The caller must close the file when done.
-// logDir defaults to "./logs" if empty.
+// logDir defaults to ".vox-radio/logs" if empty.
 func setupLogger(commandName string, logDir string) (*slog.Logger, *os.File, error) {
 	if logDir == "" {
-		logDir = "logs"
+		logDir = defaultLogDir
 	}
 	return logging.NewSetup(time.Now(), commandName, logDir)
 }

--- a/internal/cli/util_test.go
+++ b/internal/cli/util_test.go
@@ -1,0 +1,42 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetupLogger_DefaultLogDir(t *testing.T) {
+	// os.Chdir changes the process-wide cwd, so no t.Parallel().
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("chdir to tmpDir: %v", err)
+	}
+	defer func() {
+		_ = os.Chdir(origDir)
+	}()
+
+	logger, f, err := setupLogger("collect", "")
+	if err != nil {
+		t.Fatalf("setupLogger: %v", err)
+	}
+	defer f.Close()
+
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+
+	logPath, err := filepath.Abs(f.Name())
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	wantPrefix := filepath.Join(tmpDir, ".vox-radio", "logs")
+	if !strings.HasPrefix(logPath, wantPrefix) {
+		t.Errorf("log file path %q does not start with %q", logPath, wantPrefix)
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/cli/util.go` に `const defaultLogDir = ".vox-radio/logs"` を追加し、`setupLogger` のフォールバックを `"logs"` から `defaultLogDir` に変更
- `setupLogger` のコメントを `.vox-radio/logs` を指すよう更新
- `internal/cli/util_test.go` を新規作成し、空文字 `logDir` を渡したときに `.vox-radio/logs` 配下にログファイルが作られることを TDD で検証
- `.gitignore` から `logs/` を削除（`.vox-radio/` で既にカバーされるため）、コメント文言を調整

Closes #168

---
🤖 Generated with [Claude Code](https://claude.ai/code)