### PR TITLE
feat: BGMの切り替わりにフェード／クロスフェードを導入してぶつ切り感をなくす

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,10 @@ vox-radio assemble --in work/intermediate/04_script.json --clips work/clips --ou
 | `volume` | float64 | 任意 | 音量倍率。デフォルト: 0（Go ゼロ値） |
 | `duck_ratio` | float64 | 任意 | セリフ再生中の音量低減比率（サイドチェインコンプ）。デフォルト: 0 |
 | `loop` | bool | 任意 | ループ再生するかどうか。デフォルト: false |
+| `fade_in` | float64 | 任意 | BGM 開始時のフェードイン秒数。省略時は 1.0 秒。`0` を指定するとフェードなし |
+| `fade_out` | float64 | 任意 | BGM 終了時のフェードアウト秒数。省略時は 1.0 秒。`0` を指定するとフェードなし |
 | `description` | string | 任意 | アセットの説明（「何の音か・いつ使うか」）。LLM が挿入タイミングを判断する際の手がかりになる |
 
 BGM の開始・停止は台本の `bgm` セグメントで制御します。`asset_name` にキー名を指定するとその BGM を開始し、空文字列を指定すると停止します。
+
+同一ラン内で BGM が別の BGM に切り替わる場合、前の BGM がフェードアウトしつつ次の BGM がフェードインするクロスフェードが自動で適用されます（重なり幅 = `min(prevFadeOut, nextFadeIn)`）。ジングル境界または BGM 明示停止時も `fade_out` 秒でフェードアウトします。

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -2,6 +2,7 @@ package assemble
 
 import (
 	"fmt"
+	"math"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -372,6 +373,31 @@ func buildRun(b *filterBuilder, run runData, clipInputIdx []int, assets config.A
 
 	// BGM intervals overlay.
 	if hasBGM {
+		// Pre-compute crossfade parameters for adjacent BGM pairs.
+		// crossfadeExtSec[i] = seconds to extend interval i (due to following crossfade with i+1).
+		// crossfadeFadeInSec[i] = fade-in duration override for interval i (due to preceding crossfade from i-1).
+		crossfadeExtSec := make([]float64, len(run.bgmIntervals))
+		crossfadeFadeInSec := make([]float64, len(run.bgmIntervals))
+		for i := 0; i < len(run.bgmIntervals)-1; i++ {
+			curr := run.bgmIntervals[i]
+			next := run.bgmIntervals[i+1]
+			currEntry, currOk := assets.BGM[curr.assetName]
+			nextEntry, nextOk := assets.BGM[next.assetName]
+			if !currOk || !nextOk {
+				continue
+			}
+			currEndMs := curr.endMs
+			if currEndMs < 0 {
+				currEndMs = run.durationMs
+			}
+			if next.startMs == currEndMs {
+				// Adjacent BGM pair: apply crossfade.
+				overlapSec := math.Min(currEntry.EffectiveFadeOut(), nextEntry.EffectiveFadeIn())
+				crossfadeExtSec[i] = overlapSec
+				crossfadeFadeInSec[i+1] = overlapSec
+			}
+		}
+
 		bgmParts := make([]string, 0, len(run.bgmIntervals))
 		for i, interval := range run.bgmIntervals {
 			entry, ok := assets.BGM[interval.assetName]
@@ -389,9 +415,35 @@ func buildRun(b *filterBuilder, run runData, clipInputIdx []int, assets config.A
 			if endMs < 0 {
 				endMs = run.durationMs
 			}
-			durationSec := float64(endMs-interval.startMs) / 1000.0
-			b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f,atrim=duration=%.3f,adelay=%d|%d%s",
-				bgmIdx, entry.Volume, durationSec, interval.startMs, interval.startMs, intervalLabel))
+			durationSec := float64(endMs-interval.startMs)/1000.0 + crossfadeExtSec[i]
+
+			// Determine fade-in/out durations.
+			fadeIn := crossfadeFadeInSec[i]
+			if fadeIn == 0 {
+				fadeIn = entry.EffectiveFadeIn()
+			}
+			fadeOut := crossfadeExtSec[i]
+			if fadeOut == 0 {
+				fadeOut = entry.EffectiveFadeOut()
+			}
+			// Clamp to half duration to prevent overlapping fades.
+			half := durationSec / 2
+			if fadeIn > half {
+				fadeIn = half
+			}
+			if fadeOut > half {
+				fadeOut = half
+			}
+
+			filterStr := fmt.Sprintf("[%d:a]volume=%.2f,atrim=duration=%.3f", bgmIdx, entry.Volume, durationSec)
+			if fadeIn > 0 {
+				filterStr += fmt.Sprintf(",afade=t=in:d=%.3f", fadeIn)
+			}
+			if fadeOut > 0 {
+				filterStr += fmt.Sprintf(",areverse,afade=t=in:d=%.3f,areverse", fadeOut)
+			}
+			filterStr += fmt.Sprintf(",adelay=%d|%d%s", interval.startMs, interval.startMs, intervalLabel)
+			b.addFilter(filterStr)
 			bgmParts = append(bgmParts, intervalLabel)
 		}
 

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -148,7 +148,7 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 		}
 		idx := b.addInput(entry.File)
 		label := buildJingleFadeIn(b, idx, entry)
-		label = applyFadeOut(b, label, idx, entry)
+		label = applyFadeOut(b, label, fmt.Sprintf("jingle%d", idx), entry.FadeOut)
 		jingleLabels[i] = label
 	}
 
