### PR TITLE
feat: バイナリを手軽に導入できるインストールスクリプト(scripts/install-vox-radio.sh)を追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ make release-check
 
 ## CLIの使い方
 
+### バイナリインストール（リリース版）
+
+GitHub Releases のバイナリを `curl` のワンライナーで導入できます。
+
+```bash
+# 最新版をインストール
+curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | bash
+
+# バージョンを指定してインストール（引数で渡す）
+curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | bash -s -- v0.0.1
+
+# 設置先を変更（環境変数）
+curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | INSTALL_DIR=$HOME/.local/bin bash -s -- v0.0.1
+```
+
+デフォルトの設置先は `/usr/local/bin` です。書き込み権限がない場合は自動で `sudo` にフォールバックします。
+
 ### ビルド
 
 ```bash

--- a/scripts/install-vox-radio.sh
+++ b/scripts/install-vox-radio.sh
@@ -16,23 +16,33 @@ set -euo pipefail
 REPO="canpok1/vox-radio"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
-# ---- 引数パース ----
-if [[ $# -gt 1 ]]; then
-  echo "Usage: $0 [VERSION]" >&2
-  echo "  VERSION: release tag (e.g. v0.0.1). Omit to install the latest." >&2
-  exit 1
-fi
-
-if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+usage() {
   echo "Usage: $0 [VERSION]" >&2
   echo "  VERSION: release tag (e.g. v0.0.1). Omit to install the latest." >&2
   echo "" >&2
   echo "Environment variables:" >&2
   echo "  INSTALL_DIR  Installation directory (default: /usr/local/bin)" >&2
+}
+
+# ---- 引数パース ----
+if [[ $# -gt 1 ]]; then
+  usage
+  exit 1
+fi
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
   exit 0
 fi
 
 VERSION="${1:-}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: $1 が必要です" >&2
+    exit 1
+  fi
+}
 
 # ---- 必須コマンド検出 ----
 if command -v curl >/dev/null 2>&1; then
@@ -44,15 +54,7 @@ else
   exit 1
 fi
 
-if ! command -v tar >/dev/null 2>&1; then
-  echo "ERROR: tar が必要です" >&2
-  exit 1
-fi
-
-if ! command -v uname >/dev/null 2>&1; then
-  echo "ERROR: uname が必要です" >&2
-  exit 1
-fi
+require_cmd tar
 
 # sha256 検証コマンドを選択
 if command -v sha256sum >/dev/null 2>&1; then
@@ -96,14 +98,21 @@ download() {
   fi
 }
 
+download_stdout() {
+  local url="$1"
+  if [[ "$DOWNLOADER" == "curl" ]]; then
+    curl -fsSL "$url"
+  else
+    wget -qO- "$url"
+  fi
+}
+
 # ---- latest 解決 ----
 if [[ -z "$VERSION" ]]; then
   echo "最新バージョンを GitHub API から解決しています..."
-  api_url="https://api.github.com/repos/${REPO}/releases/latest"
-  api_response_file="$(mktemp)"
-  download "$api_url" "$api_response_file"
-  VERSION="$(grep '"tag_name"' "$api_response_file" | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
-  rm -f "$api_response_file"
+  VERSION="$(download_stdout "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
   if [[ -z "$VERSION" ]]; then
     echo "ERROR: latest バージョンの解決に失敗しました" >&2
     exit 1
@@ -133,9 +142,8 @@ download "$CHECKSUMS_URL" "$TMPDIR_WORK/$CHECKSUMS_NAME"
 
 # ---- sha256 検証 ----
 echo "チェックサムを検証しています..."
-# checksums.txt 内から対象アセットの行のみ抽出して検証
-grep "$ASSET_NAME" "$TMPDIR_WORK/$CHECKSUMS_NAME" > "$TMPDIR_WORK/expected.txt"
-(cd "$TMPDIR_WORK" && $SHA256CMD --check expected.txt)
+grep "$ASSET_NAME" "$TMPDIR_WORK/$CHECKSUMS_NAME" \
+  | (cd "$TMPDIR_WORK" && $SHA256CMD --check -)
 echo "チェックサム OK"
 
 # ---- 展開 ----

--- a/scripts/install-vox-radio.sh
+++ b/scripts/install-vox-radio.sh
@@ -142,8 +142,12 @@ download "$CHECKSUMS_URL" "$TMPDIR_WORK/$CHECKSUMS_NAME"
 
 # ---- sha256 検証 ----
 echo "チェックサムを検証しています..."
-grep "$ASSET_NAME" "$TMPDIR_WORK/$CHECKSUMS_NAME" \
-  | (cd "$TMPDIR_WORK" && $SHA256CMD --check -)
+checksum_line="$(grep "$ASSET_NAME" "$TMPDIR_WORK/$CHECKSUMS_NAME" || true)"
+if [[ -z "$checksum_line" ]]; then
+  echo "ERROR: checksums.txt に $ASSET_NAME のエントリが見つかりません" >&2
+  exit 1
+fi
+echo "$checksum_line" | (cd "$TMPDIR_WORK" && $SHA256CMD --check -)
 echo "チェックサム OK"
 
 # ---- 展開 ----

--- a/scripts/install-vox-radio.sh
+++ b/scripts/install-vox-radio.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# vox-radio バイナリを GitHub Releases から取得して INSTALL_DIR に配置する。
+#
+# 使い方:
+#   bash install-vox-radio.sh [VERSION]
+#   curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | bash -s -- v0.0.1
+#
+# 引数:
+#   VERSION  取得するリリースタグ (例: v0.0.1)。省略時は最新版を自動解決。
+#
+# 環境変数:
+#   INSTALL_DIR  バイナリ設置先ディレクトリ (デフォルト: /usr/local/bin)
+set -euo pipefail
+
+REPO="canpok1/vox-radio"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# ---- 引数パース ----
+if [[ $# -gt 1 ]]; then
+  echo "Usage: $0 [VERSION]" >&2
+  echo "  VERSION: release tag (e.g. v0.0.1). Omit to install the latest." >&2
+  exit 1
+fi
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  echo "Usage: $0 [VERSION]" >&2
+  echo "  VERSION: release tag (e.g. v0.0.1). Omit to install the latest." >&2
+  echo "" >&2
+  echo "Environment variables:" >&2
+  echo "  INSTALL_DIR  Installation directory (default: /usr/local/bin)" >&2
+  exit 0
+fi
+
+VERSION="${1:-}"
+
+# ---- 必須コマンド検出 ----
+if command -v curl >/dev/null 2>&1; then
+  DOWNLOADER="curl"
+elif command -v wget >/dev/null 2>&1; then
+  DOWNLOADER="wget"
+else
+  echo "ERROR: curl または wget が必要です" >&2
+  exit 1
+fi
+
+if ! command -v tar >/dev/null 2>&1; then
+  echo "ERROR: tar が必要です" >&2
+  exit 1
+fi
+
+if ! command -v uname >/dev/null 2>&1; then
+  echo "ERROR: uname が必要です" >&2
+  exit 1
+fi
+
+# sha256 検証コマンドを選択
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA256CMD="shasum -a 256"
+else
+  echo "ERROR: sha256sum または shasum が必要です" >&2
+  exit 1
+fi
+
+# ---- OS・arch 判定 ----
+os_raw="$(uname -s)"
+case "$os_raw" in
+  Linux)  OS="Linux" ;;
+  Darwin) OS="Darwin" ;;
+  *)
+    echo "ERROR: 未対応の OS: $os_raw (Linux / macOS のみサポート)" >&2
+    exit 1
+    ;;
+esac
+
+arch_raw="$(uname -m)"
+case "$arch_raw" in
+  x86_64 | amd64)   ARCH="x86_64" ;;
+  aarch64 | arm64)  ARCH="arm64" ;;
+  *)
+    echo "ERROR: 未対応の arch: $arch_raw (x86_64 / arm64 のみサポート)" >&2
+    exit 1
+    ;;
+esac
+
+# ---- ダウンロードヘルパー ----
+download() {
+  local url="$1"
+  local out="$2"
+  if [[ "$DOWNLOADER" == "curl" ]]; then
+    curl -fsSL -o "$out" "$url"
+  else
+    wget -q -O "$out" "$url"
+  fi
+}
+
+# ---- latest 解決 ----
+if [[ -z "$VERSION" ]]; then
+  echo "最新バージョンを GitHub API から解決しています..."
+  api_url="https://api.github.com/repos/${REPO}/releases/latest"
+  api_response_file="$(mktemp)"
+  download "$api_url" "$api_response_file"
+  VERSION="$(grep '"tag_name"' "$api_response_file" | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+  rm -f "$api_response_file"
+  if [[ -z "$VERSION" ]]; then
+    echo "ERROR: latest バージョンの解決に失敗しました" >&2
+    exit 1
+  fi
+  echo "最新バージョン: $VERSION"
+fi
+
+# VERSION から先頭 "v" を除いたもの（checksums ファイル名用）
+VERSION_NUM="${VERSION#v}"
+
+ASSET_NAME="vox-radio_${OS}_${ARCH}.tar.gz"
+CHECKSUMS_NAME="vox-radio_${VERSION_NUM}_checksums.txt"
+BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+TARBALL_URL="${BASE_URL}/${ASSET_NAME}"
+CHECKSUMS_URL="${BASE_URL}/${CHECKSUMS_NAME}"
+
+# ---- 一時ディレクトリ（EXIT 時に自動削除） ----
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+# ---- ダウンロード ----
+echo "ダウンロード中: $TARBALL_URL"
+download "$TARBALL_URL" "$TMPDIR_WORK/$ASSET_NAME"
+
+echo "ダウンロード中: $CHECKSUMS_URL"
+download "$CHECKSUMS_URL" "$TMPDIR_WORK/$CHECKSUMS_NAME"
+
+# ---- sha256 検証 ----
+echo "チェックサムを検証しています..."
+# checksums.txt 内から対象アセットの行のみ抽出して検証
+grep "$ASSET_NAME" "$TMPDIR_WORK/$CHECKSUMS_NAME" > "$TMPDIR_WORK/expected.txt"
+(cd "$TMPDIR_WORK" && $SHA256CMD --check expected.txt)
+echo "チェックサム OK"
+
+# ---- 展開 ----
+tar -xzf "$TMPDIR_WORK/$ASSET_NAME" -C "$TMPDIR_WORK" vox-radio
+
+# ---- インストール ----
+if [[ ! -d "$INSTALL_DIR" ]]; then
+  echo "ERROR: INSTALL_DIR が存在しません: $INSTALL_DIR" >&2
+  exit 1
+fi
+
+if [[ -w "$INSTALL_DIR" ]]; then
+  install -m 0755 "$TMPDIR_WORK/vox-radio" "$INSTALL_DIR/vox-radio"
+else
+  echo "書き込み権限がないため sudo でインストールします..."
+  sudo install -m 0755 "$TMPDIR_WORK/vox-radio" "$INSTALL_DIR/vox-radio"
+fi
+
+echo ""
+echo "インストール完了: $INSTALL_DIR/vox-radio"
+"$INSTALL_DIR/vox-radio" --version


### PR DESCRIPTION
## Summary

- `scripts/install-vox-radio.sh` を新規作成
  - `curl`/`wget` で GitHub Releases のバイナリを取得してインストール
  - Linux / macOS (Darwin) × x86_64 / arm64 対応
  - 第1引数でバージョン指定可。省略時は GitHub API で latest を自動解決（jq 非依存）
  - `vox-radio_<VERSION>_checksums.txt` による sha256 チェックサム検証
  - `INSTALL_DIR` 環境変数で設置先変更可、書き込み不可時は `sudo` フォールバック
  - `set -euo pipefail` + `trap` による一時ディレクトリクリーンアップ
  - `shellcheck` 指摘ゼロ
- `README.md` に「バイナリインストール（リリース版）」セクションとワンライナーを追記
- ローカルで動作確認済み（`v0.0.1` 指定・latest 両方）

Closes #205

---
🤖 Generated with [Claude Code](https://claude.ai/code)