### PR TITLE
fix: rundown ステップのログをカスタムハンドラ経由に統一する

### DIFF
--- a/internal/cli/episodegen.go
+++ b/internal/cli/episodegen.go
@@ -87,7 +87,7 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 
 			collector := collect.New(nil, collect.WithLogger(logger))
 			summarizer := summarize.NewLLMSummarizer(llmClient, prompts["summarize"], stepTemp(cfg.LLM, "summarize"))
-			rundowner := rundown.NewLLMRundowner(selector, summarizer, collector, excludedURLs)
+			rundowner := rundown.NewLLMRundowner(selector, summarizer, collector, excludedURLs, rundown.WithLogger(logger))
 
 			scripter := script.NewLLMScriptGenerator(
 				writer,

--- a/internal/cli/rundown.go
+++ b/internal/cli/rundown.go
@@ -33,7 +33,6 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 				return fmt.Errorf("setup logger: %w", err)
 			}
 			defer func() { _ = logFile.Close() }()
-			_ = logger
 
 			cfg, p, err := loadConfigAndSpec(specPath)
 			if err != nil {
@@ -54,7 +53,7 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 
 			selector := sel.NewLLMSelector(llmClient, prompts["select"], stepTemp(cfg.LLM, "select"))
 			summarizer := summarize.NewLLMSummarizer(llmClient, prompts["summarize"], stepTemp(cfg.LLM, "summarize"))
-			rd := rundown.NewLLMRundowner(selector, summarizer, nil, nil)
+			rd := rundown.NewLLMRundowner(selector, summarizer, nil, nil, rundown.WithLogger(logger))
 
 			result, err := rd.Run(context.Background(), p.Corners, articles)
 			if err != nil {

--- a/internal/rundown/rundown.go
+++ b/internal/rundown/rundown.go
@@ -56,11 +56,11 @@ func NewLLMRundowner(selector sel.Selector, summarizer summarize.Summarizer, fet
 	for _, opt := range opts {
 		opt(r)
 	}
+	r.logger = r.logger.With("step", "rundown")
 	return r
 }
 
 func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, articles model.Articles) (model.Rundown, error) {
-	logger := r.logger.With("step", "rundown")
 	articleMap := articles.CornerMap()
 	rundownCorners := make([]model.RundownCorner, 0, len(corners))
 
@@ -74,7 +74,7 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 			}
 		}
 		if n := len(cornerArticles) - len(filtered); n > 0 {
-			logger.Info("excluded past articles", "corner", corner.Title, "count", n)
+			r.logger.Info("excluded past articles", "corner", corner.Title, "count", n)
 		}
 		cornerArticles = filtered
 