@@ -435,15 +435,12 @@ func buildRun(b *filterBuilder, run runData, clipInputIdx []int, assets config.A
 				fadeOut = half
 			}
 
-			filterStr := fmt.Sprintf("[%d:a]volume=%.2f,atrim=duration=%.3f", bgmIdx, entry.Volume, durationSec)
-			if fadeIn > 0 {
-				filterStr += fmt.Sprintf(",afade=t=in:d=%.3f", fadeIn)
-			}
-			if fadeOut > 0 {
-				filterStr += fmt.Sprintf(",areverse,afade=t=in:d=%.3f,areverse", fadeOut)
-			}
-			filterStr += fmt.Sprintf(",adelay=%d|%d%s", interval.startMs, interval.startMs, intervalLabel)
-			b.addFilter(filterStr)
+			key := fmt.Sprintf("run%d_bgm%d", runIdx, i)
+			trimLabel := fmt.Sprintf("[%s_trim]", key)
+			b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f,atrim=duration=%.3f%s", bgmIdx, entry.Volume, durationSec, trimLabel))
+			label := applyFadeIn(b, trimLabel, key, fadeIn)
+			label = applyFadeOut(b, label, key, fadeOut)
+			b.addFilter(fmt.Sprintf("%sadelay=%d|%d%s", label, interval.startMs, interval.startMs, intervalLabel))
 			bgmParts = append(bgmParts, intervalLabel)
 		}
 
