### PR TITLE
feat: コーナーを回ごとに組み替える機能を追加する（各コーナーの回番号条件で出現を切り替え）

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,48 @@ vox-radio episodegen assemble --in work/intermediate/04_script.json --clips work
 | `bgm` | string | 任意 | コーナー中 BGM のキー名（`assets.bgm` のキーと一致させること）。コーナー本編を開始/停止セグメントで挟む |
 | `start_pause_sec` | float64 | 任意 | コーナー先頭（`start_jingle` より前）に挿入する無音時間（秒）。0 または省略時は挿入しない |
 | `end_pause_sec` | float64 | 任意 | コーナー末尾（`end_jingle` より後）に挿入する無音時間（秒）。0 または省略時は挿入しない |
+| `condition` | EpisodeCondition | 任意 | コーナーの出現条件（省略すると毎回必ず出る固定コーナー） |
+
+##### `corners[].condition` サブフィールド
+
+`condition` を設定すると、回番号が条件に合致したときのみそのコーナーが採用されます。`condition` を省略したコーナーは毎回必ず採用される固定コーナーとなります。
+
+```yaml
+corners:
+  - title: "オープニング"       # condition なし → 毎回必須
+    content: "挨拶と自己紹介"
+    cast: { zundamon: "MC" }
+    length_sec: 30
+
+  - title: "リスナー投稿コーナー"
+    content: "投稿を紹介して語り合う"
+    cast: { zundamon: "進行", metan: "ツッコミ" }
+    length_sec: 120
+    condition:
+      every: 2                  # 偶数回（2,4,6,…）に採用
+
+  - title: "今週の一冊"
+    content: "おすすめの本を紹介"
+    cast: { zundamon: "ボケ", metan: "解説" }
+    length_sec: 120
+    condition:
+      episodes: [1, 5, 9]       # 第1・5・9回に採用
+
+  - title: "エンディング"        # condition なし → 毎回必須
+    content: "締めの挨拶"
+    cast: { zundamon: "MC" }
+    length_sec: 30
+```
+
+| フィールド | 型 | 必須/任意 | 説明 |
+|---|---|---|---|
+| `condition.episodes` | []int | 任意 | 採用する回番号の明示リスト（各値は 1 以上） |
+| `condition.every` | int | 任意 | 周期的な採用（N の倍数回に採用。1 以上） |
+
+- `condition.episodes` と `condition.every` の両方を指定した場合は **論理和**（どちらかに合致すれば採用）
+- `condition.episodes` と `condition.every` のどちらも未設定の場合はバリデーションエラー
+- キャッシュが無効または `program.id` が未設定で回番号が不明な場合、条件付きコーナーを含む全コーナーが採用されます（警告ログが出力されます）
+- 採用されたコーナーは元の `corners` 配列の順序を維持したまま台本に出力されます
 
 ##### `corners[].source` サブフィールド
 

--- a/examples/tech.yaml
+++ b/examples/tech.yaml
@@ -25,6 +25,28 @@ corners:
           max_items: 5
         - url: https://qiita.com/popular-items/feed
           max_items: 5
+  - title: "リスナー Q&A"
+    content: "リスナーからの質問や投稿を紹介して語り合う。"
+    cast:
+      zundamon: "MC。元気に読み上げる進行役。ボケ担当。"
+      metan: "MC。ずんだもんに突っ込む。ツッコミ担当。"
+    length_sec: 120
+    condition:
+      every: 2                  # 偶数回（2,4,6,…）に採用
+
+  - title: "今週のピックアップ記事"
+    content: "編集部おすすめのテック記事を1本深掘りして紹介。"
+    cast:
+      zundamon: "MC。ボケ担当。記事を読んだことがない設定。"
+      metan: "MC。解説役。ツッコミ担当。"
+    length_sec: 120
+    source:
+      feeds:
+        - url: https://zenn.dev/feed
+          max_items: 3
+    condition:
+      episodes: [1, 3, 5, 7, 9]  # 奇数回に採用
+
   - title: "エンディング"
     content: "次回も聴いて欲しいという宣伝をする。"
     direction: "エンディングでまとめる。"

--- a/internal/cli/collect.go
+++ b/internal/cli/collect.go
@@ -41,10 +41,8 @@ source フィールドのないコーナーはスキップされます。
 			}
 
 			// 回番号を持たないため全コーナーを superset として収集する（rundown 側で絞る）
-			allCorners := config.ResolveCornersForEpisode(p.Corners, 0)
-
 			c := collect.New(nil, collect.WithLogger(logger))
-			articles, err := c.RunAll(context.Background(), allCorners)
+			articles, err := c.RunAll(context.Background(), p.Corners)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/collect.go
+++ b/internal/cli/collect.go
@@ -36,8 +36,15 @@ source フィールドのないコーナーはスキップされます。
 				return fmt.Errorf("load spec: %w", err)
 			}
 
+			if err := config.ValidateEpisodeSpecCorners(p); err != nil {
+				return fmt.Errorf("spec validation: %w", err)
+			}
+
+			// 回番号を持たないため全コーナーを superset として収集する（rundown 側で絞る）
+			allCorners := config.ResolveCornersForEpisode(p.Corners, 0)
+
 			c := collect.New(nil, collect.WithLogger(logger))
-			articles, err := c.RunAll(context.Background(), p.Corners)
+			articles, err := c.RunAll(context.Background(), allCorners)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/episodegen.go
+++ b/internal/cli/episodegen.go
@@ -88,6 +88,8 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 			selectedGuests := selectGuests(p.Guests, episodeNumber, logger)
 			writer.SetGuests(selectedGuests)
 