@@ -106,9 +106,9 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 			}
 			if r.fetcher != nil {
 				if fullText, err := r.fetcher.FetchFullText(ctx, url); err != nil {
-					logger.Warn("full text fetch failed, using feed body", "url", url, "err", err)
+					r.logger.Warn("full text fetch failed, using feed body", "url", url, "err", err)
 				} else if fullText == "" {
-					logger.Warn("full text fetch returned empty body, using feed body", "url", url)
+					r.logger.Warn("full text fetch returned empty body, using feed body", "url", url)
 				} else {
 					a.Body = fullText
 				}

--- a/internal/rundown/rundown.go
+++ b/internal/rundown/rundown.go
@@ -21,26 +21,46 @@ type ArticleFetcher interface {
 	FetchFullText(ctx context.Context, url string) (string, error)
 }
 
+// Option configures an LLMRundowner.
+type Option func(*LLMRundowner)
+
+// WithLogger sets the logger used for log output.
+func WithLogger(l *slog.Logger) Option {
+	return func(r *LLMRundowner) { r.logger = l }
+}
+
 // LLMRundowner uses Selector + Summarizer to produce a Rundown.
 type LLMRundowner struct {
 	selector     sel.Selector
 	summarizer   summarize.Summarizer
 	fetcher      ArticleFetcher
 	excludedURLs map[string]struct{}
+	logger       *slog.Logger
 }
 
 // NewLLMRundowner creates a LLMRundowner.
 // fetcher may be nil (skips full-text fetch).
 // excludedURLs is the set of article URLs to exclude before selection (nil = no exclusion).
-func NewLLMRundowner(selector sel.Selector, summarizer summarize.Summarizer, fetcher ArticleFetcher, excludedURLs []string) *LLMRundowner {
+func NewLLMRundowner(selector sel.Selector, summarizer summarize.Summarizer, fetcher ArticleFetcher, excludedURLs []string, opts ...Option) *LLMRundowner {
 	excluded := make(map[string]struct{}, len(excludedURLs))
 	for _, u := range excludedURLs {
 		excluded[u] = struct{}{}
 	}
-	return &LLMRundowner{selector: selector, summarizer: summarizer, fetcher: fetcher, excludedURLs: excluded}
+	r := &LLMRundowner{
+		selector:     selector,
+		summarizer:   summarizer,
+		fetcher:      fetcher,
+		excludedURLs: excluded,
+		logger:       slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, articles model.Articles) (model.Rundown, error) {
+	logger := r.logger.With("step", "rundown")
 	articleMap := articles.CornerMap()
 	rundownCorners := make([]model.RundownCorner, 0, len(corners))
 
@@ -54,7 +74,7 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 			}
 		}
 		if n := len(cornerArticles) - len(filtered); n > 0 {
-			slog.Info("excluded past articles", "corner", corner.Title, "count", n)
+			logger.Info("excluded past articles", "corner", corner.Title, "count", n)
 		}
 		cornerArticles = filtered
 
@@ -86,9 +106,9 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 			}
 			if r.fetcher != nil {
 				if fullText, err := r.fetcher.FetchFullText(ctx, url); err != nil {
-					slog.Warn("full text fetch failed, using feed body", "url", url, "err", err)
+					logger.Warn("full text fetch failed, using feed body", "url", url, "err", err)
 				} else if fullText == "" {
-					slog.Warn("full text fetch returned empty body, using feed body", "url", url)
+					logger.Warn("full text fetch returned empty body, using feed body", "url", url)
 				} else {
 					a.Body = fullText
 				}

--- a/internal/rundown/rundown_test.go
+++ b/internal/rundown/rundown_test.go
@@ -1,11 +1,15 @@
 package rundown_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/logging"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/rundown"
 	sel "github.com/canpok1/vox-radio/internal/rundown/select"
@@ -420,6 +424,46 @@ func TestLLMRundowner_Run_FetcherNil_SkipsFetch(t *testing.T) {
 	}
 	if body, ok := msum.receivedBodies["https://example.com/1"]; !ok || body != "フィードボディ" {
 		t.Errorf("summarizer should receive original feed body when fetcher is nil, got %q", body)
+	}
+}
+
+func TestLLMRundowner_WithLogger_ExcludedArticlesLogFormat(t *testing.T) {
+	var buf bytes.Buffer
+	handler := logging.NewTextHandler(&buf, slog.LevelInfo)
+	logger := slog.New(handler)
+
+	ms := &mockSelector{
+		result: sel.SelectResult{SelectedURLs: []string{"https://example.com/2"}, Flow: "flow"},
+	}
+	rd := rundown.NewLLMRundowner(ms, &mockSummarizer{}, nil, []string{"https://example.com/1"}, rundown.WithLogger(logger))
+
+	articles := model.Articles{
+		Corners: []model.CornerArticles{
+			{
+				CornerTitle: "今日のテックニュース",
+				Articles: []model.Article{
+					{URL: "https://example.com/1", Title: "除外記事", Body: "body"},
+					{URL: "https://example.com/2", Title: "対象記事", Body: "body"},
+				},
+			},
+		},
+	}
+	corners := []config.CornerConfig{defaultCorner("今日のテックニュース")}
+
+	_, err := rd.Run(context.Background(), corners, articles)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "rundown: excluded past articles") {
+		t.Errorf("log output should contain 'rundown: excluded past articles', got: %q", got)
+	}
+	if !strings.Contains(got, "corner=今日のテックニュース") {
+		t.Errorf("log output should contain 'corner=今日のテックニュース', got: %q", got)
+	}
+	if !strings.Contains(got, "count=1") {
+		t.Errorf("log output should contain 'count=1', got: %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `internal/rundown` に functional option パターン（`Option` / `WithLogger`）を追加し、`LLMRundowner` に `logger *slog.Logger` フィールドを持たせた
- コンストラクタ末尾で `r.logger.With("step", "rundown")` を一度適用することで、`Run` のたびのアロケートを排除
- `Run` 内の `slog.Info` / `slog.Warn`（グローバル呼び出し）を `r.logger.Info` / `r.logger.Warn` に置換
- `internal/cli/episodegen.go` と `internal/cli/rundown.go` の呼び出し側で `rundown.WithLogger(logger)` を渡すよう更新（`_ = logger` 抑制ダミーも除去）
- `TestLLMRundowner_WithLogger_ExcludedArticlesLogFormat` テストで `logging.TextHandler` 注入時に `[HH:MM:SS] rundown: excluded past articles` 形式で出力されることを検証

Closes #223

---
🤖 Generated with [Claude Code](https://claude.ai/code)