### PR TITLE
feat: EpisodeCondition に offset を追加しゲスト・コーナーをN者ローテーションできるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,7 @@ corners:
 |---|---|---|---|
 | `condition.episodes` | []int | 任意 | 採用する回番号の明示リスト（各値は 1 以上） |
 | `condition.every` | int | 任意 | 周期的な採用（N の倍数回に採用。1 以上） |
+| `condition.offset` | int | 任意 | `every` と組み合わせる剰余（`episodeNumber % every == offset` で採用。未指定=0 で倍数回） |
 | `condition.not` | EpisodeCondition | 任意 | この条件に合致する回を除外（補集合） |
 
 - `condition.episodes` と `condition.every` の両方を指定した場合は **論理和**（どちらかに合致すれば採用）
@@ -379,6 +380,18 @@ corners:
 - `condition.episodes`・`condition.every`・`condition.not` のいずれも未設定の場合、および `not` の中身が空の場合はバリデーションエラー
 - キャッシュが無効または `program.id` が未設定で回番号が不明な場合、条件付きコーナーを含む全コーナーが採用されます（警告ログが出力されます）
 - 採用されたコーナーは元の `corners` 配列の順序を維持したまま台本に出力されます
+
+**N者ローテーションの例（`every` + `offset`）**
+
+```yaml
+corners:
+  - title: "コーナーA"
+    condition: { every: 3, offset: 1 }   # 1,4,7,… 回に採用
+  - title: "コーナーB"
+    condition: { every: 3, offset: 2 }   # 2,5,8,… 回に採用
+  - title: "コーナーC"
+    condition: { every: 3, offset: 0 }   # 3,6,9,… 回に採用
+```
 
 ##### `corners[].source` サブフィールド
 
@@ -420,6 +433,7 @@ guests:
 | `role` | string | 任意 | 全コーナーの cast にマージされるゲストの役割説明 |
 | `condition.episodes` | []int | 任意 | 出演する回番号の明示リスト（各値は 1 以上） |
 | `condition.every` | int | 任意 | 周期的な出演（N の倍数回に出演。1 以上） |
+| `condition.offset` | int | 任意 | `every` と組み合わせる剰余（`episodeNumber % every == offset` で出演。未指定=0 で倍数回） |
 | `condition.not` | EpisodeCondition | 任意 | この条件に合致する回を除外（補集合） |
 
 - `condition.episodes` と `condition.every` の両方を指定した場合は **論理和**（どちらかに合致すれば出演）
@@ -427,6 +441,21 @@ guests:
 - 肯定条件（`episodes`/`every`）を省略すると「常に真」として扱われ、`not` 単独で補集合を表現できる
 - `condition.episodes`・`condition.every`・`condition.not` のいずれも未設定の場合はバリデーションエラー
 - キャッシュが無効または `program.id` が未設定で回番号が不明な場合、ゲストは出演しません（警告ログが出力されます）
+
+**N者ローテーションの例（`every` + `offset`）**
+
+```yaml
+guests:
+  alice:
+    role: ゲストA
+    condition: { every: 3, offset: 1 }   # 1,4,7,… 回に出演
+  bob:
+    role: ゲストB
+    condition: { every: 3, offset: 2 }   # 2,5,8,… 回に出演
+  carol:
+    role: ゲストC
+    condition: { every: 3, offset: 0 }   # 3,6,9,… 回に出演
+```
 
 #### `assets_files` フィールド
 

--- a/examples/tech.yaml
+++ b/examples/tech.yaml
@@ -73,6 +73,25 @@ corners:
 #     condition:
 #       not:
 #         every: 5              # 5の倍数以外の回（zunkoがいない回）に登場