+			p.Corners = resolveCorners(p.Corners, episodeNumber, logger)
+
 			collector := collect.New(nil, collect.WithLogger(logger))
 			summarizer := summarize.NewLLMSummarizer(llmClient, prompts["summarize"], stepTemp(cfg.LLM, "summarize"))
 			rundowner := rundown.NewLLMRundowner(selector, summarizer, collector, excludedURLs, rundown.WithLogger(logger))

--- a/internal/cli/episodegen_check.go
+++ b/internal/cli/episodegen_check.go
@@ -46,6 +46,10 @@ func newEpisodegenCheckCmd() *cobra.Command {
 				return err
 			}
 
+			if err := config.ValidateEpisodeSpecCorners(p); err != nil {
+				return err
+			}
+
 			_, _ = fmt.Fprintf(cmd.OutOrStdout(), "OK: %s\n", path)
 			return nil
 		},

--- a/internal/cli/rundown.go
+++ b/internal/cli/rundown.go
@@ -51,16 +51,18 @@ vox-radio.yaml はカレントディレクトリから自動読み込みされ�
 				return fmt.Errorf("read articles: %w", err)
 			}
 
+			episodeNumber := resolveEpisodeNumber(cfg, p.Program.ID)
+			corners := resolveCorners(p.Corners, episodeNumber, logger)
+
 			selector := sel.NewLLMSelector(llmClient, prompts["select"], stepTemp(cfg.LLM, "select"))
 			summarizer := summarize.NewLLMSummarizer(llmClient, prompts["summarize"], stepTemp(cfg.LLM, "summarize"))
 			rd := rundown.NewLLMRundowner(selector, summarizer, nil, nil, rundown.WithLogger(logger))
 
-			result, err := rd.Run(context.Background(), p.Corners, articles)
+			result, err := rd.Run(context.Background(), corners, articles)
 			if err != nil {
 				return fmt.Errorf("rundown: %w", err)
 			}
 
-			episodeNumber := resolveEpisodeNumber(cfg, p.Program.ID)
 			result.Guests = selectGuests(p.Guests, episodeNumber, logger)
 
 			if err := writeJSON(out, result); err != nil {

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -94,13 +94,18 @@ func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, c
 	if in == "" {
 		return fmt.Errorf("--in is required for full pipeline")
 	}
-	rundown, err := readJSON[model.Rundown](in)
+	rd, err := readJSON[model.Rundown](in)
 	if err != nil {
 		return fmt.Errorf("read rundown: %w", err)
 	}
 
+	corners, err := resolveCornersByRundown(p.Corners, rd)
+	if err != nil {
+		return fmt.Errorf("resolve corners: %w", err)
+	}
+
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(cfg.LLM, "write"), cfg)
-	w.SetGuests(rundown.Guests)
+	w.SetGuests(rd.Guests)
 
 	gen := script.NewLLMScriptGenerator(
 		w,
@@ -110,7 +115,7 @@ func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, c
 		script.WithLogger(logger),
 	)
 
-	scr, err := gen.Generate(ctx, p.Program, rundown, p.Corners, cfg.Characters)
+	scr, err := gen.Generate(ctx, p.Program, rd, corners, cfg.Characters)
 	if err != nil {
 		return fmt.Errorf("generate: %w", err)
 	}