@@ -539,28 +536,29 @@ func applySilenceTrim(b *filterBuilder, currentLabel string, key string, enabled
 
 // buildJingleFadeIn applies silence trim then fade-in to a jingle input and returns the resulting label.
 func buildJingleFadeIn(b *filterBuilder, idx int, entry config.JingleEntry) string {
-	label := applySilenceTrim(b, fmt.Sprintf("[%d:a]", idx), fmt.Sprintf("jingle%d", idx), entry.EffectiveTrimSilence())
-	return applyFadeIn(b, label, idx, entry.FadeIn)
+	key := fmt.Sprintf("jingle%d", idx)
+	label := applySilenceTrim(b, fmt.Sprintf("[%d:a]", idx), key, entry.EffectiveTrimSilence())
+	return applyFadeIn(b, label, key, entry.FadeIn)
 }
 
-// applyFadeOut applies fade-out to the current label and returns the resulting label.
-// Returns currentLabel unchanged when entry.FadeOut <= 0.
-func applyFadeOut(b *filterBuilder, currentLabel string, idx int, entry config.JingleEntry) string {
-	if entry.FadeOut <= 0 {
+// applyFadeOut applies fade-out (areverse/afade/areverse) to currentLabel and returns the resulting label.
+// key is used to name the intermediate output label. Returns currentLabel unchanged when fadeSec <= 0.
+func applyFadeOut(b *filterBuilder, currentLabel string, key string, fadeSec float64) string {
+	if fadeSec <= 0 {
 		return currentLabel
 	}
-	fadedLabel := fmt.Sprintf("[jingle%d_fo]", idx)
-	b.addFilter(fmt.Sprintf("%sareverse,afade=t=in:d=%.3f,areverse%s", currentLabel, entry.FadeOut, fadedLabel))
+	fadedLabel := fmt.Sprintf("[%s_fo]", key)
+	b.addFilter(fmt.Sprintf("%sareverse,afade=t=in:d=%.3f,areverse%s", currentLabel, fadeSec, fadedLabel))
 	return fadedLabel
 }
 
 // applyFadeIn applies an afade=t=in filter to currentLabel and returns the output label.
-// Returns currentLabel unchanged when fadeSec <= 0.
-func applyFadeIn(b *filterBuilder, currentLabel string, idx int, fadeSec float64) string {
+// key is used to name the intermediate output label. Returns currentLabel unchanged when fadeSec <= 0.
+func applyFadeIn(b *filterBuilder, currentLabel string, key string, fadeSec float64) string {
 	if fadeSec <= 0 {
 		return currentLabel
 	}
-	outLabel := fmt.Sprintf("[jingle%d_fi]", idx)
+	outLabel := fmt.Sprintf("[%s_fi]", key)
 	b.addFilter(fmt.Sprintf("%safade=t=in:d=%.3f%s", currentLabel, fadeSec, outLabel))
 	return outLabel
 }

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -1498,3 +1498,224 @@ func TestBuildFFmpegArgs_SE_SequentialDurationAdvancesOverlaySEOffset(t *testing
 		t.Errorf("overlay SE adelay should be 7500ms (after sequential SE duration), filter: %s", args.FilterComplex)
 	}
 }
+
+func float64Ptr(v float64) *float64 { return &v }
+
+// TestBuildFFmpegArgs_BGMFadeInOut_A1 verifies that a BGM interval with explicit FadeIn/FadeOut
+// gets afade filters applied before adelay.
+func TestBuildFFmpegArgs_BGMFadeInOut_A1(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeBGM, AssetName: "talk_bgm"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "with bgm"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 5.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			BGM: map[string]config.BGMEntry{
+				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: float64Ptr(0.5), FadeOut: float64Ptr(0.5)},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Fade-in filter must appear.
+	if !strings.Contains(args.FilterComplex, "afade=t=in:d=0.500") {
+		t.Errorf("filter_complex missing afade fade-in for BGM: %s", args.FilterComplex)
+	}
+	// Fade-out filter (areverse trick) must appear.
+	if !strings.Contains(args.FilterComplex, "areverse,afade=t=in:d=0.500,areverse") {
+		t.Errorf("filter_complex missing areverse fade-out for BGM: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_BGMFadeDefault_A5 verifies that a BGM with no FadeIn/FadeOut fields
+// defaults to 1.0 second fade-in and fade-out.
+func TestBuildFFmpegArgs_BGMFadeDefault_A5(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeBGM, AssetName: "talk_bgm"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "with bgm"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 10.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			BGM: map[string]config.BGMEntry{
+				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Default 1.0-second fade-in must appear.
+	if !strings.Contains(args.FilterComplex, "afade=t=in:d=1.000") {
+		t.Errorf("filter_complex missing default 1.0s fade-in for BGM: %s", args.FilterComplex)
+	}
+	// Default 1.0-second fade-out (areverse trick) must appear.
+	if !strings.Contains(args.FilterComplex, "areverse,afade=t=in:d=1.000,areverse") {
+		t.Errorf("filter_complex missing default 1.0s fade-out for BGM: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_BGMFadeDisabled_A5 verifies that explicit FadeIn=0 / FadeOut=0
+// produces no afade filters for that BGM.
+func TestBuildFFmpegArgs_BGMFadeDisabled_A5(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeBGM, AssetName: "talk_bgm"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "with bgm"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 5.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			BGM: map[string]config.BGMEntry{
+				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: float64Ptr(0), FadeOut: float64Ptr(0)},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No afade filter should appear for this BGM.
+	if strings.Contains(args.FilterComplex, "afade") {
+		t.Errorf("filter_complex must not contain afade when FadeIn=FadeOut=0: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_BGMCrossfade_A2 verifies that adjacent BGM intervals produce a crossfade:
+// the first interval is extended and both intervals get afade filters.
+func TestBuildFFmpegArgs_BGMCrossfade_A2(t *testing.T) {
+	// Script: BGM(a) starts, speech1(5s), BGM(b) switches (adjacent to end of a), speech2(5s)
+	// BGM a: [0, 5500ms] (5s clip + 0.5s pauseSec), BGM b: [5500ms, end]
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeBGM, AssetName: "bgm_a"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "with bgm a"},
+				{Type: model.SegmentTypeBGM, AssetName: "bgm_b"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "guest", Text: "with bgm b"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 5.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 5.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			BGM: map[string]config.BGMEntry{
+				"bgm_a": {File: "/assets/bgm_a.mp3", Volume: 0.3, Loop: true, FadeIn: float64Ptr(0.5), FadeOut: float64Ptr(1.0)},
+				"bgm_b": {File: "/assets/bgm_b.mp3", Volume: 0.3, Loop: true, FadeIn: float64Ptr(1.0), FadeOut: float64Ptr(0.5)},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both BGM inputs must be present.
+	foundA, foundB := false, false
+	for _, inp := range args.Inputs {
+		if inp.Path == "/assets/bgm_a.mp3" {
+			foundA = true
+		}
+		if inp.Path == "/assets/bgm_b.mp3" {
+			foundB = true
+		}
+	}
+	if !foundA {
+		t.Errorf("bgm_a not in inputs: %v", args.Inputs)
+	}
+	if !foundB {
+		t.Errorf("bgm_b not in inputs: %v", args.Inputs)
+	}
+
+	// afade must appear for both intervals (fade-in of A, fade-out of A, fade-in of B, fade-out of B).
+	afadeCount := strings.Count(args.FilterComplex, "afade=t=in")
+	if afadeCount < 3 {
+		// At minimum: fade-in of A (0.5s), fade-out of A into crossfade (1.0s), fade-in of B (1.0s), fade-out of B (0.5s) = 4
+		// But with areverse trick, each fade-out has one afade call.
+		t.Errorf("expected at least 3 afade filters for crossfade (got %d): %s", afadeCount, args.FilterComplex)
+	}
+
+	// The first BGM interval (bgm_a) must be EXTENDED: atrim duration > 5.5s (original BGM a duration)
+	// overlapSec = min(FadeOut_A=1.0, FadeIn_B=1.0) = 1.0
+	// extended atrim = 5.5 + 1.0 = 6.5s → atrim=duration=6.500
+	if !strings.Contains(args.FilterComplex, "atrim=duration=6.500") {
+		t.Errorf("bgm_a should be extended for crossfade (atrim=duration=6.500): %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_BGMShortClamp_A4 verifies that a very short BGM interval (shorter than
+// FadeIn+FadeOut) does not break the filter generation.
+func TestBuildFFmpegArgs_BGMShortClamp_A4(t *testing.T) {
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeBGM, AssetName: "talk_bgm"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "short"},
+				{Type: model.SegmentTypeBGM, AssetName: ""},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 0.8},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			BGM: map[string]config.BGMEntry{
+				// FadeIn=1.0 and FadeOut=1.0 both exceed half the BGM interval duration
+				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: float64Ptr(1.0), FadeOut: float64Ptr(1.0)},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	// Should not error (filter is generated without breaking).
+	_, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Errorf("unexpected error for short BGM with large fade: %v", err)
+	}
+}

--- a/internal/cli/templates/profile.yaml
+++ b/internal/cli/templates/profile.yaml
@@ -90,4 +90,6 @@ corners:
 #       volume: 0.3
 #       duck_ratio: 8
 #       loop: true
+#       # fade_in: 1.0   # フェードイン秒数（省略時デフォルト 1.0 秒）
+#       # fade_out: 1.0  # フェードアウト秒数（省略時デフォルト 1.0 秒）。0 指定でフェードなし
 #       description: "雑談向けの落ち着いたBGM"  # 省略可

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,12 +65,41 @@ func effectiveTrimSilence(v *bool) bool {
 	return *v
 }
 
+// DefaultBGMFadeSec is the default fade-in/out duration (seconds) for BGM when not explicitly specified.
+const DefaultBGMFadeSec = 1.0
+
 type BGMEntry struct {
-	File        string  `yaml:"file"`
-	Volume      float64 `yaml:"volume"`
-	DuckRatio   float64 `yaml:"duck_ratio"`
-	Loop        bool    `yaml:"loop"`
-	Description string  `yaml:"description,omitempty"`
+	File        string   `yaml:"file"`
+	Volume      float64  `yaml:"volume"`
+	DuckRatio   float64  `yaml:"duck_ratio"`
+	Loop        bool     `yaml:"loop"`
+	FadeIn      *float64 `yaml:"fade_in,omitempty"`
+	FadeOut     *float64 `yaml:"fade_out,omitempty"`
+	Description string   `yaml:"description,omitempty"`
+}
+
+// EffectiveFadeIn returns the fade-in duration in seconds.
+// nil (unspecified) → DefaultBGMFadeSec; negative values are clamped to 0.
+func (e BGMEntry) EffectiveFadeIn() float64 {
+	if e.FadeIn == nil {
+		return DefaultBGMFadeSec
+	}
+	if *e.FadeIn < 0 {
+		return 0
+	}
+	return *e.FadeIn
+}
+
+// EffectiveFadeOut returns the fade-out duration in seconds.
+// nil (unspecified) → DefaultBGMFadeSec; negative values are clamped to 0.
+func (e BGMEntry) EffectiveFadeOut() float64 {
+	if e.FadeOut == nil {
+		return DefaultBGMFadeSec
+	}
+	if *e.FadeOut < 0 {
+		return 0
+	}
+	return *e.FadeOut
 }
 
 type AssetsConfig struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,7 @@ type BGMEntry struct {
 	Description string   `yaml:"description,omitempty"`
 }
 
-// effectiveFadeSec resolves a *float64 fade setting: nil → defaultVal, negative → 0.
+// effectiveFadeSec resolves a *float64 fade setting: nil → DefaultBGMFadeSec, negative → 0.
 func effectiveFadeSec(v *float64) float64 {
 	if v == nil {
 		return DefaultBGMFadeSec

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,29 +78,24 @@ type BGMEntry struct {
 	Description string   `yaml:"description,omitempty"`
 }
 
-// EffectiveFadeIn returns the fade-in duration in seconds.
-// nil (unspecified) → DefaultBGMFadeSec; negative values are clamped to 0.
-func (e BGMEntry) EffectiveFadeIn() float64 {
-	if e.FadeIn == nil {
+// effectiveFadeSec resolves a *float64 fade setting: nil → defaultVal, negative → 0.
+func effectiveFadeSec(v *float64) float64 {
+	if v == nil {
 		return DefaultBGMFadeSec
 	}
-	if *e.FadeIn < 0 {
+	if *v < 0 {
 		return 0
 	}
-	return *e.FadeIn
+	return *v
 }
+
+// EffectiveFadeIn returns the fade-in duration in seconds.
+// nil (unspecified) → DefaultBGMFadeSec; negative values are clamped to 0.
+func (e BGMEntry) EffectiveFadeIn() float64 { return effectiveFadeSec(e.FadeIn) }
 
 // EffectiveFadeOut returns the fade-out duration in seconds.
 // nil (unspecified) → DefaultBGMFadeSec; negative values are clamped to 0.
-func (e BGMEntry) EffectiveFadeOut() float64 {
-	if e.FadeOut == nil {
-		return DefaultBGMFadeSec
-	}
-	if *e.FadeOut < 0 {
-		return 0
-	}
-	return *e.FadeOut
-}
+func (e BGMEntry) EffectiveFadeOut() float64 { return effectiveFadeSec(e.FadeOut) }
 
 type AssetsConfig struct {
 	Jingle map[string]JingleEntry `yaml:"jingle"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -849,3 +849,47 @@ func TestSEEntry_EffectiveOverlay(t *testing.T) {
 		}
 	}
 }
+
+func float64Ptr(v float64) *float64 { return &v }
+
+func TestBGMEntry_EffectiveFadeIn(t *testing.T) {
+	cases := []struct {
+		name string
+		ptr  *float64
+		want float64
+	}{
+		{"nil defaults to DefaultBGMFadeSec", nil, config.DefaultBGMFadeSec},
+		{"zero disables fade-in", float64Ptr(0.0), 0.0},
+		{"positive value used as-is", float64Ptr(2.0), 2.0},
+		{"negative clamped to zero", float64Ptr(-1.0), 0.0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := config.BGMEntry{FadeIn: c.ptr}
+			if got := e.EffectiveFadeIn(); got != c.want {
+				t.Errorf("ptr=%v: got %v, want %v", c.ptr, got, c.want)
+			}
+		})
+	}
+}
+
+func TestBGMEntry_EffectiveFadeOut(t *testing.T) {
+	cases := []struct {
+		name string
+		ptr  *float64
+		want float64
+	}{
+		{"nil defaults to DefaultBGMFadeSec", nil, config.DefaultBGMFadeSec},
+		{"zero disables fade-out", float64Ptr(0.0), 0.0},
+		{"positive value used as-is", float64Ptr(2.0), 2.0},
+		{"negative clamped to zero", float64Ptr(-1.0), 0.0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := config.BGMEntry{FadeOut: c.ptr}
+			if got := e.EffectiveFadeOut(); got != c.want {
+				t.Errorf("ptr=%v: got %v, want %v", c.ptr, got, c.want)
+			}
+		})
+	}
+}

--- a/sample-profiles/tech_profile.yaml
+++ b/sample-profiles/tech_profile.yaml
@@ -51,4 +51,6 @@ assets:
       volume: 0.3
       duck_ratio: 8
       loop: true
+      # fade_in: 1.0   # フェードイン秒数（省略時デフォルト 1.0 秒）
+      # fade_out: 1.0  # フェードアウト秒数（省略時デフォルト 1.0 秒）。0 指定でフェードなし
       description: "雑談・ゆるい話題向けの落ち着いたカフェ風BGM"


### PR DESCRIPTION
## Summary

- `BGMEntry` に `fade_in` / `fade_out` (*float64) フィールドと `EffectiveFadeIn` / `EffectiveFadeOut` メソッドを追加
  - nil (未指定) → デフォルト 1.0 秒のフェードが有効、明示的 `0` → フェードなし
  - 定数 `DefaultBGMFadeSec = 1.0` を追加
- `buildRun` の BGM 区間処理に `afade=t=in` + `areverse` フェードフィルターを適用
- 同一ラン内で BGM が隣接して切り替わる場合は前後を重ねる**クロスフェード**を実現（重なり幅 = `min(prevFadeOut, nextFadeIn)`）
- 短い BGM でフェード合計が区間長を超えても破綻しないようハーフ幅クランプを実装
- `applyFadeIn` / `applyFadeOut` ヘルパーをジングルと BGM で共通化（`key string` ベースに統一）
- README・`internal/cli/templates/profile.yaml`・`sample-profiles/tech_profile.yaml` に `fade_in`/`fade_out` の説明を追記

## Acceptance Criteria

- [x] A1: 各 BGM 区間が開始で `EffectiveFadeIn` 秒、終了で `EffectiveFadeOut` 秒フェード
- [x] A2: 同一ラン内で BGM が別 BGM に隣接切り替わるときクロスフェード
- [x] A3: ジングル境界・BGM 明示停止時に `EffectiveFadeOut` 秒フェードアウト
- [x] A4: フェード合計 > 区間長でも破綻しない（クランプ）
- [x] A5: 未指定で 1.0 秒適用・明示的 `0` でフェード無効
- [x] A6: ジングル・SE・loudnorm・alimiter・ダッキングの出力は変化なし

Closes #210

---
🤖 Generated with [Claude Code](https://claude.ai/code)