+#
+# --- 3者ローテーションの例 (every + offset) ---
+# every: 3 + offset: 0/1/2 の3条件で全回を均等に分担できる
+# guests:
+#   alice:
+#     role: ゲストA
+#     condition:
+#       every: 3
+#       offset: 1   # 1,4,7,… 回に登場
+#   bob:
+#     role: ゲストB
+#     condition:
+#       every: 3
+#       offset: 2   # 2,5,8,… 回に登場
+#   carol:
+#     role: ゲストC
+#     condition:
+#       every: 3
+#       offset: 0   # 3,6,9,… 回に登場（offset省略時と同じ動作）
 
 # アセット設定ファイルのパス（このプロファイルファイルからの相対パス）
 # アセット設定ファイル内のfileパスはアセット設定ファイルのディレクトリを基準に解決される

--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -64,6 +64,11 @@ corners:
     #   # condition:
     #   #   not:
     #   #     every: 2         # 奇数回に採用（偶数でない回すべて）
+    # --- N者ローテーション（every + offset）---
+    # every: 3 + offset: 0/1/2 の3条件で全回を均等に分担できる
+    # コーナーA: condition: { every: 3, offset: 1 }  # 1,4,7,…
+    # コーナーB: condition: { every: 3, offset: 2 }  # 2,5,8,…
+    # コーナーC: condition: { every: 3, offset: 0 }  # 3,6,9,…
 
   - title: "エンディング"
     content: "まとめと締め"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -386,6 +386,7 @@ type Config struct {
 type EpisodeCondition struct {
 	Episodes []int             `yaml:"episodes,omitempty"` // この回番号で採用（明示リスト）
 	Every    int               `yaml:"every,omitempty"`    // N の倍数回で採用（0 で無効）
+	Offset   int               `yaml:"offset,omitempty"`   // every との剰余。未指定=0 で倍数回（episodeNumber%Every==Offset で採用）
 	Not      *EpisodeCondition `yaml:"not,omitempty"`      // この条件に合致する回は除外（補集合）
 }
 
@@ -402,7 +403,7 @@ func (c EpisodeCondition) Matches(episodeNumber int) bool {
 		return true
 	}
 	return slices.Contains(c.Episodes, episodeNumber) ||
-		(c.Every > 0 && episodeNumber%c.Every == 0)
+		(c.Every > 0 && episodeNumber%c.Every == c.Offset)
 }
 
 // GuestConfig はゲスト1人分の設定（キャラIDは map のキーで持つため持たない）。
