### PR TITLE
feat: コーナーごとの start_pause_sec/end_pause_sec を新設し program.segment_pause_sec と program.length_sec を削除する

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,6 @@ vox-radio assemble --in work/intermediate/04_script.json --clips work/clips --ou
 |---|---|---|---|
 | `title` | string | 任意 | 番組タイトル |
 | `description` | string | 任意 | 番組の説明（LLM への指示に使用） |
-| `segment_pause_sec` | float64 | 任意 | コーナー間の無音時間（秒）。デフォルト: 0（Go ゼロ値） |
-| `length_sec` | int | 任意 | 番組全体の目標収録時間（秒）。デフォルト: 0（Go ゼロ値） |
 
 #### `corners` セクション
 
@@ -294,6 +292,8 @@ vox-radio assemble --in work/intermediate/04_script.json --clips work/clips --ou
 | `start_jingle` | string | 任意 | コーナー開始ジングルのキー名（`assets.jingle` のキーと一致させること）。コーナー本編の前に確定的に挿入される |
 | `end_jingle` | string | 任意 | コーナー終了ジングルのキー名（`assets.jingle` のキーと一致させること）。コーナー本編の後に確定的に挿入される |
 | `bgm` | string | 任意 | コーナー中 BGM のキー名（`assets.bgm` のキーと一致させること）。コーナー本編を開始/停止セグメントで挟む |
+| `start_pause_sec` | float64 | 任意 | コーナー先頭（`start_jingle` より前）に挿入する無音時間（秒）。0 または省略時は挿入しない |
+| `end_pause_sec` | float64 | 任意 | コーナー末尾（`end_jingle` より後）に挿入する無音時間（秒）。0 または省略時は挿入しない |
 
 ##### `corners[].source` サブフィールド
 

--- a/docs/adr/0024-corner-level-pause-and-remove-program-pause-length.md
+++ b/docs/adr/0024-corner-level-pause-and-remove-program-pause-length.md
@@ -1,0 +1,26 @@
+# 0024. コーナーごとの開始/終了無音設定と program.segment_pause_sec / program.length_sec の削除
+
+- ステータス: 採用
+- 日付: 2026-06-01
+
+## コンテキスト
+
+`program.segment_pause_sec` はセリフ間・ラン間すべてに一律に適用される無音時間として ADR-0011 で導入された。しかし実際の要件はコーナーごとに異なる「コーナー開始前/終了後の無音」であり、一律設定では表現できない。加えて `program.length_sec`（番組全体の目標収録時間）は本番コードで参照されておらず、コーナーごとの `length_sec` と二重管理になっていた。ADR-0020 の方針「番組構成として事前決定できる要素はコーナーごとに決定的に持たせる」に沿って整理する必要があった。
+
+## 決定
+
+- `program.segment_pause_sec` を削除し、セリフ間・ラン間の無音は固定値 `defaultPauseSec = 0.3` を常に使用する。
+- `program.length_sec` を削除する（コーナーごとの `corners[].length_sec` のみ残す）。
+- `corners[]` に `start_pause_sec` / `end_pause_sec` を追加する（`omitempty`、デフォルト 0 = 挿入しない）。
+- `buildScript` でコーナーの最外側に pause セグメントを注入する（`start_pause → start_jingle → ... → end_jingle → end_pause` の順）。
+- `model.CornerLines` にも同フィールドを追加し `03_lines.json` へ永続化する（jingle/bgm と同じ決定的配線）。
+
+## 結果
+
+**良い点:** コーナーごとに開始/終了の無音を細かく制御できる。設定が一元化され整合性チェック不要になった。`defaultPauseSec` 固定でセリフ間挙動が単純化された。  
+**トレードオフ:** `segment_pause_sec` を設定していた既存プロファイルは strict モードでエラーになるため手動マイグレーションが必要。
+
+## 検討した代替案
+
+**`program.segment_pause_sec` を残しコーナー設定と共存させる案:** `program` 側が優先か `corners` 側が優先かの競合ロジックが発生し、テストが複雑になる。ADR-0011 の一部見直しとして削除を選択した。  
+**`start_pause_sec` をLLM判断にする案:** pause は番組構成として事前決定できる要素であり、ADR-0020 の方針（決定的設定駆動）に反するため却下。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,3 +29,4 @@
 | [0021](0021-intra-episode-corner-context.md) | コーナー台本生成に同一回の生成済みセリフを文脈として渡す | 採用 | 2026-06-01 |
 | [0022](0022-dify-api-llm-provider.md) | LLM プロバイダに Dify API 経由の利用を追加する | 採用 | 2026-06-01 |
 | [0023](0023-embed-prompts-in-binary.md) | プロンプトをバイナリに同梱し --prompts フラグを廃止する | 採用 | 2026-06-01 |