@@ -122,16 +127,21 @@ func runScriptWrite(ctx context.Context, in, workDir string, c llm.Client, cfg *
 	if in == "" {
 		return fmt.Errorf("--in is required for write step")
 	}
-	rundown, err := readJSON[model.Rundown](in)
+	rd, err := readJSON[model.Rundown](in)
 	if err != nil {
 		return fmt.Errorf("read rundown: %w", err)
 	}
 
-	cornerMap := rundown.CornerMap()
-	appliedCorners := script.ApplyGuests(p.Corners, rundown.Guests)
+	corners, err := resolveCornersByRundown(p.Corners, rd)
+	if err != nil {
+		return fmt.Errorf("resolve corners: %w", err)
+	}
+
+	cornerMap := rd.CornerMap()
+	appliedCorners := script.ApplyGuests(corners, rd.Guests)
 
 	w := write.NewLLMWriter(c, prompts["write"], stepTemp(cfg.LLM, "write"), cfg)
-	w.SetGuests(rundown.Guests)
+	w.SetGuests(rd.Guests)
 	allCornerLines, err := script.WriteAll(ctx, w, p.Program, appliedCorners, cornerMap, cfg.Characters)
 	if err != nil {
 		return fmt.Errorf("write corners: %w", err)

--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -52,6 +52,12 @@ corners:
         - url: https://example.com/feed
           max_items: 5
       articles: []
+    # 出現条件（省略すると毎回出る固定コーナー）
+    # condition を設定すると、回番号が合致したときのみ採用される
+    # condition:
+    #   episodes: [1, 3, 5]    # 第1・3・5回に採用（明示リスト）
+    #   every: 2               # 偶数回に採用（周期指定）
+    #   # episodes と every は両方指定すると論理和（どちらかに合致すれば採用）
 
   - title: "エンディング"
     content: "まとめと締め"

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"github.com/canpok1/vox-radio/internal/cache"
@@ -106,17 +107,8 @@ func resolveCornersByRundown(corners []config.CornerConfig, rd model.Rundown) ([
 // resolveCorners は回番号で採用コーナーを絞り込む。
 // 回番号不明（0）の場合は全コーナーを採用し、条件付きコーナーが存在するときは警告を出す。
 func resolveCorners(corners []config.CornerConfig, episodeNumber int, logger *slog.Logger) []config.CornerConfig {
-	if episodeNumber == 0 {
-		hasConditioned := false
-		for _, c := range corners {
-			if c.Condition != nil {
-				hasConditioned = true
-				break
-			}
-		}
-		if hasConditioned {
-			logger.Warn("回番号が不明なため、条件付きコーナーを含む全コーナーを採用します")
-		}
+	if episodeNumber == 0 && slices.ContainsFunc(corners, func(c config.CornerConfig) bool { return c.Condition != nil }) {
+		logger.Warn("回番号が不明なため、条件付きコーナーを含む全コーナーを採用します")
 	}
 	return config.ResolveCornersForEpisode(corners, episodeNumber)
 }

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -93,6 +93,34 @@ func selectGuests(guests map[string]config.GuestConfig, episodeNumber int, logge
 	return selected
 }
 
+// resolveCornersByRundown は rundown のコーナータイトル順に spec のコーナーを再構成する。
+// script 系で採用コーナーを再現するために使う（回番号不要・再実行で不変）。
+func resolveCornersByRundown(corners []config.CornerConfig, rd model.Rundown) ([]config.CornerConfig, error) {
+	titles := make([]string, len(rd.Corners))
+	for i, c := range rd.Corners {
+		titles[i] = c.Title
+	}
+	return config.ResolveCornersByTitles(corners, titles)
+}
+
+// resolveCorners は回番号で採用コーナーを絞り込む。
+// 回番号不明（0）の場合は全コーナーを採用し、条件付きコーナーが存在するときは警告を出す。
+func resolveCorners(corners []config.CornerConfig, episodeNumber int, logger *slog.Logger) []config.CornerConfig {
+	if episodeNumber == 0 {
+		hasConditioned := false
+		for _, c := range corners {
+			if c.Condition != nil {
+				hasConditioned = true
+				break
+			}
+		}
+		if hasConditioned {
+			logger.Warn("回番号が不明なため、条件付きコーナーを含む全コーナーを採用します")
+		}
+	}
+	return config.ResolveCornersForEpisode(corners, episodeNumber)
+}
+
 // resolveEpisodeNumber returns the next episode number from cache.
 // Returns 0 if cache is disabled, programID is empty, or cache fails to load.
 func resolveEpisodeNumber(cfg *config.Config, programID string) int {
@@ -124,6 +152,9 @@ func loadConfigAndSpec(specPath string) (*config.Config, *config.EpisodeSpec, er
 		return nil, nil, fmt.Errorf("spec validation: %w", err)
 	}
 	if err := config.ValidateEpisodeSpecGuests(p, cfg.Characters); err != nil {
+		return nil, nil, fmt.Errorf("spec validation: %w", err)
+	}
+	if err := config.ValidateEpisodeSpecCorners(p); err != nil {
 		return nil, nil, fmt.Errorf("spec validation: %w", err)
 	}
 	return cfg, p, nil

--- a/internal/cli/util_test.go
+++ b/internal/cli/util_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/cache"
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/model"
 )
 
 func writeCacheJSONL(t *testing.T, dir string, programID string, entries []cache.Entry) {
@@ -114,5 +116,79 @@ func TestSetupLogger_DefaultLogDir(t *testing.T) {
 	wantPrefix := filepath.Join(tmpDir, ".vox-radio", "logs")
 	if !strings.HasPrefix(logPath, wantPrefix) {
 		t.Errorf("log file path %q does not start with %q", logPath, wantPrefix)
+	}
+}
+
+func TestResolveCorners_WithEpisodeNumber(t *testing.T) {
+	cond := &config.EpisodeCondition{Episodes: []int{2, 4}}
+	corners := []config.CornerConfig{
+		{Title: "固定", LengthSec: 30},
+		{Title: "条件付き", LengthSec: 60, Condition: cond},
+	}
+	logger := slog.Default()
+
+	got := resolveCorners(corners, 2, logger)
+	if len(got) != 2 {
+		t.Errorf("resolveCorners(_, 2) len = %d, want 2", len(got))
+	}
+
+	got = resolveCorners(corners, 3, logger)
+	if len(got) != 1 || got[0].Title != "固定" {
+		t.Errorf("resolveCorners(_, 3) = %v, want [固定]", got)
+	}
+}
+
+func TestResolveCorners_UnknownEpisodeReturnsAll(t *testing.T) {
+	cond := &config.EpisodeCondition{Every: 2}
+	corners := []config.CornerConfig{
+		{Title: "固定", LengthSec: 30},
+		{Title: "条件付き", LengthSec: 60, Condition: cond},
+	}
+	logger := slog.Default()
+
+	got := resolveCorners(corners, 0, logger)
+	if len(got) != 2 {
+		t.Errorf("resolveCorners(_, 0) len = %d, want 2 (all corners)", len(got))
+	}
+}
+
+func TestResolveCornersByRundown(t *testing.T) {
+	corners := []config.CornerConfig{
+		{Title: "A", LengthSec: 30},
+		{Title: "B", LengthSec: 60},
+		{Title: "C", LengthSec: 90},
+	}
+	rd := model.Rundown{
+		Corners: []model.RundownCorner{
+			{Title: "C"},
+			{Title: "A"},
+		},
+	}
+
+	got, err := resolveCornersByRundown(corners, rd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d corners, want 2", len(got))
+	}
+	if got[0].Title != "C" || got[1].Title != "A" {
+		t.Errorf("titles = [%s %s], want [C A]", got[0].Title, got[1].Title)
+	}
+}
+
+func TestResolveCornersByRundown_UnknownTitle(t *testing.T) {
+	corners := []config.CornerConfig{
+		{Title: "A", LengthSec: 30},
+	}
+	rd := model.Rundown{
+		Corners: []model.RundownCorner{
+			{Title: "X"},
+		},
+	}
+
+	_, err := resolveCornersByRundown(corners, rd)
+	if err == nil {
+		t.Error("expected error for unknown title, got nil")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,6 +246,7 @@ type CornerConfig struct {
 	BGM           string            `yaml:"bgm,omitempty"`
 	StartPauseSec float64           `yaml:"start_pause_sec,omitempty"`
 	EndPauseSec   float64           `yaml:"end_pause_sec,omitempty"`
+	Condition     *EpisodeCondition `yaml:"condition,omitempty"` // 出現条件（nil なら毎回出る固定コーナー）
 }
 
 // EffectiveSummaryLength returns the configured SummaryLength, falling back to DefaultCornerSummaryLength.
@@ -381,14 +382,15 @@ type Config struct {
 	Cache      CacheConfig                `yaml:"cache"`
 }
 
-// GuestCondition は出現条件。将来 probability 等を後方互換で追加可能。
-type GuestCondition struct {
-	Episodes []int `yaml:"episodes,omitempty"` // この回番号で出演（明示リスト）
-	Every    int   `yaml:"every,omitempty"`    // N の倍数回で出演（0 で無効）
+// EpisodeCondition は回番号ベースの出現条件。将来 probability 等を後方互換で追加可能。
+// コーナーとゲストで共有する。
+type EpisodeCondition struct {
+	Episodes []int `yaml:"episodes,omitempty"` // この回番号で採用（明示リスト）
+	Every    int   `yaml:"every,omitempty"`    // N の倍数回で採用（0 で無効）
 }
 
 // Matches は episodeNumber が条件に合致するか判定する（論理和）。
-func (c GuestCondition) Matches(episodeNumber int) bool {
+func (c EpisodeCondition) Matches(episodeNumber int) bool {
 	if episodeNumber <= 0 {
 		return false
 	}
@@ -403,8 +405,8 @@ func (c GuestCondition) Matches(episodeNumber int) bool {
 
 // GuestConfig はゲスト1人分の設定（キャラIDは map のキーで持つため持たない）。
 type GuestConfig struct {
-	Role      string         `yaml:"role"`
-	Condition GuestCondition `yaml:"condition"`
+	Role      string           `yaml:"role"`
+	Condition EpisodeCondition `yaml:"condition"`
 }
 
 // EpisodeSpec holds episode-specific settings (program, corners, assets).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -421,6 +421,23 @@ type EpisodeSpec struct {
 	Assets      AssetsConfig           `yaml:"-"`
 }
 
+// validateEpisodeCondition は EpisodeCondition の値が有効かを検証する共通ヘルパー。
+// prefix はエラーメッセージの先頭に付加するフィールドパス文字列。
+func validateEpisodeCondition(cond EpisodeCondition, prefix string) error {
+	for _, e := range cond.Episodes {
+		if e < 1 {
+			return fmt.Errorf("%s.episodes: value %d must be >= 1", prefix, e)
+		}
+	}
+	if cond.Every < 0 {
+		return fmt.Errorf("%s.every: value %d must be >= 1", prefix, cond.Every)
+	}
+	if len(cond.Episodes) == 0 && cond.Every == 0 {
+		return fmt.Errorf("%s: at least one of episodes or every must be set", prefix)
+	}
+	return nil
+}
+
 // ValidateEpisodeSpecGuests checks that every guest character ID exists in chars,
 // and that each guest's condition has at least one of episodes or every set.
 func ValidateEpisodeSpecGuests(p *EpisodeSpec, chars map[string]CharacterConfig) error {
@@ -428,17 +445,25 @@ func ValidateEpisodeSpecGuests(p *EpisodeSpec, chars map[string]CharacterConfig)
 		if _, ok := chars[charID]; !ok {
 			return fmt.Errorf("guests[%q]: character not found in characters catalog", charID)
 		}
-		cond := g.Condition
-		for _, e := range cond.Episodes {
-			if e < 1 {
-				return fmt.Errorf("guests[%q].condition.episodes: value %d must be >= 1", charID, e)
+		if err := validateEpisodeCondition(g.Condition, fmt.Sprintf("guests[%q].condition", charID)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ValidateEpisodeSpecCorners は corners の出現条件を検証する（キャラ不要・spec 内部整合のみ）。
+func ValidateEpisodeSpecCorners(p *EpisodeSpec) error {
+	seen := make(map[string]bool, len(p.Corners))
+	for i, c := range p.Corners {
+		if seen[c.Title] {
+			return fmt.Errorf("corners[%d]: title %q is duplicated", i, c.Title)
+		}
+		seen[c.Title] = true
+		if c.Condition != nil {
+			if err := validateEpisodeCondition(*c.Condition, fmt.Sprintf("corners[%d].condition", i)); err != nil {
+				return err
 			}
-		}
-		if cond.Every < 0 {
-			return fmt.Errorf("guests[%q].condition.every: value %d must be >= 1", charID, cond.Every)
-		}
-		if len(cond.Episodes) == 0 && cond.Every == 0 {
-			return fmt.Errorf("guests[%q].condition: at least one of episodes or every must be set", charID)
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -507,7 +507,7 @@ func TestValidateEpisodeSpecCast_UnknownCharacter(t *testing.T) {
 	}
 }
 
-func TestGuestCondition_Matches(t *testing.T) {
+func TestEpisodeCondition_Matches(t *testing.T) {
 	tests := []struct {
 		name          string
 		cond          config.EpisodeCondition
@@ -534,7 +534,7 @@ func TestGuestCondition_Matches(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.cond.Matches(tt.episodeNumber)
 			if got != tt.want {
-				t.Errorf("GuestCondition%+v.Matches(%d) = %v, want %v", tt.cond, tt.episodeNumber, got, tt.want)
+				t.Errorf("EpisodeCondition%+v.Matches(%d) = %v, want %v", tt.cond, tt.episodeNumber, got, tt.want)
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -510,25 +510,25 @@ func TestValidateEpisodeSpecCast_UnknownCharacter(t *testing.T) {
 func TestGuestCondition_Matches(t *testing.T) {
 	tests := []struct {
 		name          string
-		cond          config.GuestCondition
+		cond          config.EpisodeCondition
 		episodeNumber int
 		want          bool
 	}{
 		// episodes（明示リスト）
-		{name: "episodes: 合致する回番号", cond: config.GuestCondition{Episodes: []int{3, 10}}, episodeNumber: 3, want: true},
-		{name: "episodes: 合致しない回番号", cond: config.GuestCondition{Episodes: []int{3, 10}}, episodeNumber: 5, want: false},
-		{name: "episodes: 空リスト", cond: config.GuestCondition{Episodes: []int{}}, episodeNumber: 1, want: false},
+		{name: "episodes: 合致する回番号", cond: config.EpisodeCondition{Episodes: []int{3, 10}}, episodeNumber: 3, want: true},
+		{name: "episodes: 合致しない回番号", cond: config.EpisodeCondition{Episodes: []int{3, 10}}, episodeNumber: 5, want: false},
+		{name: "episodes: 空リスト", cond: config.EpisodeCondition{Episodes: []int{}}, episodeNumber: 1, want: false},
 		// every（周期）
-		{name: "every: 倍数回に合致", cond: config.GuestCondition{Every: 5}, episodeNumber: 10, want: true},
-		{name: "every: 倍数でない回は合致しない", cond: config.GuestCondition{Every: 5}, episodeNumber: 7, want: false},
-		{name: "every: 0 は無効", cond: config.GuestCondition{Every: 0}, episodeNumber: 5, want: false},
+		{name: "every: 倍数回に合致", cond: config.EpisodeCondition{Every: 5}, episodeNumber: 10, want: true},
+		{name: "every: 倍数でない回は合致しない", cond: config.EpisodeCondition{Every: 5}, episodeNumber: 7, want: false},
+		{name: "every: 0 は無効", cond: config.EpisodeCondition{Every: 0}, episodeNumber: 5, want: false},
 		// 論理和（両方指定）
-		{name: "episodes+every: どちらかに合致すれば true", cond: config.GuestCondition{Episodes: []int{3}, Every: 5}, episodeNumber: 5, want: true},
-		{name: "episodes+every: episodes のみ合致", cond: config.GuestCondition{Episodes: []int{3}, Every: 5}, episodeNumber: 3, want: true},
-		{name: "episodes+every: どちらにも合致しない", cond: config.GuestCondition{Episodes: []int{3}, Every: 5}, episodeNumber: 2, want: false},
+		{name: "episodes+every: どちらかに合致すれば true", cond: config.EpisodeCondition{Episodes: []int{3}, Every: 5}, episodeNumber: 5, want: true},
+		{name: "episodes+every: episodes のみ合致", cond: config.EpisodeCondition{Episodes: []int{3}, Every: 5}, episodeNumber: 3, want: true},
+		{name: "episodes+every: どちらにも合致しない", cond: config.EpisodeCondition{Episodes: []int{3}, Every: 5}, episodeNumber: 2, want: false},
 		// 回番号不明（0 以下）
-		{name: "episodeNumber=0 は false", cond: config.GuestCondition{Episodes: []int{3}, Every: 5}, episodeNumber: 0, want: false},
-		{name: "episodeNumber<0 は false", cond: config.GuestCondition{Episodes: []int{1}}, episodeNumber: -1, want: false},
+		{name: "episodeNumber=0 は false", cond: config.EpisodeCondition{Episodes: []int{3}, Every: 5}, episodeNumber: 0, want: false},
+		{name: "episodeNumber<0 は false", cond: config.EpisodeCondition{Episodes: []int{1}}, episodeNumber: -1, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -552,19 +552,19 @@ func TestValidateEpisodeSpecGuests_Valid(t *testing.T) {
 		{
 			name: "episodes のみ指定",
 			guests: map[string]config.GuestConfig{
-				"zundamon": {Role: "ゲスト", Condition: config.GuestCondition{Episodes: []int{3, 10}}},
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Episodes: []int{3, 10}}},
 			},
 		},
 		{
 			name: "every のみ指定",
 			guests: map[string]config.GuestConfig{
-				"metan": {Role: "解説ゲスト", Condition: config.GuestCondition{Every: 5}},
+				"metan": {Role: "解説ゲスト", Condition: config.EpisodeCondition{Every: 5}},
 			},
 		},
 		{
 			name: "両方指定",
 			guests: map[string]config.GuestConfig{
-				"zundamon": {Role: "ゲスト", Condition: config.GuestCondition{Episodes: []int{3}, Every: 5}},
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Episodes: []int{3}, Every: 5}},
 			},
 		},
 		{
@@ -593,25 +593,25 @@ func TestValidateEpisodeSpecGuests_Error(t *testing.T) {
 		{
 			name: "存在しないキャラID",
 			guests: map[string]config.GuestConfig{
-				"unknown_char": {Role: "ゲスト", Condition: config.GuestCondition{Episodes: []int{3}}},
+				"unknown_char": {Role: "ゲスト", Condition: config.EpisodeCondition{Episodes: []int{3}}},
 			},
 		},
 		{
 			name: "condition が空（episodes も every も未設定）",
 			guests: map[string]config.GuestConfig{
-				"zundamon": {Role: "ゲスト", Condition: config.GuestCondition{}},
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{}},
 			},
 		},
 		{
 			name: "episodes の値が 0",
 			guests: map[string]config.GuestConfig{
-				"zundamon": {Role: "ゲスト", Condition: config.GuestCondition{Episodes: []int{0}}},
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Episodes: []int{0}}},
 			},
 		},
 		{
 			name: "every が負数",
 			guests: map[string]config.GuestConfig{
-				"zundamon": {Role: "ゲスト", Condition: config.GuestCondition{Every: -1}},
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Every: -1}},
 			},
 		},
 	}

--- a/internal/config/corners.go
+++ b/internal/config/corners.go
@@ -1,0 +1,63 @@
+package config
+
+import "fmt"
+
+// ResolveCornersForEpisode は condition を持つコーナーを回番号で絞り込んだコーナー列を返す。
+// Condition == nil のコーナー（固定）は常に採用。順序は元の配列のまま保持する。
+// episodeNumber <= 0（回番号不明）の場合は全コーナーを採用する（呼び出し側で警告）。乱数なし。
+func ResolveCornersForEpisode(corners []CornerConfig, episodeNumber int) []CornerConfig {
+	result := make([]CornerConfig, 0, len(corners))
+	for _, c := range corners {
+		if c.Condition == nil || episodeNumber <= 0 || c.Condition.Matches(episodeNumber) {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+// ResolveCornersByTitles は titles に含まれるタイトルのコーナーだけを titles の順序で返す。
+// rundown.Corners のタイトル順を渡し、script 系で採用コーナーを再構成するために使う（回番号不要）。
+// titles にあるが spec に存在しないタイトルがあればエラー。
+func ResolveCornersByTitles(corners []CornerConfig, titles []string) ([]CornerConfig, error) {
+	cornerMap := make(map[string]CornerConfig, len(corners))
+	for _, c := range corners {
+		cornerMap[c.Title] = c
+	}
+	result := make([]CornerConfig, 0, len(titles))
+	for _, title := range titles {
+		c, ok := cornerMap[title]
+		if !ok {
+			return nil, fmt.Errorf("corner %q not found in spec", title)
+		}
+		result = append(result, c)
+	}
+	return result, nil
+}
+
+// ValidateEpisodeSpecCorners は corners の出現条件を検証する（キャラ不要・spec 内部整合のみ）。
+func ValidateEpisodeSpecCorners(p *EpisodeSpec) error {
+	seen := make(map[string]bool, len(p.Corners))
+	for i, c := range p.Corners {
+		if seen[c.Title] {
+			return fmt.Errorf("corners[%d]: title %q is duplicated", i, c.Title)
+		}
+		seen[c.Title] = true
+
+		if c.Condition == nil {
+			continue
+		}
+		cond := c.Condition
+		for _, e := range cond.Episodes {
+			if e < 1 {
+				return fmt.Errorf("corners[%d].condition.episodes: value %d must be >= 1", i, e)
+			}
+		}
+		if cond.Every < 0 {
+			return fmt.Errorf("corners[%d].condition.every: value %d must be >= 1", i, cond.Every)
+		}
+		if len(cond.Episodes) == 0 && cond.Every == 0 {
+			return fmt.Errorf("corners[%d].condition: at least one of episodes or every must be set", i)
+		}
+	}
+	return nil
+}

--- a/internal/config/corners.go
+++ b/internal/config/corners.go
@@ -33,31 +33,3 @@ func ResolveCornersByTitles(corners []CornerConfig, titles []string) ([]CornerCo
 	}
 	return result, nil
 }
-
-// ValidateEpisodeSpecCorners は corners の出現条件を検証する（キャラ不要・spec 内部整合のみ）。
-func ValidateEpisodeSpecCorners(p *EpisodeSpec) error {
-	seen := make(map[string]bool, len(p.Corners))
-	for i, c := range p.Corners {
-		if seen[c.Title] {
-			return fmt.Errorf("corners[%d]: title %q is duplicated", i, c.Title)
-		}
-		seen[c.Title] = true
-
-		if c.Condition == nil {
-			continue
-		}
-		cond := c.Condition
-		for _, e := range cond.Episodes {
-			if e < 1 {
-				return fmt.Errorf("corners[%d].condition.episodes: value %d must be >= 1", i, e)
-			}
-		}
-		if cond.Every < 0 {
-			return fmt.Errorf("corners[%d].condition.every: value %d must be >= 1", i, cond.Every)
-		}
-		if len(cond.Episodes) == 0 && cond.Every == 0 {
-			return fmt.Errorf("corners[%d].condition: at least one of episodes or every must be set", i)
-		}
-	}
-	return nil
-}

--- a/internal/config/corners_test.go
+++ b/internal/config/corners_test.go
@@ -1,0 +1,230 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestResolveCornersForEpisode(t *testing.T) {
+	fixed := CornerConfig{Title: "固定コーナー", LengthSec: 30}
+	cond1 := CornerConfig{
+		Title:     "条件コーナーA",
+		LengthSec: 60,
+		Condition: &EpisodeCondition{Episodes: []int{1, 3, 5}},
+	}
+	cond2 := CornerConfig{
+		Title:     "条件コーナーB",
+		LengthSec: 60,
+		Condition: &EpisodeCondition{Every: 2},
+	}
+	corners := []CornerConfig{fixed, cond1, cond2}
+
+	tests := []struct {
+		name          string
+		episodeNumber int
+		wantTitles    []string
+	}{
+		{
+			name:          "固定コーナーは常に採用",
+			episodeNumber: 1,
+			wantTitles:    []string{"固定コーナー", "条件コーナーA"},
+		},
+		{
+			name:          "偶数回はevery:2の条件コーナーのみ採用",
+			episodeNumber: 2,
+			wantTitles:    []string{"固定コーナー", "条件コーナーB"},
+		},
+		{
+			name:          "奇数回でepisodesに含まれる回",
+			episodeNumber: 3,
+			wantTitles:    []string{"固定コーナー", "条件コーナーA"},
+		},
+		{
+			name:          "いずれの条件にも合致しない回",
+			episodeNumber: 7,
+			wantTitles:    []string{"固定コーナー"},
+		},
+		{
+			name:          "回番号不明(0)は全コーナー採用",
+			episodeNumber: 0,
+			wantTitles:    []string{"固定コーナー", "条件コーナーA", "条件コーナーB"},
+		},
+		{
+			name:          "回番号不明(<0)は全コーナー採用",
+			episodeNumber: -1,
+			wantTitles:    []string{"固定コーナー", "条件コーナーA", "条件コーナーB"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveCornersForEpisode(corners, tt.episodeNumber)
+			if len(got) != len(tt.wantTitles) {
+				t.Fatalf("ResolveCornersForEpisode(_, %d) len = %d, want %d; got titles: %v",
+					tt.episodeNumber, len(got), len(tt.wantTitles), cornerTitles(got))
+			}
+			for i, c := range got {
+				if c.Title != tt.wantTitles[i] {
+					t.Errorf("ResolveCornersForEpisode(_, %d)[%d].Title = %q, want %q",
+						tt.episodeNumber, i, c.Title, tt.wantTitles[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveCornersForEpisode_PreservesOrder(t *testing.T) {
+	corners := []CornerConfig{
+		{Title: "A", LengthSec: 10, Condition: &EpisodeCondition{Episodes: []int{1}}},
+		{Title: "B", LengthSec: 10},
+		{Title: "C", LengthSec: 10, Condition: &EpisodeCondition{Every: 2}},
+		{Title: "D", LengthSec: 10},
+	}
+	got := ResolveCornersForEpisode(corners, 2)
+	wantTitles := []string{"B", "C", "D"}
+	if len(got) != len(wantTitles) {
+		t.Fatalf("got %d corners, want %d", len(got), len(wantTitles))
+	}
+	for i, c := range got {
+		if c.Title != wantTitles[i] {
+			t.Errorf("order[%d]: got %q, want %q", i, c.Title, wantTitles[i])
+		}
+	}
+}
+
+func TestResolveCornersByTitles(t *testing.T) {
+	corners := []CornerConfig{
+		{Title: "A", LengthSec: 30},
+		{Title: "B", LengthSec: 60},
+		{Title: "C", LengthSec: 90},
+	}
+
+	t.Run("タイトル順にコーナーを返す", func(t *testing.T) {
+		got, err := ResolveCornersByTitles(corners, []string{"C", "A"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 2 {
+			t.Fatalf("got %d corners, want 2", len(got))
+		}
+		if got[0].Title != "C" || got[1].Title != "A" {
+			t.Errorf("titles = %v, want [C A]", cornerTitles(got))
+		}
+	})
+
+	t.Run("存在しないタイトルはエラー", func(t *testing.T) {
+		_, err := ResolveCornersByTitles(corners, []string{"A", "X"})
+		if err == nil {
+			t.Error("expected error for unknown title, got nil")
+		}
+	})
+
+	t.Run("空のtitlesは空スライスを返す", func(t *testing.T) {
+		got, err := ResolveCornersByTitles(corners, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("got %d corners, want 0", len(got))
+		}
+	})
+}
+
+func TestValidateEpisodeSpecCorners_Valid(t *testing.T) {
+	tests := []struct {
+		name    string
+		corners []CornerConfig
+	}{
+		{
+			name: "conditionなし（固定コーナー）のみ",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30},
+				{Title: "B", LengthSec: 60},
+			},
+		},
+		{
+			name: "episodes指定の条件コーナー",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30},
+				{Title: "B", LengthSec: 60, Condition: &EpisodeCondition{Episodes: []int{1, 3}}},
+			},
+		},
+		{
+			name: "every指定の条件コーナー",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30},
+				{Title: "B", LengthSec: 60, Condition: &EpisodeCondition{Every: 2}},
+			},
+		},
+		{
+			name: "episodes+every両方指定",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30, Condition: &EpisodeCondition{Episodes: []int{1}, Every: 3}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &EpisodeSpec{Corners: tt.corners}
+			if err := ValidateEpisodeSpecCorners(p); err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateEpisodeSpecCorners_Error(t *testing.T) {
+	tests := []struct {
+		name    string
+		corners []CornerConfig
+	}{
+		{
+			name: "タイトルが重複",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30},
+				{Title: "A", LengthSec: 60},
+			},
+		},
+		{
+			name: "conditionがあるがepisodesもeveryも未設定（永久不採用）",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30, Condition: &EpisodeCondition{}},
+			},
+		},
+		{
+			name: "episodesの値が0",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30, Condition: &EpisodeCondition{Episodes: []int{0}}},
+			},
+		},
+		{
+			name: "episodesの値が負数",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30, Condition: &EpisodeCondition{Episodes: []int{-1}}},
+			},
+		},
+		{
+			name: "everyが負数",
+			corners: []CornerConfig{
+				{Title: "A", LengthSec: 30, Condition: &EpisodeCondition{Every: -1}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &EpisodeSpec{Corners: tt.corners}
+			if err := ValidateEpisodeSpecCorners(p); err == nil {
+				t.Errorf("expected error for %q, got nil", tt.name)
+			}
+		})
+	}
+}
+
+func cornerTitles(corners []CornerConfig) []string {
+	titles := make([]string, len(corners))
+	for i, c := range corners {
+		titles[i] = c.Title
+	}
+	return titles
+}

--- a/internal/guest/guest_test.go
+++ b/internal/guest/guest_test.go
@@ -17,7 +17,7 @@ func TestSelect_NoGuests(t *testing.T) {
 
 func TestSelect_EpisodeNumberUnknown(t *testing.T) {
 	guests := map[string]config.GuestConfig{
-		"zundamon": {Role: "ゲスト", Condition: config.GuestCondition{Episodes: []int{3}}},
+		"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Episodes: []int{3}}},
 	}
 	result := guest.Select(guests, 0)
 	if len(result) != 0 {
@@ -27,7 +27,7 @@ func TestSelect_EpisodeNumberUnknown(t *testing.T) {
 
 func TestSelect_ExplicitEpisodeList(t *testing.T) {
 	guests := map[string]config.GuestConfig{
-		"zundamon": {Role: "ゲスト", Condition: config.GuestCondition{Episodes: []int{3, 10}}},
+		"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Episodes: []int{3, 10}}},
 	}
 	// 合致する回
 	result := guest.Select(guests, 3)
@@ -43,7 +43,7 @@ func TestSelect_ExplicitEpisodeList(t *testing.T) {
 
 func TestSelect_Every(t *testing.T) {
 	guests := map[string]config.GuestConfig{
-		"metan": {Role: "解説ゲスト", Condition: config.GuestCondition{Every: 5}},
+		"metan": {Role: "解説ゲスト", Condition: config.EpisodeCondition{Every: 5}},
 	}
 	// 合致する回（5の倍数）
 	result := guest.Select(guests, 10)
@@ -59,9 +59,9 @@ func TestSelect_Every(t *testing.T) {
 
 func TestSelect_MultipleGuestsAreSorted(t *testing.T) {
 	guests := map[string]config.GuestConfig{
-		"zundamon": {Role: "ゲストA", Condition: config.GuestCondition{Episodes: []int{5}}},
-		"metan":    {Role: "ゲストB", Condition: config.GuestCondition{Episodes: []int{5}}},
-		"aaa":      {Role: "ゲストC", Condition: config.GuestCondition{Episodes: []int{5}}},
+		"zundamon": {Role: "ゲストA", Condition: config.EpisodeCondition{Episodes: []int{5}}},
+		"metan":    {Role: "ゲストB", Condition: config.EpisodeCondition{Episodes: []int{5}}},
+		"aaa":      {Role: "ゲストC", Condition: config.EpisodeCondition{Episodes: []int{5}}},
 	}
 	result := guest.Select(guests, 5)
 	if len(result) != 3 {
@@ -78,8 +78,8 @@ func TestSelect_MultipleGuestsAreSorted(t *testing.T) {
 
 func TestSelect_DeterministicOutput(t *testing.T) {
 	guests := map[string]config.GuestConfig{
-		"b_char": {Role: "ゲスト", Condition: config.GuestCondition{Episodes: []int{1}}},
-		"a_char": {Role: "ゲスト", Condition: config.GuestCondition{Episodes: []int{1}}},
+		"b_char": {Role: "ゲスト", Condition: config.EpisodeCondition{Episodes: []int{1}}},
+		"a_char": {Role: "ゲスト", Condition: config.EpisodeCondition{Episodes: []int{1}}},
 	}
 	r1 := guest.Select(guests, 1)
 	r2 := guest.Select(guests, 1)
@@ -102,7 +102,7 @@ func TestSelect_ReturnsEmptySliceNotNil(t *testing.T) {
 
 func TestSelect_RoleIsPreserved(t *testing.T) {
 	guests := map[string]config.GuestConfig{
-		"zundamon": {Role: "古参リスナー出身の常連ゲスト", Condition: config.GuestCondition{Episodes: []int{3}}},
+		"zundamon": {Role: "古参リスナー出身の常連ゲスト", Condition: config.EpisodeCondition{Episodes: []int{3}}},
 	}
 	result := guest.Select(guests, 3)
 	if len(result) != 1 {


### PR DESCRIPTION
## Summary

- `GuestCondition` を `EpisodeCondition` にリネームし、コーナーとゲストで共有する型として統一
- `CornerConfig` に `Condition *EpisodeCondition` フィールドを追加（nil なら毎回出る固定コーナー）
- `ResolveCornersForEpisode` / `ResolveCornersByTitles` を `internal/config/corners.go` に実装
  - 固定コーナー（condition なし）は常に採用、条件付きコーナーは回番号に合致した場合のみ採用
  - 回番号不明（0）の場合は全コーナーを採用（degraded mode）し警告ログを出力
  - `ResolveCornersByTitles` は `rundown.json` のタイトル順で spec のコーナーを再構成（再現性）
- `validateEpisodeCondition` 共通ヘルパーを追加し `ValidateEpisodeSpecGuests` / `ValidateEpisodeSpecCorners` で共有
- `ValidateEpisodeSpecCorners` を `loadConfigAndSpec` / `episodegen check` / `collect` の検証フローに組み込む
- `resolveCorners` / `resolveCornersByRundown` を `util.go` に追加し、各エントリポイントに配線
  - `episodegen`（full）: 回番号算出後に `p.Corners` を再代入してから Runner 構築
  - `rundown`（単独）: 回番号算出 → `resolveCorners` → 採用コーナーで `Rundowner.Run`
  - `collect`（単独）: 全コーナーを superset として収集（rundown 側で絞る）
  - `script`（full/write）: `resolveCornersByRundown` で rundown タイトル順に再構成
- `examples/tech.yaml` / `episode-spec.yaml` テンプレートに `condition:` の例を追加
- README に `corners[].condition` スキーマの説明と使用例を追記

Closes #234

---
🤖 Generated with [Claude Code](https://claude.ai/code)