### PR TITLE
feat: jingle / SE の前後無音を silenceremove で自動除去する

### DIFF
--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -314,8 +314,7 @@ func buildRun(b *filterBuilder, run runData, clipInputIdx []int, assets config.A
 		}
 		seIdx := b.addInput(entry.File)
 		seKey := fmt.Sprintf("run%d_se%d", runIdx, i)
-		seRawLabel := fmt.Sprintf("[%d:a]", seIdx)
-		seLabel := applySilenceTrim(b, seRawLabel, seKey, entry.EffectiveTrimSilence())
+		seLabel := applySilenceTrim(b, fmt.Sprintf("[%d:a]", seIdx), seKey, entry.EffectiveTrimSilence())
 		delayedLabel := fmt.Sprintf("[%s]", seKey)
 		nextLabel := fmt.Sprintf("[run%d_after_se%d]", runIdx, i)
 		b.addFilter(fmt.Sprintf("%svolume=%.2f,adelay=%d|%d%s",

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -16,6 +16,9 @@ const (
 	outputNormFilter = "loudnorm=I=-16:TP=-1.5:LRA=11"
 	// outputLimiterLimit is the linear equivalent of the TP ceiling used in outputNormFilter (10^(-1.5/20) ≈ 0.841).
 	outputLimiterLimit = 0.841
+	// silenceTrimThreshold is the amplitude below which audio is treated as silence
+	// when stripping leading/trailing silence from jingle/SE inputs.
+	silenceTrimThreshold = "-50dB"
 )
 
 // BuildContext holds all data needed to build the ffmpeg command.
@@ -310,10 +313,13 @@ func buildRun(b *filterBuilder, run runData, clipInputIdx []int, assets config.A
 			continue
 		}
 		seIdx := b.addInput(entry.File)
-		delayedLabel := fmt.Sprintf("[run%d_se%d]", runIdx, i)
+		seKey := fmt.Sprintf("run%d_se%d", runIdx, i)
+		seRawLabel := fmt.Sprintf("[%d:a]", seIdx)
+		seLabel := applySilenceTrim(b, seRawLabel, seKey, entry.EffectiveTrimSilence())
+		delayedLabel := fmt.Sprintf("[%s]", seKey)
 		nextLabel := fmt.Sprintf("[run%d_after_se%d]", runIdx, i)
-		b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f,adelay=%d|%d%s",
-			seIdx, entry.Volume, ev.offsetMs, ev.offsetMs, delayedLabel))
+		b.addFilter(fmt.Sprintf("%svolume=%.2f,adelay=%d|%d%s",
+			seLabel, entry.Volume, ev.offsetMs, ev.offsetMs, delayedLabel))
 		b.addFilter(fmt.Sprintf("%s%samix=inputs=2:duration=first:normalize=0%s",
 			currentLabel, delayedLabel, nextLabel))
 		currentLabel = nextLabel
@@ -412,10 +418,25 @@ func buildSpeechConcat(b *filterBuilder, items []speechItem, clipInputIdx []int,
 	return concatLabel
 }
 