@@ -433,6 +434,15 @@ func validateEpisodeCondition(cond EpisodeCondition, prefix string) error {
 	}
 	if cond.Every < 0 {
 		return fmt.Errorf("%s.every: value %d must be >= 1", prefix, cond.Every)
+	}
+	if cond.Offset < 0 {
+		return fmt.Errorf("%s.offset: value %d must be >= 0", prefix, cond.Offset)
+	}
+	if cond.Offset > 0 && cond.Every == 0 {
+		return fmt.Errorf("%s.offset: requires every to be set", prefix)
+	}
+	if cond.Every > 0 && cond.Offset >= cond.Every {
+		return fmt.Errorf("%s.offset: value %d must be < every (%d)", prefix, cond.Offset, cond.Every)
 	}
 	if len(cond.Episodes) == 0 && cond.Every == 0 && cond.Not == nil {
 		return fmt.Errorf("%s: at least one of episodes, every, or not must be set", prefix)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -539,12 +539,100 @@ func TestEpisodeCondition_Matches(t *testing.T) {
 		{name: "every+not: 倍数でない → false", cond: config.EpisodeCondition{Every: 2, Not: &config.EpisodeCondition{Episodes: []int{6}}}, episodeNumber: 3, want: false},
 		// 肯定条件なし（not 単独）で episodeNumber <= 0 は false
 		{name: "not 単独で episodeNumber=0 は false", cond: config.EpisodeCondition{Not: &config.EpisodeCondition{Every: 5}}, episodeNumber: 0, want: false},
+		// offset（剰余）
+		{name: "every+offset: 余り1に合致", cond: config.EpisodeCondition{Every: 3, Offset: 1}, episodeNumber: 1, want: true},
+		{name: "every+offset: 余り1に合致(4回目)", cond: config.EpisodeCondition{Every: 3, Offset: 1}, episodeNumber: 4, want: true},
+		{name: "every+offset: 余り1に合致(7回目)", cond: config.EpisodeCondition{Every: 3, Offset: 1}, episodeNumber: 7, want: true},
+		{name: "every+offset: 余り2に合致", cond: config.EpisodeCondition{Every: 3, Offset: 2}, episodeNumber: 2, want: true},
+		{name: "every+offset: 余り0に合致（offset=0 は従来の倍数回）", cond: config.EpisodeCondition{Every: 3, Offset: 0}, episodeNumber: 3, want: true},
+		{name: "every+offset: 合致しない（余り不一致）", cond: config.EpisodeCondition{Every: 3, Offset: 1}, episodeNumber: 3, want: false},
+		{name: "offset未指定（0）は every の倍数回（後方互換）", cond: config.EpisodeCondition{Every: 5}, episodeNumber: 10, want: true},
+		{name: "offset未指定（0）で倍数でない回は false（後方互換）", cond: config.EpisodeCondition{Every: 5}, episodeNumber: 7, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.cond.Matches(tt.episodeNumber)
 			if got != tt.want {
 				t.Errorf("EpisodeCondition%+v.Matches(%d) = %v, want %v", tt.cond, tt.episodeNumber, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateEpisodeCondition_Offset(t *testing.T) {
+	tests := []struct {
+		name    string
+		guests  map[string]config.GuestConfig
+		wantErr bool
+	}{
+		{
+			name: "every+offset 有効（3者ローテ offset=0）",
+			guests: map[string]config.GuestConfig{
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Every: 3, Offset: 0}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "every+offset 有効（3者ローテ offset=1）",
+			guests: map[string]config.GuestConfig{
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Every: 3, Offset: 1}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "every+offset 有効（3者ローテ offset=2）",
+			guests: map[string]config.GuestConfig{
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Every: 3, Offset: 2}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "offset が負数",
+			guests: map[string]config.GuestConfig{
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Every: 3, Offset: -1}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "offset > 0 かつ every == 0",
+			guests: map[string]config.GuestConfig{
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Offset: 1}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "offset >= every",
+			guests: map[string]config.GuestConfig{
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Every: 3, Offset: 3}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "not 内の offset が負数",
+			guests: map[string]config.GuestConfig{
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Not: &config.EpisodeCondition{Every: 3, Offset: -1}}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "not 内の offset >= every",
+			guests: map[string]config.GuestConfig{
+				"zundamon": {Role: "ゲスト", Condition: config.EpisodeCondition{Not: &config.EpisodeCondition{Every: 3, Offset: 3}}},
+			},
+			wantErr: true,
+		},
+	}
+	chars := map[string]config.CharacterConfig{
+		"zundamon": {Name: "ずんだもん"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &config.EpisodeSpec{Guests: tt.guests}
+			err := config.ValidateEpisodeSpecGuests(p, chars)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			} else if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/internal/config/corners_test.go
+++ b/internal/config/corners_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -291,6 +292,40 @@ func TestValidateEpisodeSpecCorners_Error(t *testing.T) {
 			p := &EpisodeSpec{Corners: tt.corners}
 			if err := ValidateEpisodeSpecCorners(p); err == nil {
 				t.Errorf("expected error for %q, got nil", tt.name)
+			}
+		})
+	}
+}
+
+func TestResolveCornersForEpisode_Offset_ThreeRotation(t *testing.T) {
+	corners := []CornerConfig{
+		{Title: "コーナーA", LengthSec: 60, Condition: &EpisodeCondition{Every: 3, Offset: 1}}, // 1,4,7,...
+		{Title: "コーナーB", LengthSec: 60, Condition: &EpisodeCondition{Every: 3, Offset: 2}}, // 2,5,8,...
+		{Title: "コーナーC", LengthSec: 60, Condition: &EpisodeCondition{Every: 3, Offset: 0}}, // 3,6,9,...
+	}
+
+	tests := []struct {
+		episodeNumber int
+		wantTitle     string
+	}{
+		{episodeNumber: 1, wantTitle: "コーナーA"},
+		{episodeNumber: 2, wantTitle: "コーナーB"},
+		{episodeNumber: 3, wantTitle: "コーナーC"},
+		{episodeNumber: 4, wantTitle: "コーナーA"},
+		{episodeNumber: 5, wantTitle: "コーナーB"},
+		{episodeNumber: 6, wantTitle: "コーナーC"},
+		{episodeNumber: 7, wantTitle: "コーナーA"},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("episode%d", tt.episodeNumber), func(t *testing.T) {
+			got := ResolveCornersForEpisode(corners, tt.episodeNumber)
+			if len(got) != 1 {
+				t.Fatalf("episode %d: got %d corners, want 1; titles: %v",
+					tt.episodeNumber, len(got), cornerTitles(got))
+			}
+			if got[0].Title != tt.wantTitle {
+				t.Errorf("episode %d: got %q, want %q", tt.episodeNumber, got[0].Title, tt.wantTitle)
 			}
 		})
 	}

--- a/internal/guest/guest_test.go
+++ b/internal/guest/guest_test.go
@@ -150,3 +150,35 @@ func TestSelect_Not(t *testing.T) {
 		}
 	}
 }
+
+func TestSelect_Offset_ThreePersonRotation(t *testing.T) {
+	guests := map[string]config.GuestConfig{
+		"alice": {Role: "ゲストA", Condition: config.EpisodeCondition{Every: 3, Offset: 1}}, // 1,4,7,...
+		"bob":   {Role: "ゲストB", Condition: config.EpisodeCondition{Every: 3, Offset: 2}}, // 2,5,8,...
+		"carol": {Role: "ゲストC", Condition: config.EpisodeCondition{Every: 3, Offset: 0}}, // 3,6,9,...
+	}
+
+	tests := []struct {
+		episodeNumber int
+		wantID        string
+	}{
+		{episodeNumber: 1, wantID: "alice"},
+		{episodeNumber: 2, wantID: "bob"},
+		{episodeNumber: 3, wantID: "carol"},
+		{episodeNumber: 4, wantID: "alice"},
+		{episodeNumber: 5, wantID: "bob"},
+		{episodeNumber: 6, wantID: "carol"},
+		{episodeNumber: 7, wantID: "alice"},
+	}
+
+	for _, tt := range tests {
+		result := guest.Select(guests, tt.episodeNumber)
+		if len(result) != 1 {
+			t.Errorf("episode %d: got %d guests, want 1; result: %v", tt.episodeNumber, len(result), result)
+			continue
+		}
+		if result[0].CharacterID != tt.wantID {
+			t.Errorf("episode %d: got guest %q, want %q", tt.episodeNumber, result[0].CharacterID, tt.wantID)
+		}
+	}
+}


### PR DESCRIPTION
## 概要

Issue #243 の実装。`EpisodeCondition` に `offset` フィールドを追加し、`episodeNumber % every == offset` の判定でゲスト・コーナーをN者ローテーションできるようにする。

## 変更内容

- `EpisodeCondition` に `Offset int`（`yaml:"offset,omitempty"`）を追加
- `Matches` の `every` 判定を `episodeNumber % every == offset` に変更（`offset` 未指定=0 で後方互換）
- `validateEpisodeCondition` に3つの検証を追加
  - `offset < 0` → エラー
  - `offset > 0 && every == 0` → エラー
  - `every > 0 && offset >= every` → エラー
- `config_test.go` / `guest_test.go` / `corners_test.go` に3者ローテのテストを追加
- README / `examples/tech.yaml` / `templates/episode-spec.yaml` にローテ設定例を追記

## 設定例（3者ローテ）

```yaml
guests:
  alice:
    role: ゲストA
    condition: { every: 3, offset: 1 }   # 1,4,7,...
  bob:
    role: ゲストB
    condition: { every: 3, offset: 2 }   # 2,5,8,...
  carol:
    role: ゲストC
    condition: { every: 3, offset: 0 }   # 3,6,9,...
```

## 関連

- Closes #243
- ADR は PR #244 にて別途マージ済み

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)