### PR TITLE
feat: jingle/se の無音トリミング閾値をアセット単位で設定できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,7 @@ assets_files:
 | `fade_in` | float64 | 任意 | フェードイン時間（秒）。デフォルト: 0 |
 | `fade_out` | float64 | 任意 | フェードアウト時間（秒）。デフォルト: 0 |
 | `trim_silence` | bool | 任意 | 前後の無音を自動除去するかどうか。デフォルト: true |
+| `trim_silence_threshold` | float64 | 任意 | 無音判定の振幅閾値（dB、負値のみ）。デフォルト: -50。素材のノイズフロアに合わせて調整 |
 | `description` | string | 任意 | アセットの説明（「何の音か・いつ使うか」）。LLM が挿入タイミングを判断する際の手がかりになる |
 
 ジングルはコーナー毎に `corners[].start_jingle` / `corners[].end_jingle` で設定します。script 生成ステップでコードがコーナー本編の前後へ確定的に挿入するため、生成された `04_script.json` にジングルセグメントが含まれます。BGM も `corners[].bgm` で同様にコーナー単位で管理します。
@@ -507,6 +508,7 @@ assets_files:
 | `file` | string | 必須 | 音声ファイルパス |
 | `volume` | float64 | 任意 | 音量倍率。デフォルト: 0（Go ゼロ値） |
 | `trim_silence` | bool | 任意 | 前後の無音を自動除去するかどうか。デフォルト: true |
+| `trim_silence_threshold` | float64 | 任意 | 無音判定の振幅閾値（dB、負値のみ）。デフォルト: -50。素材のノイズフロアに合わせて調整 |
 | `overlay` | bool | 任意 | `true` = 音声に重ねて再生（従来の overlay 動作）。`false` または省略 = SE が鳴り終わってから次のセリフを再生（順次）。デフォルト: false |
 | `description` | string | 任意 | アセットの説明（「何の音か・いつ使うか」）。LLM が挿入タイミングを判断する際の手がかりになる |
 

--- a/examples/assets/assets.yaml
+++ b/examples/assets/assets.yaml
@@ -8,6 +8,8 @@ se:
   accent_low:
     file: se/accent-low.mp3
     volume: 0.8
+    # trim_silence: true          # 省略時 true（前後の無音を自動除去）
+    # trim_silence_threshold: -50 # 省略時 -50（dB）。素材のノイズフロアに合わせて調整
     description: "話題の切り替わりや新コーナー導入時に使うアクセント音"
 bgm:
   coffee_break:

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -17,9 +17,6 @@ const (
 	outputNormFilter = "loudnorm=I=-16:TP=-1.5:LRA=11"
 	// outputLimiterLimit is the linear equivalent of the TP ceiling used in outputNormFilter (10^(-1.5/20) ≈ 0.841).
 	outputLimiterLimit = 0.841
-	// silenceTrimThreshold is the amplitude below which audio is treated as silence
-	// when stripping leading/trailing silence from jingle/SE inputs.
-	silenceTrimThreshold = "-50dB"
 )
 
 // BuildContext holds all data needed to build the ffmpeg command.
@@ -361,7 +358,7 @@ func buildRun(b *filterBuilder, run runData, clipInputIdx []int, assets config.A
 		}
 		seIdx := b.addInput(entry.File)
 		seKey := fmt.Sprintf("run%d_se%d", runIdx, i)