+| [0024](0024-corner-level-pause-and-remove-program-pause-length.md) | コーナーごとの開始/終了無音設定と program.segment_pause_sec / program.length_sec の削除 | 採用 | 2026-06-01 |

--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -77,17 +77,12 @@ func (a *Assembler) Run(ctx context.Context, script model.Script, clips model.Cl
 		return nil, fmt.Errorf("create output dir: %w", err)
 	}
 
-	pauseSec := a.Program.SegmentPauseSec
-	if pauseSec == 0 {
-		pauseSec = defaultPauseSec
-	}
-
 	bctx := BuildContext{
 		Script:   script,
 		Clips:    clips,
 		ClipsDir: clipsDir,
 		Assets:   a.AssetsConfig,
-		PauseSec: pauseSec,
+		PauseSec: defaultPauseSec,
 		OutPath:  outPath,
 	}
 

--- a/internal/assemble/assemble_test.go
+++ b/internal/assemble/assemble_test.go
@@ -17,7 +17,7 @@ import (
 func newTestAssembler(ffmpegErr error, duration float64, size int64) *Assembler {
 	return &Assembler{
 		AssetsConfig: config.AssetsConfig{},
-		Program:      config.ProgramConfig{SegmentPauseSec: 0.5},
+		Program:      config.ProgramConfig{},
 		runFFmpeg:    func(_ context.Context, _ []string, _ io.Writer) error { return ffmpegErr },
 		getDuration:  func(_ string) (float64, error) { return duration, nil },
 		getFileSize:  func(_ string) (int64, error) { return size, nil },
@@ -29,7 +29,7 @@ func TestAssembler_Run_ReturnsResult(t *testing.T) {
 	var capturedArgs []string
 	a := &Assembler{
 		AssetsConfig: config.AssetsConfig{},
-		Program:      config.ProgramConfig{SegmentPauseSec: 0.5},
+		Program:      config.ProgramConfig{},
 		runFFmpeg: func(_ context.Context, args []string, _ io.Writer) error {
 			capturedArgs = args
 			return nil
@@ -142,7 +142,7 @@ func TestAssembler_Run_DefaultPause(t *testing.T) {
 	var capturedArgs []string
 	a := &Assembler{
 		AssetsConfig: config.AssetsConfig{},
-		Program:      config.ProgramConfig{SegmentPauseSec: 0}, // zero → default
+		Program:      config.ProgramConfig{},
 		runFFmpeg: func(_ context.Context, args []string, _ io.Writer) error {
 			capturedArgs = args
 			return nil
@@ -211,7 +211,7 @@ func TestAssembler_Run_FFmpegOutputGoesToWriter(t *testing.T) {
 	var ffmpegOutput strings.Builder
 	a := &Assembler{
 		AssetsConfig: config.AssetsConfig{},
-		Program:      config.ProgramConfig{SegmentPauseSec: 0.5},
+		Program:      config.ProgramConfig{},
 		runFFmpeg: func(_ context.Context, _ []string, w io.Writer) error {
 			if w != nil {
 				_, _ = io.WriteString(w, "ffmpeg output here")

--- a/internal/cli/profile_check_test.go
+++ b/internal/cli/profile_check_test.go
@@ -63,8 +63,6 @@ func TestProfileCheck_UnknownCast_Error(t *testing.T) {
 	profileContent := []byte(`program:
   title: "テスト"
   description: "テスト"
-  segment_pause_sec: 0.3
-  length_sec: 60
 
 corners:
   - title: "コーナー1"

--- a/internal/cli/templates/profile.yaml
+++ b/internal/cli/templates/profile.yaml
@@ -10,10 +10,6 @@ program:
   title: "番組タイトル"
   # 番組の説明（LLM への指示に使用）
   description: "番組の説明"
-  # コーナー間の無音時間（秒）
-  segment_pause_sec: 0.3
-  # 番組全体の目標収録時間（秒）
-  length_sec: 240
 
 # コーナー定義（番組を構成する各コーナーを順番に記述）
 corners:
@@ -30,6 +26,10 @@ corners:
     length_sec: 30
     # コーナー開始ジングル（assets.jingle のキー名。不要な場合は行ごと削除）
     # start_jingle: opening
+    # コーナー開始前の無音時間（秒）。0 または省略時は挿入しない。
+    # start_pause_sec: 1.0
+    # コーナー終了後の無音時間（秒）。0 または省略時は挿入しない。
+    # end_pause_sec: 1.0
 
   - title: "メインコーナー"
     content: "メインコンテンツの紹介"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,11 +159,9 @@ func (c CacheConfig) EffectiveLLMContextEntries() int {
 
 // ProgramConfig holds program-wide settings for content generation.
 type ProgramConfig struct {
-	ID              string  `yaml:"id,omitempty"`
-	Title           string  `yaml:"title"`
-	Description     string  `yaml:"description"`
-	SegmentPauseSec float64 `yaml:"segment_pause_sec"`
-	LengthSec       int     `yaml:"length_sec"`
+	ID          string `yaml:"id,omitempty"`
+	Title       string `yaml:"title"`
+	Description string `yaml:"description"`
 }
 
 // SourceConfig defines the data sources for a corner (feeds and individual article URLs).
@@ -174,15 +172,17 @@ type SourceConfig struct {
 
 // CornerConfig defines a fixed corner in the program structure.
 type CornerConfig struct {
-	Title       string            `yaml:"title"`
-	Content     string            `yaml:"content"`
-	Direction   string            `yaml:"direction,omitempty"`
-	Cast        map[string]string `yaml:"cast"`
-	LengthSec   int               `yaml:"length_sec"`
-	Source      *SourceConfig     `yaml:"source,omitempty"`
-	StartJingle string            `yaml:"start_jingle,omitempty"`
-	EndJingle   string            `yaml:"end_jingle,omitempty"`
-	BGM         string            `yaml:"bgm,omitempty"`
+	Title         string            `yaml:"title"`
+	Content       string            `yaml:"content"`
+	Direction     string            `yaml:"direction,omitempty"`
+	Cast          map[string]string `yaml:"cast"`
+	LengthSec     int               `yaml:"length_sec"`
+	Source        *SourceConfig     `yaml:"source,omitempty"`
+	StartJingle   string            `yaml:"start_jingle,omitempty"`
+	EndJingle     string            `yaml:"end_jingle,omitempty"`
+	BGM           string            `yaml:"bgm,omitempty"`
+	StartPauseSec float64           `yaml:"start_pause_sec,omitempty"`
+	EndPauseSec   float64           `yaml:"end_pause_sec,omitempty"`
 }
 
 // VoicevoxPresets maps preset names to float64 scale values for each axis.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,9 +73,6 @@ func TestLoadProfile(t *testing.T) {
 		if profile.Program.Title == "" {
 			t.Error("Program.Title must not be empty")
 		}
-		if profile.Program.SegmentPauseSec <= 0 {
-			t.Error("Program.SegmentPauseSec must be positive")
-		}
 	})
 
 	t.Run("CornerAssets", func(t *testing.T) {
@@ -113,12 +110,6 @@ func TestLoadProfile(t *testing.T) {
 		}
 		if c.LengthSec <= 0 {
 			t.Error("Corners[0].LengthSec must be positive")
-		}
-	})
-
-	t.Run("ProgramLengthSec", func(t *testing.T) {
-		if profile.Program.LengthSec <= 0 {
-			t.Error("Program.LengthSec must be positive")
 		}
 	})
 

--- a/internal/config/testdata/profile.yaml
+++ b/internal/config/testdata/profile.yaml
@@ -1,8 +1,6 @@
 program:
   title: "テストニュース"
   description: "テスト用"
-  segment_pause_sec: 0.3
-  length_sec: 75
 
 corners:
   - title: "オープニング"

--- a/internal/config/testdata/profile_unknown_key.yaml
+++ b/internal/config/testdata/profile_unknown_key.yaml
@@ -1,8 +1,6 @@
 program:
   title: "テストニュース"
   description: "テスト用"
-  segment_pause_sec: 0.3
-  length_sec: 75
   typo_unknown_field: should_cause_strict_error
 
 corners:

--- a/internal/config/testdata/profile_with_id.yaml
+++ b/internal/config/testdata/profile_with_id.yaml
@@ -2,8 +2,6 @@ program:
   id: "test-program"
   title: "テストニュース"
   description: "テスト用"
-  segment_pause_sec: 0.3
-  length_sec: 75
 
 corners:
   - title: "オープニング"

--- a/internal/model/line.go
+++ b/internal/model/line.go
@@ -15,15 +15,17 @@ type Lines struct {
 }
 
 // CornerLines holds the lines and direction for one corner.
-// Asset fields (StartJingle, EndJingle, BGM) are transferred from CornerConfig
-// and persisted in 03_lines.json for deterministic segment injection.
+// Asset fields (StartJingle, EndJingle, BGM) and pause fields (StartPauseSec, EndPauseSec)
+// are transferred from CornerConfig and persisted in 03_lines.json for deterministic segment injection.
 type CornerLines struct {
-	Title       string `json:"title"`
-	Direction   string `json:"direction,omitempty"`
-	Lines       []Line `json:"lines"`
-	StartJingle string `json:"start_jingle,omitempty"`
-	EndJingle   string `json:"end_jingle,omitempty"`
-	BGM         string `json:"bgm,omitempty"`
+	Title         string  `json:"title"`
+	Direction     string  `json:"direction,omitempty"`
+	Lines         []Line  `json:"lines"`
+	StartJingle   string  `json:"start_jingle,omitempty"`
+	EndJingle     string  `json:"end_jingle,omitempty"`
+	BGM           string  `json:"bgm,omitempty"`
+	StartPauseSec float64 `json:"start_pause_sec,omitempty"`
+	EndPauseSec   float64 `json:"end_pause_sec,omitempty"`
 }
 
 // ScriptLines is the root structure of 03_lines.json.

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -154,6 +154,13 @@ func buildScript(corners []model.CornerLines, insertions []insertion, pauseInser
 	activeBGM := ""
 
 	for ci, corner := range corners {
+		if corner.StartPauseSec > 0 {
+			segments = append(segments, model.ScriptSegment{
+				Type:        model.SegmentTypePause,
+				DurationSec: corner.StartPauseSec,
+			})
+		}
+
 		if corner.StartJingle != "" {
 			segments = append(segments, model.ScriptSegment{
 				Type:      model.SegmentTypeJingle,
@@ -201,6 +208,13 @@ func buildScript(corners []model.CornerLines, insertions []insertion, pauseInser
 				AssetName: corner.EndJingle,
 			})
 			activeBGM = ""
+		}
+
+		if corner.EndPauseSec > 0 {
+			segments = append(segments, model.ScriptSegment{
+				Type:        model.SegmentTypePause,
+				DurationSec: corner.EndPauseSec,
+			})
 		}
 	}
 

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -398,6 +398,140 @@ func TestLLMDirector_Direct_SpeechSegmentFields(t *testing.T) {
 	}
 }
 
+func TestBuildScript_StartPauseSec_InjectedBeforeStartJingle(t *testing.T) {
+	d := noInsertionDirector()
+
+	corners := []model.CornerLines{{
+		Title:         "C1",
+		StartJingle:   "opening",
+		StartPauseSec: 1.0,
+		Lines:         []model.Line{{SpeakerRole: "host", Text: "話す"}},
+	}}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [pause(1.0), jingle(opening), speech]
+	if len(got.Segments) != 3 {
+		t.Fatalf("Segments: got %d, want 3", len(got.Segments))
+	}
+	if got.Segments[0].Type != model.SegmentTypePause {
+		t.Errorf("Segment[0].Type: got %q, want pause", got.Segments[0].Type)
+	}
+	if got.Segments[0].DurationSec != 1.0 {
+		t.Errorf("Segment[0].DurationSec: got %f, want 1.0", got.Segments[0].DurationSec)
+	}
+	if got.Segments[1].Type != model.SegmentTypeJingle {
+		t.Errorf("Segment[1].Type: got %q, want jingle", got.Segments[1].Type)
+	}
+}
+
+func TestBuildScript_EndPauseSec_InjectedAfterEndJingle(t *testing.T) {
+	d := noInsertionDirector()
+
+	corners := []model.CornerLines{{
+		Title:       "C1",
+		EndJingle:   "ending",
+		EndPauseSec: 2.0,
+		Lines:       []model.Line{{SpeakerRole: "host", Text: "話す"}},
+	}}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [speech, jingle(ending), pause(2.0)]
+	if len(got.Segments) != 3 {
+		t.Fatalf("Segments: got %d, want 3", len(got.Segments))
+	}
+	if got.Segments[1].Type != model.SegmentTypeJingle {
+		t.Errorf("Segment[1].Type: got %q, want jingle", got.Segments[1].Type)
+	}
+	if got.Segments[2].Type != model.SegmentTypePause {
+		t.Errorf("Segment[2].Type: got %q, want pause", got.Segments[2].Type)
+	}
+	if got.Segments[2].DurationSec != 2.0 {
+		t.Errorf("Segment[2].DurationSec: got %f, want 2.0", got.Segments[2].DurationSec)
+	}
+}
+
+func TestBuildScript_ZeroStartPauseSec_NoInjection(t *testing.T) {
+	d := noInsertionDirector()
+
+	corners := []model.CornerLines{{
+		Title:         "C1",
+		StartPauseSec: 0,
+		Lines:         []model.Line{{SpeakerRole: "host", Text: "話す"}},
+	}}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [speech] — no pause injected when StartPauseSec == 0
+	if len(got.Segments) != 1 {
+		t.Fatalf("Segments: got %d, want 1", len(got.Segments))
+	}
+	if got.Segments[0].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[0].Type: got %q, want speech", got.Segments[0].Type)
+	}
+}
+
+func TestBuildScript_ZeroEndPauseSec_NoInjection(t *testing.T) {
+	d := noInsertionDirector()
+
+	corners := []model.CornerLines{{
+		Title:       "C1",
+		EndPauseSec: 0,
+		Lines:       []model.Line{{SpeakerRole: "host", Text: "話す"}},
+	}}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [speech] — no pause injected when EndPauseSec == 0
+	if len(got.Segments) != 1 {
+		t.Fatalf("Segments: got %d, want 1", len(got.Segments))
+	}
+	if got.Segments[0].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[0].Type: got %q, want speech", got.Segments[0].Type)
+	}
+}
+
+func TestBuildScript_AdjacentCorners_BothPausesInjected(t *testing.T) {
+	d := noInsertionDirector()
+
+	corners := []model.CornerLines{
+		{
+			Title:       "C1",
+			EndPauseSec: 1.0,
+			Lines:       []model.Line{{SpeakerRole: "host", Text: "コーナー1"}},
+		},
+		{
+			Title:         "C2",
+			StartPauseSec: 0.5,
+			Lines:         []model.Line{{SpeakerRole: "host", Text: "コーナー2"}},
+		},
+	}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// [speech_c1, pause(1.0), pause(0.5), speech_c2]
+	if len(got.Segments) != 4 {
+		t.Fatalf("Segments: got %d, want 4", len(got.Segments))
+	}
+	if got.Segments[1].Type != model.SegmentTypePause || got.Segments[1].DurationSec != 1.0 {
+		t.Errorf("Segment[1]: want pause(1.0), got %+v", got.Segments[1])
+	}
+	if got.Segments[2].Type != model.SegmentTypePause || got.Segments[2].DurationSec != 0.5 {
+		t.Errorf("Segment[2]: want pause(0.5), got %+v", got.Segments[2])
+	}
+}
+
 func TestLLMDirector_Direct_CatalogDescriptionPassedToPrompt(t *testing.T) {
 	var capturedPrompt string
 	mc := &capturingClient{

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -181,12 +181,14 @@ func BuildScriptLines(corners []config.CornerConfig, cornerLines [][]model.Line)
 	result := make([]model.CornerLines, len(corners))
 	for i, corner := range corners {
 		result[i] = model.CornerLines{
-			Title:       corner.Title,
-			Direction:   corner.Direction,
-			Lines:       cornerLines[i],
-			StartJingle: corner.StartJingle,
-			EndJingle:   corner.EndJingle,
-			BGM:         corner.BGM,
+			Title:         corner.Title,
+			Direction:     corner.Direction,
+			Lines:         cornerLines[i],
+			StartJingle:   corner.StartJingle,
+			EndJingle:     corner.EndJingle,
+			BGM:           corner.BGM,
+			StartPauseSec: corner.StartPauseSec,
+			EndPauseSec:   corner.EndPauseSec,
 		}
 	}
 	return result

--- a/sample-profiles/tech_profile.yaml
+++ b/sample-profiles/tech_profile.yaml
@@ -2,8 +2,6 @@ program:
   id: "tech-daily"
   title: "今日のテックニュース"
   description: "毎日5分のニュースラジオ"
-  segment_pause_sec: 0.3
-  length_sec: 240
 
 corners:
   - title: "オープニング"


### PR DESCRIPTION
## Summary

- `config.CornerConfig` に `start_pause_sec` / `end_pause_sec` フィールドを追加（`omitempty`、デフォルト 0 = 挿入しない）
- `config.ProgramConfig` から `segment_pause_sec` / `length_sec` を削除（後者は本番コードで未使用だった）
- `model.CornerLines` に同フィールドを追加して `03_lines.json` に永続化
- `direct.go` の `buildScript` でコーナー最外側に pause セグメントを注入（`start_pause → start_jingle → ... → end_jingle → end_pause` の順）
- `assemble.go` が `SegmentPauseSec` を参照せず `defaultPauseSec = 0.3` 固定に変更
- `direct_test.go` に start/end pause 注入の単体テストを追加（位置・値・0 時非注入・隣接合算）
- ADR-0024 を追加（ADR-0011 一部見直し・ADR-0020 方針延長として記録）

## Test plan

- [x] `make test` → 全パッケージ pass
- [x] `gofmt -l .` → 差分なし
- [x] `golangci-lint run` → 0 issues
- [x] `direct_test.go` に start/end pause の単体テスト追加・確認

Closes #181

---
🤖 Generated with [Claude Code](https://claude.ai/code)