-// buildJingleFadeIn applies fade-in to a jingle input and returns the resulting label.
+// applySilenceTrim strips leading and trailing silence from currentLabel when enabled.
+// Trailing silence is removed via the areverse trick (same pattern as applyFadeOut).
+// Returns currentLabel unchanged when enabled is false.
+func applySilenceTrim(b *filterBuilder, currentLabel string, key string, enabled bool) string {
+	if !enabled {
+		return currentLabel
+	}
+	outLabel := fmt.Sprintf("[%s_st]", key)
+	b.addFilter(fmt.Sprintf(
+		"%ssilenceremove=start_periods=1:start_threshold=%s,areverse,silenceremove=start_periods=1:start_threshold=%s,areverse%s",
+		currentLabel, silenceTrimThreshold, silenceTrimThreshold, outLabel))
+	return outLabel
+}
+
+// buildJingleFadeIn applies silence trim then fade-in to a jingle input and returns the resulting label.
 func buildJingleFadeIn(b *filterBuilder, idx int, entry config.JingleEntry) string {
 	rawLabel := fmt.Sprintf("[%d:a]", idx)
-	return applyFadeIn(b, rawLabel, idx, entry.FadeIn)
+	label := applySilenceTrim(b, rawLabel, fmt.Sprintf("jingle%d", idx), entry.EffectiveTrimSilence())
+	return applyFadeIn(b, label, idx, entry.FadeIn)
 }
 
 // applyFadeOut applies fade-out to the current label and returns the resulting label.

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -434,8 +434,7 @@ func applySilenceTrim(b *filterBuilder, currentLabel string, key string, enabled
 
 // buildJingleFadeIn applies silence trim then fade-in to a jingle input and returns the resulting label.
 func buildJingleFadeIn(b *filterBuilder, idx int, entry config.JingleEntry) string {
-	rawLabel := fmt.Sprintf("[%d:a]", idx)
-	label := applySilenceTrim(b, rawLabel, fmt.Sprintf("jingle%d", idx), entry.EffectiveTrimSilence())
+	label := applySilenceTrim(b, fmt.Sprintf("[%d:a]", idx), fmt.Sprintf("jingle%d", idx), entry.EffectiveTrimSilence())
 	return applyFadeIn(b, label, idx, entry.FadeIn)
 }
 

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -1109,3 +1109,145 @@ func TestBuildFFmpegArgs_BGMNoLoop_NoStreamLoop(t *testing.T) {
 		}
 	}
 }
