### PR TITLE
fix: コーナー切替時のBGM停止を「次にBGMが無くなる時」だけに変更し、停止→再生でBGMが鳴らないバグを修正

### DIFF
--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -350,7 +350,7 @@ func buildRun(b *filterBuilder, run runData, clipInputIdx []int, assets config.A
 				bgmFullLabel = bgmParts[0]
 			} else {
 				bgmFullLabel = fmt.Sprintf("[run%d_bgm_full]", runIdx)
-				b.addFilter(fmt.Sprintf("%samix=inputs=%d:duration=first:normalize=0%s",
+				b.addFilter(fmt.Sprintf("%samix=inputs=%d:duration=longest:normalize=0%s",
 					strings.Join(bgmParts, ""), len(bgmParts), bgmFullLabel))
 			}
 

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -1062,11 +1062,8 @@ func TestBuildFFmpegArgs_BGMStopThenPlay_BothIntervalsInOutput(t *testing.T) {
 	filters := strings.Split(args.FilterComplex, ";")
 	for _, f := range filters {
 		if strings.Contains(f, "bgm0_raw") && strings.Contains(f, "bgm1_raw") {
-			if strings.Contains(f, "duration=first") {
-				t.Errorf("BGM interval amix must not use duration=first (truncates 2nd interval): %s", f)
-			}
 			if !strings.Contains(f, "duration=longest") {
-				t.Errorf("BGM interval amix must use duration=longest: %s", f)
+				t.Errorf("BGM interval amix must use duration=longest (not duration=first): %s", f)
 			}
 		}
 	}

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -1009,6 +1009,69 @@ func TestBuildFFmpegArgs_BGMLoop_StreamLoop(t *testing.T) {
 	}
 }
 
+// TestBuildFFmpegArgs_BGMStopThenPlay_BothIntervalsInOutput verifies that when BGM stops
+// and restarts within one run, both intervals appear in the filter output.
+// This is a regression test for the bug where amix with duration=first truncated
+// the second and later BGM intervals.
+func TestBuildFFmpegArgs_BGMStopThenPlay_BothIntervalsInOutput(t *testing.T) {
+	// Script: BGM(a), speech1, BGM(""), speech2, BGM(a), speech3
+	// Interval 1: [0, ~2500ms], Interval 2: [~6000ms, end]
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeBGM, AssetName: "talk_bgm"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "with bgm"},
+				{Type: model.SegmentTypeBGM, AssetName: ""},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "no bgm"},
+				{Type: model.SegmentTypeBGM, AssetName: "talk_bgm"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "bgm again"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
+				{Index: 2, File: "clip_002.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			BGM: map[string]config.BGMEntry{
+				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// speech1(2s) + pauseSec(0.5s) = 2500ms → BGM stop
+	// speech2(3s) + pauseSec(0.5s) = 3500ms → BGM restart at 2500+3500=6000ms
+	// 2nd interval adelay should be 6000ms
+	if !strings.Contains(args.FilterComplex, "adelay=6000|6000") {
+		t.Errorf("2nd BGM interval should have adelay=6000 (started after speech1+pause+speech2+pause), filter: %s", args.FilterComplex)
+	}
+
+	// The filter that merges the two BGM raw intervals (bgm0_raw + bgm1_raw) must use
+	// duration=longest so neither interval is truncated.
+	// (The later BGM×speech amix intentionally uses duration=first; only the interval merge is checked here.)
+	filters := strings.Split(args.FilterComplex, ";")
+	for _, f := range filters {
+		if strings.Contains(f, "bgm0_raw") && strings.Contains(f, "bgm1_raw") {
+			if strings.Contains(f, "duration=first") {
+				t.Errorf("BGM interval amix must not use duration=first (truncates 2nd interval): %s", f)
+			}
+			if !strings.Contains(f, "duration=longest") {
+				t.Errorf("BGM interval amix must use duration=longest: %s", f)
+			}
+		}
+	}
+}
+
 // TestBuildFFmpegArgs_BGMNoLoop_NoStreamLoop verifies that loop:false BGM does NOT
 // get -stream_loop -1 (it should play once and stop).
 func TestBuildFFmpegArgs_BGMNoLoop_NoStreamLoop(t *testing.T) {

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -151,18 +151,23 @@ func buildScript(corners []model.CornerLines, insertions []insertion, pauseInser
 
 	segments := make([]model.ScriptSegment, 0, len(insertions)+len(pauseInsertions)+len(corners)*4)
 
+	activeBGM := ""
+
 	for ci, corner := range corners {
 		if corner.StartJingle != "" {
 			segments = append(segments, model.ScriptSegment{
 				Type:      model.SegmentTypeJingle,
 				AssetName: corner.StartJingle,
 			})
+			activeBGM = ""
 		}
-		if corner.BGM != "" {
+
+		if corner.BGM != activeBGM {
 			segments = append(segments, model.ScriptSegment{
 				Type:      model.SegmentTypeBGM,
 				AssetName: corner.BGM,
 			})
+			activeBGM = corner.BGM
 		}
 
 		for li, line := range corner.Lines {
@@ -190,17 +195,12 @@ func buildScript(corners []model.CornerLines, insertions []insertion, pauseInser
 			}
 		}
 
-		if corner.BGM != "" {
-			segments = append(segments, model.ScriptSegment{
-				Type:      model.SegmentTypeBGM,
-				AssetName: "",
-			})
-		}
 		if corner.EndJingle != "" {
 			segments = append(segments, model.ScriptSegment{
 				Type:      model.SegmentTypeJingle,
 				AssetName: corner.EndJingle,
 			})
+			activeBGM = ""
 		}
 	}
 

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -127,18 +127,15 @@ func TestLLMDirector_Direct_CornerBGMWrapsContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// [bgm(start), speech, bgm(stop)]
-	if len(got.Segments) != 3 {
-		t.Fatalf("Segments: got %d, want 3", len(got.Segments))
+	// [bgm(start), speech] — single/last corner: no trailing BGM stop
+	if len(got.Segments) != 2 {
+		t.Fatalf("Segments: got %d, want 2", len(got.Segments))
 	}
 	if got.Segments[0].Type != model.SegmentTypeBGM || got.Segments[0].AssetName != "talk_bgm" {
 		t.Errorf("Segment[0]: got %+v, want bgm(talk_bgm)", got.Segments[0])
 	}
 	if got.Segments[1].Type != model.SegmentTypeSpeech {
 		t.Errorf("Segment[1]: got %+v, want speech", got.Segments[1])
-	}
-	if got.Segments[2].Type != model.SegmentTypeBGM || got.Segments[2].AssetName != "" {
-		t.Errorf("Segment[2]: got %+v, want bgm(stop)", got.Segments[2])
 	}
 }
 
@@ -210,9 +207,9 @@ func TestLLMDirector_Direct_CornerAllAssets_CorrectOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// [jingle(op), bgm(start), speech, bgm(stop), jingle(ed)]
-	if len(got.Segments) != 5 {
-		t.Fatalf("Segments: got %d, want 5", len(got.Segments))
+	// [jingle(op), bgm(start), speech, jingle(ed)] — no BGM stop before EndJingle (filter handles it)
+	if len(got.Segments) != 4 {
+		t.Fatalf("Segments: got %d, want 4", len(got.Segments))
 	}
 	if got.Segments[0].Type != model.SegmentTypeJingle || got.Segments[0].AssetName != "op" {
 		t.Errorf("Segment[0]: want jingle(op), got %+v", got.Segments[0])
@@ -223,11 +220,8 @@ func TestLLMDirector_Direct_CornerAllAssets_CorrectOrder(t *testing.T) {
 	if got.Segments[2].Type != model.SegmentTypeSpeech {
 		t.Errorf("Segment[2]: want speech, got %+v", got.Segments[2])
 	}
-	if got.Segments[3].Type != model.SegmentTypeBGM || got.Segments[3].AssetName != "" {
-		t.Errorf("Segment[3]: want bgm(stop), got %+v", got.Segments[3])
-	}
-	if got.Segments[4].Type != model.SegmentTypeJingle || got.Segments[4].AssetName != "ed" {
-		t.Errorf("Segment[4]: want jingle(ed), got %+v", got.Segments[4])
+	if got.Segments[3].Type != model.SegmentTypeJingle || got.Segments[3].AssetName != "ed" {
+		t.Errorf("Segment[3]: want jingle(ed), got %+v", got.Segments[3])
 	}
 }
 
@@ -623,6 +617,165 @@ func TestLLMDirector_Direct_MultiCorner(t *testing.T) {
 	}
 	if got.Segments[2].Type != model.SegmentTypeSE || got.Segments[2].AssetName != "chime" {
 		t.Errorf("Segment[2] should be SE chime, got %+v", got.Segments[2])
+	}
+}
+
+// TestBuildScript_SameBGM_ContinuousPlay verifies that consecutive corners with the same BGM
+// do not insert stop/start segments between them (continuous playback).
+func TestBuildScript_SameBGM_ContinuousPlay(t *testing.T) {
+	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	corners := []model.CornerLines{
+		{Title: "C1", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
+		{Title: "C2", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
+	}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [bgm(talk_bgm), speech_c1, speech_c2] — no stop/start between corners
+	if len(got.Segments) != 3 {
+		t.Fatalf("Segments: got %d, want 3 (no BGM stop/start between same-BGM corners)\nsegments: %+v", len(got.Segments), got.Segments)
+	}
+	if got.Segments[0].Type != model.SegmentTypeBGM || got.Segments[0].AssetName != "talk_bgm" {
+		t.Errorf("Segment[0]: want bgm(talk_bgm), got %+v", got.Segments[0])
+	}
+	if got.Segments[1].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[1]: want speech, got %+v", got.Segments[1])
+	}
+	if got.Segments[2].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[2]: want speech, got %+v", got.Segments[2])
+	}
+}
+
+// TestBuildScript_DifferentBGM_SeamlessSwitch verifies that adjacent corners with different BGMs
+// switch without a stop segment (no silent gap).
+func TestBuildScript_DifferentBGM_SeamlessSwitch(t *testing.T) {
+	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	corners := []model.CornerLines{
+		{Title: "C1", BGM: "bgm_a", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
+		{Title: "C2", BGM: "bgm_b", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
+	}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [bgm(a), speech_c1, bgm(b), speech_c2] — no stop, seamless switch
+	if len(got.Segments) != 4 {
+		t.Fatalf("Segments: got %d, want 4 (BGM(a), sp1, BGM(b), sp2)\nsegments: %+v", len(got.Segments), got.Segments)
+	}
+	if got.Segments[0].Type != model.SegmentTypeBGM || got.Segments[0].AssetName != "bgm_a" {
+		t.Errorf("Segment[0]: want bgm(bgm_a), got %+v", got.Segments[0])
+	}
+	if got.Segments[1].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[1]: want speech, got %+v", got.Segments[1])
+	}
+	if got.Segments[2].Type != model.SegmentTypeBGM || got.Segments[2].AssetName != "bgm_b" {
+		t.Errorf("Segment[2]: want bgm(bgm_b), got %+v", got.Segments[2])
+	}
+	if got.Segments[3].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[3]: want speech, got %+v", got.Segments[3])
+	}
+}
+
+// TestBuildScript_BGMToNoBGM_StopAtBoundary verifies that when a BGM corner is followed by
+// a no-BGM corner, the stop segment is inserted at the beginning of the second corner.
+func TestBuildScript_BGMToNoBGM_StopAtBoundary(t *testing.T) {
+	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	corners := []model.CornerLines{
+		{Title: "C1", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
+		{Title: "C2", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
+	}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [bgm(start), speech_c1, bgm(""), speech_c2] — stop at C2 entry
+	if len(got.Segments) != 4 {
+		t.Fatalf("Segments: got %d, want 4\nsegments: %+v", len(got.Segments), got.Segments)
+	}
+	if got.Segments[0].Type != model.SegmentTypeBGM || got.Segments[0].AssetName != "talk_bgm" {
+		t.Errorf("Segment[0]: want bgm(talk_bgm), got %+v", got.Segments[0])
+	}
+	if got.Segments[1].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[1]: want speech(C1), got %+v", got.Segments[1])
+	}
+	if got.Segments[2].Type != model.SegmentTypeBGM || got.Segments[2].AssetName != "" {
+		t.Errorf("Segment[2]: want bgm(stop), got %+v", got.Segments[2])
+	}
+	if got.Segments[3].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[3]: want speech(C2), got %+v", got.Segments[3])
+	}
+}
+
+// TestBuildScript_LastCorner_NoBGMStop verifies that the last corner with BGM
+// does not get a trailing BGM stop segment.
+func TestBuildScript_LastCorner_NoBGMStop(t *testing.T) {
+	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	corners := []model.CornerLines{
+		{Title: "C1", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
+	}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [bgm(talk_bgm), speech] — no trailing BGM stop
+	if len(got.Segments) != 2 {
+		t.Fatalf("Segments: got %d, want 2 (no trailing BGM stop)\nsegments: %+v", len(got.Segments), got.Segments)
+	}
+	if got.Segments[0].Type != model.SegmentTypeBGM || got.Segments[0].AssetName != "talk_bgm" {
+		t.Errorf("Segment[0]: want bgm(talk_bgm), got %+v", got.Segments[0])
+	}
+	if got.Segments[1].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[1]: want speech, got %+v", got.Segments[1])
+	}
+}
+
+// TestBuildScript_EndJingle_ResetsBGM verifies that an EndJingle resets activeBGM,
+// causing the same BGM to restart after the jingle.
+func TestBuildScript_EndJingle_ResetsBGM(t *testing.T) {
+	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	corners := []model.CornerLines{
+		{Title: "C1", BGM: "talk_bgm", EndJingle: "jingle", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
+		{Title: "C2", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
+	}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [bgm(talk_bgm), speech_c1, jingle, bgm(talk_bgm), speech_c2]
+	// EndJingle resets activeBGM → C2 must re-emit BGM start
+	if len(got.Segments) != 5 {
+		t.Fatalf("Segments: got %d, want 5\nsegments: %+v", len(got.Segments), got.Segments)
+	}
+	if got.Segments[0].Type != model.SegmentTypeBGM || got.Segments[0].AssetName != "talk_bgm" {
+		t.Errorf("Segment[0]: want bgm(talk_bgm), got %+v", got.Segments[0])
+	}
+	if got.Segments[1].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[1]: want speech(C1), got %+v", got.Segments[1])
+	}
+	if got.Segments[2].Type != model.SegmentTypeJingle || got.Segments[2].AssetName != "jingle" {
+		t.Errorf("Segment[2]: want jingle(jingle), got %+v", got.Segments[2])
+	}
+	if got.Segments[3].Type != model.SegmentTypeBGM || got.Segments[3].AssetName != "talk_bgm" {
+		t.Errorf("Segment[3]: want bgm(talk_bgm) restart after jingle, got %+v", got.Segments[3])
+	}
+	if got.Segments[4].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[4]: want speech(C2), got %+v", got.Segments[4])
 	}
 }
 

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -281,10 +281,7 @@ func TestLLMDirector_Direct_CornerAssetFields_NotInLLMPayload(t *testing.T) {
 }
 
 func TestLLMDirector_Direct_BGMDoesNotLeakToNextCorner(t *testing.T) {
-	mc := &mockClient{
-		response: json.RawMessage(`{"insertions":[]}`),
-	}
-	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+	d := noInsertionDirector()
 
 	corners := []model.CornerLines{
 		{
@@ -302,11 +299,13 @@ func TestLLMDirector_Direct_BGMDoesNotLeakToNextCorner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// C1: [bgm(start), speech, bgm(stop)], C2: [speech]
+	// [bgm(talk_bgm), speech_c1, bgm("" stop), speech_c2] — stop emitted at C2 entry
 	if len(got.Segments) != 4 {
 		t.Fatalf("Segments: got %d, want 4", len(got.Segments))
 	}
-	// After C1 (bgm stop at index 2), C2 should just be speech
+	if got.Segments[2].Type != model.SegmentTypeBGM || got.Segments[2].AssetName != "" {
+		t.Errorf("Segment[2]: want bgm(stop), got %+v", got.Segments[2])
+	}
 	if got.Segments[3].Type != model.SegmentTypeSpeech {
 		t.Errorf("Segment[3]: want speech (C2), got %+v", got.Segments[3])
 	}

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -45,6 +45,12 @@ func emptyCatalog() model.AssetCatalog {
 	}
 }
 
+// helper: director that returns no insertions (common setup for structural tests)
+func noInsertionDirector() *direct.LLMDirector {
+	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
+	return direct.NewLLMDirector(mc, "{{corners}}", 0)
+}
+
 func TestLLMDirector_Direct_NoInsertions(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"insertions":[]}`),
@@ -623,8 +629,7 @@ func TestLLMDirector_Direct_MultiCorner(t *testing.T) {
 // TestBuildScript_SameBGM_ContinuousPlay verifies that consecutive corners with the same BGM
 // do not insert stop/start segments between them (continuous playback).
 func TestBuildScript_SameBGM_ContinuousPlay(t *testing.T) {
-	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
-	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+	d := noInsertionDirector()
 
 	corners := []model.CornerLines{
 		{Title: "C1", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
@@ -653,8 +658,7 @@ func TestBuildScript_SameBGM_ContinuousPlay(t *testing.T) {
 // TestBuildScript_DifferentBGM_SeamlessSwitch verifies that adjacent corners with different BGMs
 // switch without a stop segment (no silent gap).
 func TestBuildScript_DifferentBGM_SeamlessSwitch(t *testing.T) {
-	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
-	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+	d := noInsertionDirector()
 
 	corners := []model.CornerLines{
 		{Title: "C1", BGM: "bgm_a", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
@@ -686,8 +690,7 @@ func TestBuildScript_DifferentBGM_SeamlessSwitch(t *testing.T) {
 // TestBuildScript_BGMToNoBGM_StopAtBoundary verifies that when a BGM corner is followed by
 // a no-BGM corner, the stop segment is inserted at the beginning of the second corner.
 func TestBuildScript_BGMToNoBGM_StopAtBoundary(t *testing.T) {
-	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
-	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+	d := noInsertionDirector()
 
 	corners := []model.CornerLines{
 		{Title: "C1", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
@@ -719,8 +722,7 @@ func TestBuildScript_BGMToNoBGM_StopAtBoundary(t *testing.T) {
 // TestBuildScript_LastCorner_NoBGMStop verifies that the last corner with BGM
 // does not get a trailing BGM stop segment.
 func TestBuildScript_LastCorner_NoBGMStop(t *testing.T) {
-	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
-	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+	d := noInsertionDirector()
 
 	corners := []model.CornerLines{
 		{Title: "C1", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
@@ -745,8 +747,7 @@ func TestBuildScript_LastCorner_NoBGMStop(t *testing.T) {
 // TestBuildScript_EndJingle_ResetsBGM verifies that an EndJingle resets activeBGM,
 // causing the same BGM to restart after the jingle.
 func TestBuildScript_EndJingle_ResetsBGM(t *testing.T) {
-	mc := &mockClient{response: json.RawMessage(`{"insertions":[]}`)}
-	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+	d := noInsertionDirector()
 
 	corners := []model.CornerLines{
 		{Title: "C1", BGM: "talk_bgm", EndJingle: "jingle", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},


### PR DESCRIPTION
## Summary

- **バグ修正**: `internal/assemble/filter.go` の BGM 区間合成 `amix` を `duration=first` → `duration=longest` に変更。BGM 停止→再生が1 run 内で複数区間になったとき、2区間目以降が `duration=first` で打ち切られて無音になっていた不具合を解消。
- **仕様変更**: `internal/script/direct/direct.go` の `buildScript` に `activeBGM` 追跡ロジックを追加。コーナー終了ごとに無条件で BGM 停止セグメントを出すのをやめ、「BGM が変化するとき（または次コーナーで BGM が無くなるとき）」だけセグメントを挿入するよう変更。同じ BGM が続くコーナーでは途切れなく連続再生される。
- **テスト追加**: 回帰テスト（`filter_test.go`）、新ロジックの仕様テスト5件（`direct_test.go`）を追加。
- **既存テスト更新**: 末尾 BGM 停止が不要になった旧テスト3件の期待値を更新。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/assemble/filter.go` | BGM 区間合成 `amix` を `duration=longest` に変更 |
| `internal/assemble/filter_test.go` | BGM 停止→再生の回帰テスト追加 |
| `internal/script/direct/direct.go` | `activeBGM` 追跡ロジックを実装 |
| `internal/script/direct/direct_test.go` | 新ロジックのテスト追加、既存テスト期待値更新 |

Closes #173

---
🤖 Generated with [Claude Code](https://claude.ai/code)