### PR TITLE
refactor: writeAll の蓄積ロジックを WriteAll にまとめ CLI 経路と共有する

### DIFF
--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -131,7 +131,7 @@ func runScriptWrite(ctx context.Context, in, workDir string, c llm.Client, cfg *
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(cfg.LLM, "write"), cfg)
 	allCornerLines, err := script.WriteAll(ctx, w, p.Program, p.Corners, cornerMap, cfg.Characters)
 	if err != nil {
-		return err
+		return fmt.Errorf("write corners: %w", err)
 	}
 
 	scriptLines := model.ScriptLines{Corners: script.BuildScriptLines(p.Corners, allCornerLines)}

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -129,16 +129,9 @@ func runScriptWrite(ctx context.Context, in, workDir string, c llm.Client, cfg *
 	cornerMap := rundown.CornerMap()
 
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(cfg.LLM, "write"), cfg)
-	allCornerLines := make([][]model.Line, len(p.Corners))
-	previous := make([]model.CornerLines, 0, len(p.Corners))
-	for i, corner := range p.Corners {
-		rc := cornerMap[corner.Title]
-		lines, err := w.Write(ctx, p.Program, corner, p.Corners, previous, rc.Articles, rc.Flow, cfg.Characters)
-		if err != nil {
-			return fmt.Errorf("write corner %q: %w", corner.Title, err)
-		}
-		allCornerLines[i] = lines
-		previous = append(previous, model.CornerLines{Title: corner.Title, Lines: lines})
+	allCornerLines, err := script.WriteAll(ctx, w, p.Program, p.Corners, cornerMap, cfg.Characters)
+	if err != nil {
+		return err
 	}
 
 	scriptLines := model.ScriptLines{Corners: script.BuildScriptLines(p.Corners, allCornerLines)}

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -86,12 +86,13 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	return scr, nil
 }
 
-func (g *LLMScriptGenerator) writeAll(ctx context.Context, program config.ProgramConfig, corners []config.CornerConfig, cornerMap map[string]model.RundownCorner, chars map[string]config.CharacterConfig) ([][]model.Line, error) {
+// WriteAll writes lines for each corner in order, passing previously generated corners as context.
+func WriteAll(ctx context.Context, w write.Writer, program config.ProgramConfig, corners []config.CornerConfig, cornerMap map[string]model.RundownCorner, chars map[string]config.CharacterConfig) ([][]model.Line, error) {
 	result := make([][]model.Line, len(corners))
 	previous := make([]model.CornerLines, 0, len(corners))
 	for i, corner := range corners {
 		rc := cornerMap[corner.Title]
-		lines, err := g.writer.Write(ctx, program, corner, corners, previous, rc.Articles, rc.Flow, chars)
+		lines, err := w.Write(ctx, program, corner, corners, previous, rc.Articles, rc.Flow, chars)
 		if err != nil {
 			return nil, fmt.Errorf("write corner %q: %w", corner.Title, err)
 		}
@@ -99,6 +100,10 @@ func (g *LLMScriptGenerator) writeAll(ctx context.Context, program config.Progra
 		previous = append(previous, model.CornerLines{Title: corner.Title, Lines: lines})
 	}
 	return result, nil
+}
+
+func (g *LLMScriptGenerator) writeAll(ctx context.Context, program config.ProgramConfig, corners []config.CornerConfig, cornerMap map[string]model.RundownCorner, chars map[string]config.CharacterConfig) ([][]model.Line, error) {
+	return WriteAll(ctx, g.writer, program, corners, cornerMap, chars)
 }
 
 // buildPreviousCorners assembles the first n corners into a []model.CornerLines for context passing.

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -65,7 +65,7 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	cornerMap := rundown.CornerMap()
 
 	g.logger.With("step", "script/write").Info("開始")
-	cornerLines, err := g.writeAll(ctx, program, corners, cornerMap, chars)
+	cornerLines, err := WriteAll(ctx, g.writer, program, corners, cornerMap, chars)
 	if err != nil {
 		return model.Script{}, err
 	}
@@ -100,10 +100,6 @@ func WriteAll(ctx context.Context, w write.Writer, program config.ProgramConfig,
 		previous = append(previous, model.CornerLines{Title: corner.Title, Lines: lines})
 	}
 	return result, nil
-}
-
-func (g *LLMScriptGenerator) writeAll(ctx context.Context, program config.ProgramConfig, corners []config.CornerConfig, cornerMap map[string]model.RundownCorner, chars map[string]config.CharacterConfig) ([][]model.Line, error) {
-	return WriteAll(ctx, g.writer, program, corners, cornerMap, chars)
 }
 
 // buildPreviousCorners assembles the first n corners into a []model.CornerLines for context passing.

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -446,3 +446,57 @@ func TestLLMScriptGenerator_Generate_PassesPreviousCornersAccumulated(t *testing
 		t.Errorf("C3's previousCorners[1].Title: got %q, want C2", mw.receivedPrevious[2][1].Title)
 	}
 }
