### PR TITLE
docs: ADR-0026 を最終設計（cache を feed 状態源・配信プラットフォーム非依存）に更新

### DIFF
--- a/docs/adr/0026-feed-generation-as-vox-radio-subcommand.md
+++ b/docs/adr/0026-feed-generation-as-vox-radio-subcommand.md
@@ -5,28 +5,28 @@
 
 ## コンテキスト
 
-ADR-0012 で配信機能を別リポジトリへ分離し、RSS `feed.xml` 生成は broadcast 側の `feedgen` が担う。だが `feedgen` の vox-radio 依存は実質「manifest スキーマ」のみで、broadcast は `Manifest` を複製しており、拡張のたびの手動同期コストが顕在化した。
+ADR-0012 で配信機能を別リポジトリへ分離し、RSS `feed.xml` 生成は broadcast 側の `feedgen` が担う。だが依存は実質「manifest スキーマ」のみで、broadcast は `Manifest` 複製・`episodes.json`・ffprobe を維持しており、同期・運用コストが顕在化した。
 
-ADR-0012 は「同一リポジトリ内の別バイナリ分離」案を「配信方式の独立進化ができず責務分離が中途半端」として却下したが、本 ADR はこの同期コストを踏まえ部分修正する。
+ADR-0012 は「別バイナリ分離」を責務分離が中途半端として却下したが、本 ADR はこのコストを踏まえ部分修正する。
 
 ## 決定
 
-- `feed.xml` 生成（manifest → feed.xml 変換）を broadcast から vox-radio の**新サブコマンド `vox-radio feedgen`** へ移管する（移管元名を踏襲し `feed` 単独の曖昧さを避ける）。
-- **`distribution.yaml`・`episodes.json`・ホスティング・CI は引き続き broadcast が所有**する。
-- 形態は**別バイナリでなくサブコマンド**（goreleaser・install スクリプト変更不要、配信側 CI は同一バイナリを使い回せる）。
-- CLI 入力は **`manifest.json` と `distribution.yaml` の2ファイル**に削減し、`episodes.json`・`public` パスは `distribution.yaml` に記述する。
-- **feedgen はホスティング方式に依存しない**: 音声 URL は `distribution.yaml` のテンプレート（manifest 由来の値を置換）で組み立て、構築規約をコードに持たない。run の `episode.mp3` をリネームせず公開でき、id は manifest の `episode_number` を正とする。
-- vox-radio 既存の `internal/model.Manifest`・`internal/mediainfo` を再利用し契約を単一情報源化する。
+- `feed.xml` 生成を vox-radio の**新サブコマンド `vox-radio feedgen`** へ移管する（移管元名を踏襲、別バイナリでなくサブコマンド）。
+- **状態は run の cache（`internal/cache`）を正とし `episodes.json` は持たない**。feedgen は **cache + `distribution.yaml` → feed.xml** の純粋レンダラで、manifest・mp3・ffprobe に依存しない。
+- **`bytes`/`duration` は run 時に算出して cache に保存**し、配信側の ffprobe 依存を無くす（ADR-0012 を更新）。
+- **cache は全件保持し、detailed 窓外の回は重いフィールド（`corners`/`conversation_notes`）を compact** する（feed 全件と肥大抑制の両立）。
+- **feedgen は配信プラットフォーム非依存**（RSS 形式は前提）。音声 URL は `distribution.yaml` のテンプレート（cache 由来の値を置換）で組み立て、`episode.mp3` をリネーム不要で公開、id は `episode_number`。
+- ホスティング・配信メタ・CI は broadcast 所有。既存の `model.Manifest`・`mediainfo`・`cache` を再利用し契約を単一情報源化する。
 
 ## 結果
 
-- manifest 構造体の複製が解消し、スキーマ変更が生産者・消費者の同居でコンパイル時に検出される。
-- 責務境界を「バイナリ」でなく「設定・状態・配信先」に引き直す。配信方式の本体は broadcast に残るため『配信方式の独立進化』(ADR-0012) は維持される。
-- トレードオフ: RSS/iTunes 形式を持ち込む点は ADR-0012 と緊張するが、RSS は ADR-0005 で一本化済みで安定し、将来変われば `feedgen` を廃止できる。
-- broadcast 側は旧 `feedgen` 廃止・CI の `vox-radio feedgen` 切替が追従作業として必要。
+- Manifest 複製が解消しスキーマ変更がコンパイル時に検出される。配信側から `episodes.json` と ffprobe が消え、維持物が減る。
+- 責務境界を「設定・状態・配信先」に引き直す。ホスティングは broadcast に残り『配信プラットフォームの独立進化』(ADR-0012) は維持される。
+- トレードオフ: feed 長・dedup 窓が cache 設定に連動し、`bytes`/`duration` を vox-radio が供給する点で ADR-0012 を更新する。
+- broadcast 側は旧 `feedgen`・`episodes.json` 廃止、`distribution.yaml` 改訂、CI 切替が追従作業。
 
 ## 検討した代替案
 
-- **契約だけ共有（Manifest 型を pkg 公開し broadcast が import）**: 複製は消えるがツールが2リポジトリにまたがり、Go モジュール依存（バージョンスキュー）が生じるため却下。
-- **現状維持（二重定義の手動同期を継続）**: 顕在化した同期コストを解消できないため却下。
-- **別バイナリ化**: リリース資産・DL が二重化し配信側の取得処理変更が必要で、分離効果も限定的なため却下。
+- **`episodes.json` を別持ち**: feed の retention を独立制御できるが配信側の維持ファイルが増えるため却下。
+- **契約だけ共有（Manifest 型を pkg 公開）**: 複製は消えるが2リポジトリにまたがり Go モジュール依存（スキュー）が生じるため却下。
+- **別バイナリ化 / 現状維持**: 前者はリリース・DL の二重化、後者は同期コスト未解消で却下。


### PR DESCRIPTION
## 概要

ADR-0026（feed 生成を vox-radio feedgen に集約）を、相談で固まった最終設計に更新します。前回マージ版（#202）の `episodes.json` 前提を置き換えます。

## 主な変更点

- **状態源を cache に集約**: 別途 `episodes.json` を持たず、run が維持する `internal/cache` を feed の正とする。feedgen は **cache + distribution.yaml → feed.xml** の純粋レンダラ（manifest・mp3・ffprobe 不要）。
- **bytes/duration を run 時算出**: mp3 がローカルにある run 時に算出して cache に保存。配信側から ffprobe 依存が消える（ADR-0012 の「配信側が ffprobe」を更新）。
- **cache は全件保持＋compact**: prune（削除）を compact に変更し、detailed 窓外の回は重いフィールド（corners/conversation_notes）のみ削ぐ。feed 全件とサイズ抑制を両立。
- **原則の精密化**: 「配信形式に依存しない」→「**配信プラットフォームに依存しない**（RSS 形式は前提）」。音声 URL は distribution.yaml のテンプレート駆動で `episode.mp3` をリネーム不要で公開。

## 関連

- 前回マージ版: #202
- 実装仕様: #203（本設計に同期済み）
- 修正対象: ADR-0012

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)