+
+// TestBuildFFmpegArgs_JingleSilenceRemoveDefault verifies that silenceremove is applied
+// to a jingle when TrimSilence is nil (default = true).
+func TestBuildFFmpegArgs_JingleSilenceRemoveDefault(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeJingle, AssetName: "op"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			Jingle: map[string]config.JingleEntry{
+				"op": {File: "/assets/op.wav", FadeIn: 0.3},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(args.FilterComplex, "silenceremove") {
+		t.Errorf("filter_complex missing silenceremove for jingle with default TrimSilence: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_JingleSilenceRemoveDisabled verifies that silenceremove is NOT applied
+// when TrimSilence is explicitly false.
+func TestBuildFFmpegArgs_JingleSilenceRemoveDisabled(t *testing.T) {
+	f := false
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeJingle, AssetName: "op"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			Jingle: map[string]config.JingleEntry{
+				"op": {File: "/assets/op.wav", FadeIn: 0.3, TrimSilence: &f},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(args.FilterComplex, "silenceremove") {
+		t.Errorf("filter_complex must not contain silenceremove when TrimSilence=false: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_SESilenceRemoveDefault verifies that silenceremove is applied
+// to a SE when TrimSilence is nil (default = true).
+func TestBuildFFmpegArgs_SESilenceRemoveDefault(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
+				{Type: model.SegmentTypeSE, AssetName: "chime"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "main"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			SE: map[string]config.SEEntry{
+				"chime": {File: "/assets/chime.wav", Volume: 0.8},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(args.FilterComplex, "silenceremove") {
+		t.Errorf("filter_complex missing silenceremove for SE with default TrimSilence: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_SESilenceRemoveDisabled verifies that silenceremove is NOT applied
+// when SE TrimSilence is explicitly false.
+func TestBuildFFmpegArgs_SESilenceRemoveDisabled(t *testing.T) {
+	f := false
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
+				{Type: model.SegmentTypeSE, AssetName: "chime"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "main"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			SE: map[string]config.SEEntry{
+				"chime": {File: "/assets/chime.wav", Volume: 0.8, TrimSilence: &f},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(args.FilterComplex, "silenceremove") {
+		t.Errorf("filter_complex must not contain silenceremove when SE TrimSilence=false: %s", args.FilterComplex)
+	}
+}

--- a/internal/cli/templates/profile.yaml
+++ b/internal/cli/templates/profile.yaml
@@ -65,19 +65,23 @@ corners:
 #       file: assets/jingle/opening.mp3
 #       fade_in: 0.5
 #       fade_out: 0.5
+#       # trim_silence: false  # 省略時は true（素材前後の無音を自動除去）。無効にしたい場合のみ記載
 #       description: "番組冒頭で流すオープニングジングル"  # 省略可
 #     ending:
 #       file: assets/jingle/ending.mp3
 #       fade_in: 0.5
 #       fade_out: 1.0
+#       # trim_silence: false  # 省略時は true
 #   se:
 #     chime:
 #       file: assets/se/chime.wav
 #       volume: 0.8
+#       # trim_silence: false  # 省略時は true（素材前後の無音を自動除去）。無効にしたい場合のみ記載
 #       description: "話題の切り替わりに鳴らす明るいチャイム音"  # 省略可
 #     transition:
 #       file: assets/se/transition.wav
 #       volume: 0.8
+#       # trim_silence: false  # 省略時は true
 #   bgm:
 #     talk_bgm:
 #       file: assets/bgm/talk.mp3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,13 +35,29 @@ type JingleEntry struct {
 	File        string  `yaml:"file"`
 	FadeIn      float64 `yaml:"fade_in"`
 	FadeOut     float64 `yaml:"fade_out"`
+	TrimSilence *bool   `yaml:"trim_silence,omitempty"`
 	Description string  `yaml:"description,omitempty"`
 }
+
+// EffectiveTrimSilence returns true when TrimSilence is nil (default on) or explicitly true.
+func (e JingleEntry) EffectiveTrimSilence() bool { return effectiveTrimSilence(e.TrimSilence) }
 
 type SEEntry struct {
 	File        string  `yaml:"file"`
 	Volume      float64 `yaml:"volume"`
+	TrimSilence *bool   `yaml:"trim_silence,omitempty"`
 	Description string  `yaml:"description,omitempty"`
+}
+
+// EffectiveTrimSilence returns true when TrimSilence is nil (default on) or explicitly true.
+func (e SEEntry) EffectiveTrimSilence() bool { return effectiveTrimSilence(e.TrimSilence) }
+
+// effectiveTrimSilence returns true when v is nil (default) or points to true.
+func effectiveTrimSilence(v *bool) bool {
+	if v == nil {
+		return true
+	}
+	return *v
 }
 
 type BGMEntry struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -799,44 +799,36 @@ func TestLoadConfig_ValidationError_MissingDifyChatBlock(t *testing.T) {
 
 func boolPtr(v bool) *bool { return &v }
 
-func TestJingleEntry_EffectiveTrimSilence_Nil(t *testing.T) {
-	e := config.JingleEntry{}
-	if got := e.EffectiveTrimSilence(); got != true {
-		t.Errorf("got %v, want true (nil defaults to true)", got)
+func TestJingleEntry_EffectiveTrimSilence(t *testing.T) {
+	cases := []struct {
+		ptr  *bool
+		want bool
+	}{
+		{nil, true},
+		{boolPtr(false), false},
+		{boolPtr(true), true},
+	}
+	for _, c := range cases {
+		e := config.JingleEntry{TrimSilence: c.ptr}
+		if got := e.EffectiveTrimSilence(); got != c.want {
+			t.Errorf("ptr=%v: got %v, want %v", c.ptr, got, c.want)
+		}
 	}
 }
 
-func TestJingleEntry_EffectiveTrimSilence_False(t *testing.T) {
-	e := config.JingleEntry{TrimSilence: boolPtr(false)}
-	if got := e.EffectiveTrimSilence(); got != false {
-		t.Errorf("got %v, want false", got)
+func TestSEEntry_EffectiveTrimSilence(t *testing.T) {
+	cases := []struct {
+		ptr  *bool
+		want bool
+	}{
+		{nil, true},
+		{boolPtr(false), false},
+		{boolPtr(true), true},
 	}
-}
-
-func TestJingleEntry_EffectiveTrimSilence_True(t *testing.T) {
-	e := config.JingleEntry{TrimSilence: boolPtr(true)}
-	if got := e.EffectiveTrimSilence(); got != true {
-		t.Errorf("got %v, want true", got)
-	}
-}
-
-func TestSEEntry_EffectiveTrimSilence_Nil(t *testing.T) {
-	e := config.SEEntry{}
-	if got := e.EffectiveTrimSilence(); got != true {
-		t.Errorf("got %v, want true (nil defaults to true)", got)
-	}
-}
-
-func TestSEEntry_EffectiveTrimSilence_False(t *testing.T) {
-	e := config.SEEntry{TrimSilence: boolPtr(false)}
-	if got := e.EffectiveTrimSilence(); got != false {
-		t.Errorf("got %v, want false", got)
-	}
-}
-
-func TestSEEntry_EffectiveTrimSilence_True(t *testing.T) {
-	e := config.SEEntry{TrimSilence: boolPtr(true)}
-	if got := e.EffectiveTrimSilence(); got != true {
-		t.Errorf("got %v, want true", got)
+	for _, c := range cases {
+		e := config.SEEntry{TrimSilence: c.ptr}
+		if got := e.EffectiveTrimSilence(); got != c.want {
+			t.Errorf("ptr=%v: got %v, want %v", c.ptr, got, c.want)
+		}
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -796,3 +796,47 @@ func TestLoadConfig_ValidationError_MissingDifyChatBlock(t *testing.T) {
 		t.Error("expected error when dify-chat provider has no dify-chat block")
 	}
 }
+
+func boolPtr(v bool) *bool { return &v }
+
+func TestJingleEntry_EffectiveTrimSilence_Nil(t *testing.T) {
+	e := config.JingleEntry{}
+	if got := e.EffectiveTrimSilence(); got != true {
+		t.Errorf("got %v, want true (nil defaults to true)", got)
+	}
+}
+
+func TestJingleEntry_EffectiveTrimSilence_False(t *testing.T) {
+	e := config.JingleEntry{TrimSilence: boolPtr(false)}
+	if got := e.EffectiveTrimSilence(); got != false {
+		t.Errorf("got %v, want false", got)
+	}
+}
+
+func TestJingleEntry_EffectiveTrimSilence_True(t *testing.T) {
+	e := config.JingleEntry{TrimSilence: boolPtr(true)}
+	if got := e.EffectiveTrimSilence(); got != true {
+		t.Errorf("got %v, want true", got)
+	}
+}
+
+func TestSEEntry_EffectiveTrimSilence_Nil(t *testing.T) {
+	e := config.SEEntry{}
+	if got := e.EffectiveTrimSilence(); got != true {
+		t.Errorf("got %v, want true (nil defaults to true)", got)
+	}
+}
+
+func TestSEEntry_EffectiveTrimSilence_False(t *testing.T) {
+	e := config.SEEntry{TrimSilence: boolPtr(false)}
+	if got := e.EffectiveTrimSilence(); got != false {
+		t.Errorf("got %v, want false", got)
+	}
+}
+
+func TestSEEntry_EffectiveTrimSilence_True(t *testing.T) {
+	e := config.SEEntry{TrimSilence: boolPtr(true)}
+	if got := e.EffectiveTrimSilence(); got != true {
+		t.Errorf("got %v, want true", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `JingleEntry` / `SEEntry` に `TrimSilence *bool` フィールドを追加（nil = デフォルト true）
- `effectiveTrimSilence` 共通ヘルパー + `EffectiveTrimSilence()` メソッドを追加
- `filter.go` に `silenceTrimThreshold`（`-50dB`）定数と `applySilenceTrim` ヘルパーを追加
- jingle のフィルタチェーンを **無音除去 → fade_in → fade_out** の順に変更
- SE overlay に無音除去を挿入（`EffectiveTrimSilence()` が true のとき）
- `profile.yaml` テンプレートに `trim_silence` コメント例を追記

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `internal/config/config.go` | `TrimSilence *bool` フィールド・ヘルパー・メソッド追加 |
| `internal/config/config_test.go` | `EffectiveTrimSilence` テーブル駆動テスト追加 |
| `internal/assemble/filter.go` | 定数・ヘルパー追加、jingle/SE フィルタチェーン変更 |
| `internal/assemble/filter_test.go` | silenceremove 有無テスト追加 |
| `internal/cli/templates/profile.yaml` | `trim_silence` コメント例追記 |

## Test plan

- [x] `go test ./...` が全パスすること
- [x] `gofmt -l .` で差分なし
- [x] `golangci-lint run` で指摘なし
- [x] jingle に silenceremove が含まれること（デフォルト）を検証
- [x] `trim_silence: false` で silenceremove が含まれないことを検証
- [x] SE に silenceremove が含まれること（デフォルト）を検証
- [x] `trim_silence: false` で SE に silenceremove が含まれないことを検証

Closes #184

---
🤖 Generated with [Claude Code](https://claude.ai/code)