+
+func TestWriteAll(t *testing.T) {
+	corners := []config.CornerConfig{
+		{Title: "C1", Content: "内容1", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
+		{Title: "C2", Content: "内容2", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
+		{Title: "C3", Content: "内容3", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
+	}
+	cornerMap := map[string]model.RundownCorner{
+		"C1": {Title: "C1", Flow: "フロー1", Articles: []model.RundownArticle{{URL: "https://example.com/1"}}},
+		"C2": {Title: "C2", Flow: "フロー2", Articles: []model.RundownArticle{{URL: "https://example.com/2"}}},
+		"C3": {Title: "C3", Flow: "フロー3", Articles: []model.RundownArticle{{URL: "https://example.com/3"}}},
+	}
+	c1Lines := []model.Line{{SpeakerRole: "zundamon", Text: "C1のセリフ"}}
+	c2Lines := []model.Line{{SpeakerRole: "metan", Text: "C2のセリフ"}}
+	c3Lines := []model.Line{{SpeakerRole: "zundamon", Text: "C3のセリフ"}}
+
+	mw := &mockWriter{responses: [][]model.Line{c1Lines, c2Lines, c3Lines}}
+
+	got, err := script.WriteAll(context.Background(), mw, config.ProgramConfig{}, corners, cornerMap, testChars)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(got))
+	}
+	if len(mw.receivedPrevious[0]) != 0 {
+		t.Errorf("C1 should receive empty previousCorners, got %d", len(mw.receivedPrevious[0]))
+	}
+	if len(mw.receivedPrevious[1]) != 1 {
+		t.Fatalf("C2 should receive 1 previousCorner, got %d", len(mw.receivedPrevious[1]))
+	}
+	if mw.receivedPrevious[1][0].Title != "C1" {
+		t.Errorf("C2's previousCorners[0].Title: got %q, want C1", mw.receivedPrevious[1][0].Title)
+	}
+	if len(mw.receivedPrevious[2]) != 2 {
+		t.Fatalf("C3 should receive 2 previousCorners, got %d", len(mw.receivedPrevious[2]))
+	}
+}
+
+func TestWriteAll_Error(t *testing.T) {
+	corners := []config.CornerConfig{
+		{Title: "C1", Content: "内容1", LengthSec: 15},
+	}
+	cornerMap := map[string]model.RundownCorner{
+		"C1": {Title: "C1", Flow: "フロー1"},
+	}
+
+	mw := &mockWriter{err: context.Canceled}
+
+	_, err := script.WriteAll(context.Background(), mw, config.ProgramConfig{}, corners, cornerMap, testChars)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `script.WriteAll` 関数を追加し、コーナーごとの `previous` 蓄積ループを一箇所に集約
- `LLMScriptGenerator.Generate` が直接 `WriteAll` を呼ぶよう変更（転送ラッパー `writeAll` を削除）
- `runScriptWrite` の重複ループを `script.WriteAll` 呼び出しに置き換え
- `TestWriteAll` / `TestWriteAll_Error` を追加

Closes #165

---
🤖 Generated with [Claude Code](https://claude.ai/code)