### PR TITLE
feat: run の assemble→manifest 間（LLM要約フェーズ）に進捗ログを追加し無言の待機を解消する

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -117,39 +117,50 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("assemble: %w", err)
 	}
 
+	logger := r.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	generatedAt := opts.GeneratedAt
 	if generatedAt.IsZero() {
 		generatedAt = time.Now().UTC()
 	}
 
 	var programSummary model.ProgramSummary
-	if r.ProgramSummarizer != nil {
-		programSummary, err = r.ProgramSummarizer.Summarize(ctx, scr)
-		if err != nil {
-			return fmt.Errorf("summarize program: %w", err)
-		}
-	}
-
 	var cornerSummaries map[string]model.CornerSummary
-	if r.CornerSummarizer != nil {
-		var scriptLines model.ScriptLines
-		if err := fileio.ReadJSON(fileio.LinesPath(outDir), &scriptLines); err != nil {
-			return fmt.Errorf("read script lines for corner summarization: %w", err)
-		}
-		cornerSummaries = make(map[string]model.CornerSummary, len(scriptLines.Corners))
-		for _, cl := range scriptLines.Corners {
-			cs, err := r.CornerSummarizer.SummarizeCorner(ctx, cl)
+	if r.ProgramSummarizer != nil || r.CornerSummarizer != nil {
+		summaryLogger := logger.With("step", "summary")
+		summaryLogger.Info("開始")
+		summaryStart := time.Now()
+
+		if r.ProgramSummarizer != nil {
+			summaryLogger.Info("番組全体を要約中")
+			programSummary, err = r.ProgramSummarizer.Summarize(ctx, scr)
 			if err != nil {
-				return fmt.Errorf("summarize corner %s: %w", cl.Title, err)
+				return fmt.Errorf("summarize program: %w", err)
 			}
-			cornerSummaries[cl.Title] = cs
 		}
+
+		if r.CornerSummarizer != nil {
+			var scriptLines model.ScriptLines
+			if err := fileio.ReadJSON(fileio.LinesPath(outDir), &scriptLines); err != nil {
+				return fmt.Errorf("read script lines for corner summarization: %w", err)
+			}
+			cornerSummaries = make(map[string]model.CornerSummary, len(scriptLines.Corners))
+			for i, cl := range scriptLines.Corners {
+				summaryLogger.Info(fmt.Sprintf("コーナー「%s」を要約中 (%d/%d)", cl.Title, i+1, len(scriptLines.Corners)))
+				cs, err := r.CornerSummarizer.SummarizeCorner(ctx, cl)
+				if err != nil {
+					return fmt.Errorf("summarize corner %s: %w", cl.Title, err)
+				}
+				cornerSummaries[cl.Title] = cs
+			}
+		}
+
+		summaryLogger.Info(fmt.Sprintf("完了 (%.1fs)", time.Since(summaryStart).Seconds()))
 	}
 
-	logger := r.Logger
-	if logger == nil {
-		logger = slog.Default()
-	}
 	manifestLogger := logger.With("step", "manifest")
 	manifestLogger.Info("開始")
 	manifestStart := time.Now()

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -462,6 +462,57 @@ func TestRunner_Run_CornerSummarizerError(t *testing.T) {
 	}
 }
 
+func TestRunner_Run_LogsSummaryStep(t *testing.T) {
+	outDir := t.TempDir()
+	s := defaultStubs()
+	s.sum = &stubProgramSummarizer{summary: "要約テスト"}
+	s.csum = &stubCornerSummarizer{result: model.CornerSummary{Summary: "コーナー要約", Points: []string{"p1"}}}
+
+	writeScriptLines(t, outDir, model.ScriptLines{
+		Corners: []model.CornerLines{
+			{Title: "テストコーナー", Lines: []model.Line{{Text: "テスト"}}},
+		},
+	})
+
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	r := newRunner(s)
+	r.Logger = logger
+
+	if err := r.Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "summary") {
+		t.Errorf("should log summary step: %q", logs)
+	}
+	if !strings.Contains(logs, "要約中") {
+		t.Errorf("should log 要約中: %q", logs)
+	}
+}
+
+func TestRunner_Run_NoSummaryLogWhenSummarizersNil(t *testing.T) {
+	outDir := t.TempDir()
+	s := defaultStubs() // both sum and csum are nil
+
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	r := newRunner(s)
+	r.Logger = logger
+
+	if err := r.Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logs := buf.String()
+	if strings.Contains(logs, "summary") {
+		t.Errorf("should not log summary step when summarizers are nil: %q", logs)
+	}
+}
+
 func TestRunner_Run_ManifestIncludesConversationNotes(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()


### PR DESCRIPTION
## Summary

- `internal/pipeline/pipeline.go` の `Runner.Run` に要約フェーズの進捗ログ（`step=summary`）を追加
- `logger` 解決を要約ブロック前へ移動し、manifest との重複解決を排除
- コーナー要約ループを `for i, cl := range` に変更し、`コーナー「%s」を要約中 (%d/%d)` ログを出力
- 両 Summarizer が nil のときは summary ステップのログを出力しない（条件: `ProgramSummarizer != nil || CornerSummarizer != nil`）

## 変更点

- `internal/pipeline/pipeline.go`: logger 解決前倒し・summary フェーズログブロック追加
- `internal/pipeline/pipeline_test.go`: `TestRunner_Run_LogsSummaryStep`・`TestRunner_Run_NoSummaryLogWhenSummarizersNil` 追加

Closes #187

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)