-		seLabel := applySilenceTrim(b, fmt.Sprintf("[%d:a]", seIdx), seKey, entry.EffectiveTrimSilence())
+		seLabel := applySilenceTrim(b, fmt.Sprintf("[%d:a]", seIdx), seKey, entry.EffectiveTrimSilence(), entry.EffectiveTrimSilenceThresholdDB())
 		delayedLabel := fmt.Sprintf("[%s]", seKey)
 		nextLabel := fmt.Sprintf("[run%d_after_se%d]", runIdx, i)
 		b.addFilter(fmt.Sprintf("%svolume=%.2f,adelay=%d|%d%s",
@@ -503,7 +500,7 @@ func buildSpeechConcat(b *filterBuilder, items []speechItem, clipInputIdx []int,
 			}
 			seIdx := b.addInput(entry.File)
 			seKey := fmt.Sprintf("run%d_seqse%d", runIdx, seqSEIdx)
-			seLabel := applySilenceTrim(b, fmt.Sprintf("[%d:a]", seIdx), seKey, entry.EffectiveTrimSilence())
+			seLabel := applySilenceTrim(b, fmt.Sprintf("[%d:a]", seIdx), seKey, entry.EffectiveTrimSilence(), entry.EffectiveTrimSilenceThresholdDB())
 			seVolLabel := fmt.Sprintf("[%s_vol]", seKey)
 			b.addFilter(fmt.Sprintf("%svolume=%.2f%s", seLabel, entry.Volume, seVolLabel))
 			parts = append(parts, seVolLabel)
@@ -523,21 +520,22 @@ func buildSpeechConcat(b *filterBuilder, items []speechItem, clipInputIdx []int,
 // applySilenceTrim strips leading and trailing silence from currentLabel when enabled.
 // Trailing silence is removed via the areverse trick (same pattern as applyFadeOut).
 // Returns currentLabel unchanged when enabled is false.
-func applySilenceTrim(b *filterBuilder, currentLabel string, key string, enabled bool) string {
+func applySilenceTrim(b *filterBuilder, currentLabel string, key string, enabled bool, thresholdDB float64) string {
 	if !enabled {
 		return currentLabel
 	}
+	th := fmt.Sprintf("%gdB", thresholdDB)
 	outLabel := fmt.Sprintf("[%s_st]", key)
 	b.addFilter(fmt.Sprintf(
 		"%ssilenceremove=start_periods=1:start_threshold=%s,areverse,silenceremove=start_periods=1:start_threshold=%s,areverse%s",
-		currentLabel, silenceTrimThreshold, silenceTrimThreshold, outLabel))
+		currentLabel, th, th, outLabel))
 	return outLabel
 }
 
 // buildJingleFadeIn applies silence trim then fade-in to a jingle input and returns the resulting label.
 func buildJingleFadeIn(b *filterBuilder, idx int, entry config.JingleEntry) string {
 	key := fmt.Sprintf("jingle%d", idx)
-	label := applySilenceTrim(b, fmt.Sprintf("[%d:a]", idx), key, entry.EffectiveTrimSilence())
+	label := applySilenceTrim(b, fmt.Sprintf("[%d:a]", idx), key, entry.EffectiveTrimSilence(), entry.EffectiveTrimSilenceThresholdDB())
 	return applyFadeIn(b, label, key, entry.FadeIn)
 }
 

--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -524,11 +524,10 @@ func applySilenceTrim(b *filterBuilder, currentLabel string, key string, enabled
 	if !enabled {
 		return currentLabel
 	}
-	th := fmt.Sprintf("%gdB", thresholdDB)
 	outLabel := fmt.Sprintf("[%s_st]", key)
 	b.addFilter(fmt.Sprintf(
-		"%ssilenceremove=start_periods=1:start_threshold=%s,areverse,silenceremove=start_periods=1:start_threshold=%s,areverse%s",
-		currentLabel, th, th, outLabel))
+		"%ssilenceremove=start_periods=1:start_threshold=%gdB,areverse,silenceremove=start_periods=1:start_threshold=%gdB,areverse%s",
+		currentLabel, thresholdDB, thresholdDB, outLabel))
 	return outLabel
 }
 

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -1719,3 +1719,113 @@ func TestBuildFFmpegArgs_BGMShortClamp_A4(t *testing.T) {
 		t.Errorf("unexpected error for short BGM with large fade: %v", err)
 	}
 }
