### PR TITLE
chore: goreleaser を devcontainer / make setup に追加し make release-check を整備する

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,3 +8,6 @@ curl -fsSL https://claude.ai/install.sh | bash
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 brew tap canpok1/tap
 brew install --cask vox-actor
+
+# install goreleaser for local release config validation
+brew install goreleaser

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ OUT_DIR ?= output/$(shell date +%Y%m%d%H%M%S)
 
 setup:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
-	go install github.com/goreleaser/goreleaser/v2@latest
+	go install github.com/goreleaser/goreleaser/v2@v2.14.3
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/vox-radio

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ check-samples: build
 	cd internal/cli/templates && "$(CURDIR)/$(BINARY_NAME)" profile check profile.yaml
 	for f in sample-profiles/*.yaml; do ./$(BINARY_NAME) profile check "$$f"; done
 
+release-check:
+	goreleaser check
+
 all: build
 
-.PHONY: all setup build clean test fmt lint install docs check-samples run-sample
+.PHONY: all setup build clean test fmt lint install docs check-samples run-sample release-check

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ OUT_DIR ?= output/$(shell date +%Y%m%d%H%M%S)
 
 setup:
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+	go install github.com/goreleaser/goreleaser/v2@latest
 
 build:
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY_NAME) ./cmd/vox-radio

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@
 
 > **注意:** `.devcontainer/.env` には秘密情報が含まれるため、コミットしないこと（`.gitignore` で除外済み）。
 
+## リリース設定の検証
+
+`.goreleaser.yaml` を編集した後は、CI を待たずにローカルで構文・設定を検証できます。
+
+```bash
+make release-check
+```
+
+`goreleaser check` を実行し、設定の構文エラーや不整合を検出します。`goreleaser` は devcontainer 起動時に自動インストールされます。devcontainer 外で作業する場合は [GoReleaser のインストール手順](https://goreleaser.com/install/) を参照してください。
+
 ## CLIの使い方
 
 ### ビルド

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 make release-check
 ```
 
-`goreleaser check` を実行し、設定の構文エラーや不整合を検出します。`goreleaser` は devcontainer 起動時に自動インストールされます。devcontainer 外で作業する場合は [GoReleaser のインストール手順](https://goreleaser.com/install/) を参照してください。
+`goreleaser check` を実行し、設定の構文エラーや不整合を検出します。`goreleaser` は devcontainer 起動時または `make setup` 実行時に自動インストールされます。
 
 ## CLIの使い方
 


### PR DESCRIPTION
## Summary

- `.devcontainer/post-create.sh` に `brew install goreleaser` を追加し、devcontainer 起動時に自動インストールされるようにする
- `Makefile` の `setup` ターゲットに `go install github.com/goreleaser/goreleaser/v2@latest` を追加し、devcontainer 外のユーザーも `make setup` 一発でセットアップできるようにする
- `Makefile` に `release-check` ターゲット（`goreleaser check`）を追加し、`.goreleaser.yaml` 編集後のローカル検証を可能にする
- `README.md` に「リリース設定の検証」セクションを追記し、`make release-check` の使い方とインストール方法を明記する

Closes #150

---
🤖 Generated with [Claude Code](https://claude.ai/code)