+
+// TestBuildFFmpegArgs_JingleSilenceRemoveExplicitThreshold verifies that an explicit
+// trim_silence_threshold is used in the silenceremove filter for jingle.
+func TestBuildFFmpegArgs_JingleSilenceRemoveExplicitThreshold(t *testing.T) {
+	threshold := -40.0
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeJingle, AssetName: "op"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			Jingle: map[string]config.JingleEntry{
+				"op": {File: "/assets/op.wav", FadeIn: 0.3, TrimSilenceThreshold: &threshold},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(args.FilterComplex, "start_threshold=-40dB") {
+		t.Errorf("filter_complex missing start_threshold=-40dB for jingle with explicit threshold: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_SESilenceRemoveExplicitThreshold verifies that an explicit
+// trim_silence_threshold is used in the silenceremove filter for SE (sequential).
+func TestBuildFFmpegArgs_SESilenceRemoveExplicitThreshold(t *testing.T) {
+	threshold := -40.0
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
+				{Type: model.SegmentTypeSE, AssetName: "chime"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "main"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			SE: map[string]config.SEEntry{
+				"chime": {File: "/assets/chime.wav", Volume: 0.8, TrimSilenceThreshold: &threshold},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(args.FilterComplex, "start_threshold=-40dB") {
+		t.Errorf("filter_complex missing start_threshold=-40dB for SE with explicit threshold: %s", args.FilterComplex)
+	}
+}
+
+// TestBuildFFmpegArgs_SEOverlaySilenceRemoveExplicitThreshold verifies that an explicit
+// trim_silence_threshold is used in the silenceremove filter for SE (overlay).
+func TestBuildFFmpegArgs_SEOverlaySilenceRemoveExplicitThreshold(t *testing.T) {
+	threshold := -40.0
+	overlayTrue := true
+	ctx := BuildContext{
+		Script: model.Script{
+			Segments: []model.ScriptSegment{
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
+				{Type: model.SegmentTypeSE, AssetName: "chime"},
+				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "main"},
+			},
+		},
+		Clips: model.ClipsMeta{
+			Clips: []model.ClipMeta{
+				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+				{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
+			},
+		},
+		ClipsDir: "/clips",
+		Assets: config.AssetsConfig{
+			SE: map[string]config.SEEntry{
+				"chime": {File: "/assets/chime.wav", Volume: 0.8, TrimSilenceThreshold: &threshold, Overlay: &overlayTrue},
+			},
+		},
+		PauseSec: 0.5,
+		OutPath:  "/out.mp3",
+	}
+
+	args, err := BuildFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(args.FilterComplex, "start_threshold=-40dB") {
+		t.Errorf("filter_complex missing start_threshold=-40dB for SE overlay with explicit threshold: %s", args.FilterComplex)
+	}
+}

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -1720,112 +1720,77 @@ func TestBuildFFmpegArgs_BGMShortClamp_A4(t *testing.T) {
 	}
 }
 
-// TestBuildFFmpegArgs_JingleSilenceRemoveExplicitThreshold verifies that an explicit
-// trim_silence_threshold is used in the silenceremove filter for jingle.
-func TestBuildFFmpegArgs_JingleSilenceRemoveExplicitThreshold(t *testing.T) {
+// TestBuildFFmpegArgs_SilenceRemoveExplicitThreshold verifies that an explicit
+// trim_silence_threshold is reflected in the silenceremove filter for jingle, SE sequential, and SE overlay.
+func TestBuildFFmpegArgs_SilenceRemoveExplicitThreshold(t *testing.T) {
 	threshold := -40.0
-	ctx := BuildContext{
-		Script: model.Script{
-			Segments: []model.ScriptSegment{
+	overlayTrue := true
+	seSeg := []model.ScriptSegment{
+		{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
+		{Type: model.SegmentTypeSE, AssetName: "chime"},
+		{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "main"},
+	}
+	seClips := []model.ClipMeta{
+		{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+		{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
+	}
+	cases := []struct {
+		name   string
+		segs   []model.ScriptSegment
+		clips  []model.ClipMeta
+		assets config.AssetsConfig
+	}{
+		{
+			name: "jingle",
+			segs: []model.ScriptSegment{
 				{Type: model.SegmentTypeJingle, AssetName: "op"},
 				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "hello"},
 			},
-		},
-		Clips: model.ClipsMeta{
-			Clips: []model.ClipMeta{
-				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
+			clips: []model.ClipMeta{{Index: 0, File: "clip_000.wav", DurationSec: 2.0}},
+			assets: config.AssetsConfig{
+				Jingle: map[string]config.JingleEntry{
+					"op": {File: "/assets/op.wav", FadeIn: 0.3, TrimSilenceThreshold: &threshold},
+				},
 			},
 		},
-		ClipsDir: "/clips",
-		Assets: config.AssetsConfig{
-			Jingle: map[string]config.JingleEntry{
-				"op": {File: "/assets/op.wav", FadeIn: 0.3, TrimSilenceThreshold: &threshold},
+		{
+			name:  "SE sequential",
+			segs:  seSeg,
+			clips: seClips,
+			assets: config.AssetsConfig{
+				SE: map[string]config.SEEntry{
+					"chime": {File: "/assets/chime.wav", Volume: 0.8, TrimSilenceThreshold: &threshold},
+				},
 			},
 		},
-		PauseSec: 0.5,
-		OutPath:  "/out.mp3",
-	}
-
-	args, err := BuildFFmpegArgs(ctx)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(args.FilterComplex, "start_threshold=-40dB") {
-		t.Errorf("filter_complex missing start_threshold=-40dB for jingle with explicit threshold: %s", args.FilterComplex)
-	}
-}
-
-// TestBuildFFmpegArgs_SESilenceRemoveExplicitThreshold verifies that an explicit
-// trim_silence_threshold is used in the silenceremove filter for SE (sequential).
-func TestBuildFFmpegArgs_SESilenceRemoveExplicitThreshold(t *testing.T) {
-	threshold := -40.0
-	ctx := BuildContext{
-		Script: model.Script{
-			Segments: []model.ScriptSegment{
-				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
-				{Type: model.SegmentTypeSE, AssetName: "chime"},
-				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "main"},
+		{
+			name:  "SE overlay",
+			segs:  seSeg,
+			clips: seClips,
+			assets: config.AssetsConfig{
+				SE: map[string]config.SEEntry{
+					"chime": {File: "/assets/chime.wav", Volume: 0.8, TrimSilenceThreshold: &threshold, Overlay: &overlayTrue},
+				},
 			},
 		},
-		Clips: model.ClipsMeta{
-			Clips: []model.ClipMeta{
-				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
-				{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
-			},
-		},
-		ClipsDir: "/clips",
-		Assets: config.AssetsConfig{
-			SE: map[string]config.SEEntry{
-				"chime": {File: "/assets/chime.wav", Volume: 0.8, TrimSilenceThreshold: &threshold},
-			},
-		},
-		PauseSec: 0.5,
-		OutPath:  "/out.mp3",
 	}
-
-	args, err := BuildFFmpegArgs(ctx)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(args.FilterComplex, "start_threshold=-40dB") {
-		t.Errorf("filter_complex missing start_threshold=-40dB for SE with explicit threshold: %s", args.FilterComplex)
-	}
-}
-
-// TestBuildFFmpegArgs_SEOverlaySilenceRemoveExplicitThreshold verifies that an explicit
-// trim_silence_threshold is used in the silenceremove filter for SE (overlay).
-func TestBuildFFmpegArgs_SEOverlaySilenceRemoveExplicitThreshold(t *testing.T) {
-	threshold := -40.0
-	overlayTrue := true
-	ctx := BuildContext{
-		Script: model.Script{
-			Segments: []model.ScriptSegment{
-				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "intro"},
-				{Type: model.SegmentTypeSE, AssetName: "chime"},
-				{Type: model.SegmentTypeSpeech, SpeakerRole: "host", Text: "main"},
-			},
-		},
-		Clips: model.ClipsMeta{
-			Clips: []model.ClipMeta{
-				{Index: 0, File: "clip_000.wav", DurationSec: 2.0},
-				{Index: 1, File: "clip_001.wav", DurationSec: 3.0},
-			},
-		},
-		ClipsDir: "/clips",
-		Assets: config.AssetsConfig{
-			SE: map[string]config.SEEntry{
-				"chime": {File: "/assets/chime.wav", Volume: 0.8, TrimSilenceThreshold: &threshold, Overlay: &overlayTrue},
-			},
-		},
-		PauseSec: 0.5,
-		OutPath:  "/out.mp3",
-	}
-
-	args, err := BuildFFmpegArgs(ctx)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(args.FilterComplex, "start_threshold=-40dB") {
-		t.Errorf("filter_complex missing start_threshold=-40dB for SE overlay with explicit threshold: %s", args.FilterComplex)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := BuildContext{
+				Script:   model.Script{Segments: c.segs},
+				Clips:    model.ClipsMeta{Clips: c.clips},
+				ClipsDir: "/clips",
+				Assets:   c.assets,
+				PauseSec: 0.5,
+				OutPath:  "/out.mp3",
+			}
+			args, err := BuildFFmpegArgs(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(args.FilterComplex, "start_threshold=-40dB") {
+				t.Errorf("filter_complex missing start_threshold=-40dB: %s", args.FilterComplex)
+			}
+		})
 	}
 }

--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -122,23 +122,27 @@ corners:
 #     fade_in: 0.5
 #     fade_out: 0.5
 #     # trim_silence: false  # 省略時は true（素材前後の無音を自動除去）。無効にしたい場合のみ記載
+#     # trim_silence_threshold: -50  # 省略時は -50（dB）。素材のノイズフロアに合わせて調整
 #     description: "番組冒頭で流すオープニングジングル"  # 省略可
 #   ending:
 #     file: jingle/ending.mp3
 #     fade_in: 0.5
 #     fade_out: 1.0
 #     # trim_silence: false  # 省略時は true
+#     # trim_silence_threshold: -50  # 省略時は -50（dB）
 # se:
 #   chime:
 #     file: se/chime.wav
 #     volume: 0.8
 #     # trim_silence: false  # 省略時は true（素材前後の無音を自動除去）。無効にしたい場合のみ記載
+#     # trim_silence_threshold: -50  # 省略時は -50（dB）。素材のノイズフロアに合わせて調整
 #     # overlay: true  # 省略時は false（SE が鳴り終わってから次のセリフを再生）。セリフに重ねたい場合のみ true
 #     description: "話題の切り替わりに鳴らす明るいチャイム音"  # 省略可
 #   transition:
 #     file: se/transition.wav
 #     volume: 0.8
 #     # trim_silence: false  # 省略時は true
+#     # trim_silence_threshold: -50  # 省略時は -50（dB）
 #     # overlay: true  # 省略時は false（順次再生）
 # bgm:
 #   talk_bgm:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,26 +34,38 @@ type FeedsConfig struct {
 }
 
 type JingleEntry struct {
-	File        string  `yaml:"file"`
-	FadeIn      float64 `yaml:"fade_in"`
-	FadeOut     float64 `yaml:"fade_out"`
-	TrimSilence *bool   `yaml:"trim_silence,omitempty"`
-	Description string  `yaml:"description,omitempty"`
+	File                 string   `yaml:"file"`
+	FadeIn               float64  `yaml:"fade_in"`
+	FadeOut              float64  `yaml:"fade_out"`
+	TrimSilence          *bool    `yaml:"trim_silence,omitempty"`
+	TrimSilenceThreshold *float64 `yaml:"trim_silence_threshold,omitempty"` // dB; nil → DefaultSilenceTrimThresholdDB
+	Description          string   `yaml:"description,omitempty"`
 }
 
 // EffectiveTrimSilence returns true when TrimSilence is nil (default on) or explicitly true.
 func (e JingleEntry) EffectiveTrimSilence() bool { return effectiveTrimSilence(e.TrimSilence) }
 
+// EffectiveTrimSilenceThresholdDB returns the threshold in dB; nil → DefaultSilenceTrimThresholdDB.
+func (e JingleEntry) EffectiveTrimSilenceThresholdDB() float64 {
+	return effectiveTrimSilenceThresholdDB(e.TrimSilenceThreshold)
+}
+
 type SEEntry struct {
-	File        string  `yaml:"file"`
-	Volume      float64 `yaml:"volume"`
-	TrimSilence *bool   `yaml:"trim_silence,omitempty"`
-	Overlay     *bool   `yaml:"overlay,omitempty"` // nil=false (sequential); true=overlay on speech track
-	Description string  `yaml:"description,omitempty"`
+	File                 string   `yaml:"file"`
+	Volume               float64  `yaml:"volume"`
+	TrimSilence          *bool    `yaml:"trim_silence,omitempty"`
+	TrimSilenceThreshold *float64 `yaml:"trim_silence_threshold,omitempty"` // dB; nil → DefaultSilenceTrimThresholdDB
+	Overlay              *bool    `yaml:"overlay,omitempty"`                // nil=false (sequential); true=overlay on speech track
+	Description          string   `yaml:"description,omitempty"`
 }
 
 // EffectiveTrimSilence returns true when TrimSilence is nil (default on) or explicitly true.
 func (e SEEntry) EffectiveTrimSilence() bool { return effectiveTrimSilence(e.TrimSilence) }
+
+// EffectiveTrimSilenceThresholdDB returns the threshold in dB; nil → DefaultSilenceTrimThresholdDB.
+func (e SEEntry) EffectiveTrimSilenceThresholdDB() float64 {
+	return effectiveTrimSilenceThresholdDB(e.TrimSilenceThreshold)
+}
 
 // EffectiveOverlay returns true only when Overlay is explicitly true.
 // Default (nil) is false: the SE plays to completion before the next dialogue.
@@ -66,6 +78,18 @@ func effectiveTrimSilence(v *bool) bool {
 	}
 	return *v
 }
+
+// effectiveTrimSilenceThresholdDB resolves a *float64 threshold: nil → DefaultSilenceTrimThresholdDB.
+func effectiveTrimSilenceThresholdDB(v *float64) float64 {
+	if v == nil {
+		return DefaultSilenceTrimThresholdDB
+	}
+	return *v
+}
+
+// DefaultSilenceTrimThresholdDB is the default amplitude threshold (dB) below which
+// audio is treated as silence when trimming leading/trailing silence from jingle/SE.
+const DefaultSilenceTrimThresholdDB = -50.0
 
 // DefaultBGMFadeSec is the default fade-in/out duration (seconds) for BGM when not explicitly specified.
 const DefaultBGMFadeSec = 1.0
@@ -666,6 +690,9 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		if entry.FadeOut < 0 {
 			return fmt.Errorf("jingle[%q].fade_out: must be >= 0, got %v", name, entry.FadeOut)
 		}
+		if entry.TrimSilenceThreshold != nil && *entry.TrimSilenceThreshold >= 0 {
+			return fmt.Errorf("jingle[%q].trim_silence_threshold: must be < 0 (dB), got %v", name, *entry.TrimSilenceThreshold)
+		}
 	}
 	for name, entry := range assets.SE {
 		if err := validateFileField("se", name, entry.File); err != nil {
@@ -673,6 +700,9 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		}
 		if entry.Volume < 0 {
 			return fmt.Errorf("se[%q].volume: must be >= 0, got %v", name, entry.Volume)
+		}
+		if entry.TrimSilenceThreshold != nil && *entry.TrimSilenceThreshold >= 0 {
+			return fmt.Errorf("se[%q].trim_silence_threshold: must be < 0 (dB), got %v", name, *entry.TrimSilenceThreshold)
 		}
 	}
 	for name, entry := range assets.BGM {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -678,6 +678,13 @@ func validateFileField(category, name, file string) error {
 	return nil
 }
 
+func validateTrimSilenceThresholdDB(category, name string, v *float64) error {
+	if v != nil && *v >= 0 {
+		return fmt.Errorf("%s[%q].trim_silence_threshold: must be < 0 (dB), got %v", category, name, *v)
+	}
+	return nil
+}
+
 // ValidateAssetsConfig checks that all referenced files exist and that field values are in valid ranges.
 func ValidateAssetsConfig(assets *AssetsConfig) error {
 	for name, entry := range assets.Jingle {
@@ -690,8 +697,8 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		if entry.FadeOut < 0 {
 			return fmt.Errorf("jingle[%q].fade_out: must be >= 0, got %v", name, entry.FadeOut)
 		}
-		if entry.TrimSilenceThreshold != nil && *entry.TrimSilenceThreshold >= 0 {
-			return fmt.Errorf("jingle[%q].trim_silence_threshold: must be < 0 (dB), got %v", name, *entry.TrimSilenceThreshold)
+		if err := validateTrimSilenceThresholdDB("jingle", name, entry.TrimSilenceThreshold); err != nil {
+			return err
 		}
 	}
 	for name, entry := range assets.SE {
@@ -701,8 +708,8 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		if entry.Volume < 0 {
 			return fmt.Errorf("se[%q].volume: must be >= 0, got %v", name, entry.Volume)
 		}
-		if entry.TrimSilenceThreshold != nil && *entry.TrimSilenceThreshold >= 0 {
-			return fmt.Errorf("se[%q].trim_silence_threshold: must be < 0 (dB), got %v", name, *entry.TrimSilenceThreshold)
+		if err := validateTrimSilenceThresholdDB("se", name, entry.TrimSilenceThreshold); err != nil {
+			return err
 		}
 	}
 	for name, entry := range assets.BGM {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,10 @@ func effectiveTrimSilence(v *bool) bool {
 	return *v
 }
 
+// DefaultSilenceTrimThresholdDB is the default amplitude threshold (dB) below which
+// audio is treated as silence when trimming leading/trailing silence from jingle/SE.
+const DefaultSilenceTrimThresholdDB = -50.0
+
 // effectiveTrimSilenceThresholdDB resolves a *float64 threshold: nil → DefaultSilenceTrimThresholdDB.
 func effectiveTrimSilenceThresholdDB(v *float64) float64 {
 	if v == nil {
@@ -86,10 +90,6 @@ func effectiveTrimSilenceThresholdDB(v *float64) float64 {
 	}
 	return *v
 }
-
-// DefaultSilenceTrimThresholdDB is the default amplitude threshold (dB) below which
-// audio is treated as silence when trimming leading/trailing silence from jingle/SE.
-const DefaultSilenceTrimThresholdDB = -50.0
 
 // DefaultBGMFadeSec is the default fade-in/out duration (seconds) for BGM when not explicitly specified.
 const DefaultBGMFadeSec = 1.0

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1384,6 +1384,8 @@ func TestValidateAssetsConfig_EmptyFileField_Error(t *testing.T) {
 func TestValidateAssetsConfig_InvalidField_Error(t *testing.T) {
 	neg1 := -1.0
 	neg05 := -0.5
+	zero := 0.0
+	pos1 := 1.0
 	cases := []struct {
 		name   string
 		assets func(f string) *config.AssetsConfig
@@ -1401,9 +1403,33 @@ func TestValidateAssetsConfig_InvalidField_Error(t *testing.T) {
 			},
 		},
 		{
+			name: "jingle trim_silence_threshold zero",
+			assets: func(f string) *config.AssetsConfig {
+				return &config.AssetsConfig{Jingle: map[string]config.JingleEntry{"j": {File: f, TrimSilenceThreshold: &zero}}}
+			},
+		},
+		{
+			name: "jingle trim_silence_threshold positive",
+			assets: func(f string) *config.AssetsConfig {
+				return &config.AssetsConfig{Jingle: map[string]config.JingleEntry{"j": {File: f, TrimSilenceThreshold: &pos1}}}
+			},
+		},
+		{
 			name: "se volume negative",
 			assets: func(f string) *config.AssetsConfig {
 				return &config.AssetsConfig{SE: map[string]config.SEEntry{"chime": {File: f, Volume: -0.1}}}
+			},
+		},
+		{
+			name: "se trim_silence_threshold zero",
+			assets: func(f string) *config.AssetsConfig {
+				return &config.AssetsConfig{SE: map[string]config.SEEntry{"chime": {File: f, Volume: 0.8, TrimSilenceThreshold: &zero}}}
+			},
+		},
+		{
+			name: "se trim_silence_threshold positive",
+			assets: func(f string) *config.AssetsConfig {
+				return &config.AssetsConfig{SE: map[string]config.SEEntry{"chime": {File: f, Volume: 0.8, TrimSilenceThreshold: &pos1}}}
 			},
 		},
 		{
@@ -1440,6 +1466,46 @@ func TestValidateAssetsConfig_InvalidField_Error(t *testing.T) {
 			}
 			if err := config.ValidateAssetsConfig(c.assets(f)); err == nil {
 				t.Errorf("expected error for %q, got nil", c.name)
+			}
+		})
+	}
+}
+
+func TestJingleEntry_EffectiveTrimSilenceThresholdDB(t *testing.T) {
+	cases := []struct {
+		name string
+		ptr  *float64
+		want float64
+	}{
+		{"nil uses default", nil, -50.0},
+		{"explicit -40", float64Ptr(-40.0), -40.0},
+		{"explicit -47.5", float64Ptr(-47.5), -47.5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := config.JingleEntry{TrimSilenceThreshold: c.ptr}
+			if got := e.EffectiveTrimSilenceThresholdDB(); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSEEntry_EffectiveTrimSilenceThresholdDB(t *testing.T) {
+	cases := []struct {
+		name string
+		ptr  *float64
+		want float64
+	}{
+		{"nil uses default", nil, -50.0},
+		{"explicit -40", float64Ptr(-40.0), -40.0},
+		{"explicit -47.5", float64Ptr(-47.5), -47.5},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			e := config.SEEntry{TrimSilenceThreshold: c.ptr}
+			if got := e.EffectiveTrimSilenceThresholdDB(); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- `JingleEntry` / `SEEntry` に `trim_silence_threshold *float64` フィールドを追加し、アセットファイル単位で無音判定閾値（dB）を設定できるようにした
- `DefaultSilenceTrimThresholdDB = -50.0` 定数を導入し、`filter.go` のハードコード定数 `silenceTrimThreshold = "-50dB"` を削除
- `applySilenceTrim()` に `thresholdDB float64` 引数を追加し、jingle / SE overlay / SE sequential の 3 経路すべてでファイル単位の閾値を使用するよう更新
- `ValidateAssetsConfig` で `trim_silence_threshold >= 0` をエラーとして検証（共通ヘルパー `validateTrimSilenceThresholdDB` に抽出）
- README / `examples/assets/assets.yaml` / `episode-spec.yaml` に `trim_silence_threshold` の説明・記述例を追記

## Changes

| ファイル | 変更内容 |
|---|---|
| `internal/config/config.go` | 定数・フィールド・ヘルパー・メソッド・検証を追加 |
| `internal/assemble/filter.go` | `applySilenceTrim()` 引数化・ハードコード定数削除 |
| `internal/config/config_test.go` | `EffectiveTrimSilenceThresholdDB` と検証のテスト追加 |
| `internal/assemble/filter_test.go` | 明示閾値が filter に反映されることのテスト追加（テーブル駆動） |
| `README.md` | jingle / se 設定表に `trim_silence_threshold` 行追加 |
| `examples/assets/assets.yaml` | コメント付き記述例追加 |
| `internal/cli/templates/episode-spec.yaml` | アセット例コメントに追記 |

Closes #259

---
🤖 Generated with [Claude Code](https://claude.ai/code)