### PR TITLE
feat: 素材ID単体にパラメータを適用した音声を生成する assets preview コマンドを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ collect → rundown → script → synth → assemble → manifest
 | `config check` | 共通設定ファイルを strict モードでパースし、未知キー（typo）や設定値の不整合をエラーとして報告する（パスは `--config` で指定、省略時は `vox-radio.yaml`） |
 | `episodegen check` | エピソード仕様 YAML を strict モードでパースし、アセット参照・キャラ参照の整合性を検証する（共通設定は `--config` で指定、省略時は `vox-radio.yaml`） |
 | `assets check` | アセット設定 YAML（`assets.yaml`）を strict モードでパースし、typo・参照ファイル欠落・不正値（volume/fade/duck_ratio）をエラーとして報告する |
+| `assets preview` | 素材IDを指定し、パラメータを適用したプレビュー音声を MP3 で生成する（`--id {type}:{key} --out out.mp3 [--max-length-sec 秒]`）。loudnorm/alimiter は適用されない |
 
 ### 設定ファイルの作成
 

--- a/docs/cli/vox-radio_assets.md
+++ b/docs/cli/vox-radio_assets.md
@@ -7,7 +7,8 @@
 アセット設定ファイル（assets.yaml）の管理操作を提供します。
 
 サブコマンド:
-  check  アセット設定ファイルを strict モードで検証する
+  check    アセット設定ファイルを strict モードで検証する
+  preview  素材ID単体にパラメータを適用した音声をプレビュー生成する
 
 ### Options
 
@@ -25,4 +26,5 @@
 
 * [vox-radio](vox-radio.md)	 - AI を使ったポッドキャスト制作ツール
 * [vox-radio assets check](vox-radio_assets_check.md)	 - アセット設定ファイルを strict モードでフル検証する
+* [vox-radio assets preview](vox-radio_assets_preview.md)	 - 素材ID単体にパラメータを適用した音声をプレビュー生成する
 

--- a/docs/cli/vox-radio_assets_preview.md
+++ b/docs/cli/vox-radio_assets_preview.md
@@ -1,0 +1,37 @@
+## vox-radio assets preview
+
+素材ID単体にパラメータを適用した音声をプレビュー生成する
+
+### Synopsis
+
+指定した assets.yaml から素材IDを検索し、パラメータを適用したプレビュー音声を MP3 で生成します。
+
+loudnorm/alimiter は適用されないため、各パラメータの素の効果を確認できます。
+
+例:
+  vox-radio assets preview assets.yaml --id jingle:opening --out preview.mp3
+  vox-radio assets preview assets.yaml --id bgm:talk --out preview.mp3 --max-length-sec 15
+
+```
+vox-radio assets preview <path> [flags]
+```
+
+### Options
+
+```
+  -h, --help                   help for preview
+      --id string              {type}:{key} 形式の素材ID（type: jingle/se/bgm）（必須）
+      --max-length-sec float   プレビュー出力の最大長（秒）。出力がこれより長い場合に末尾を打ち切る (default 30)
+      --out string             MP3 出力先パス（必須）
+```
+
+### Options inherited from parent commands
+
+```
+      --config string   共通設定 YAML ファイル（vox-radio.yaml）のパス (default "vox-radio.yaml")
+```
+
+### SEE ALSO
+
+* [vox-radio assets](vox-radio_assets.md)	 - アセット設定ファイルを管理するコマンド群
+

--- a/internal/assemble/preview.go
+++ b/internal/assemble/preview.go
@@ -134,17 +134,14 @@ func buildBGMPreview(b *filterBuilder, ctx PreviewContext, maxSec float64) (stri
 	}
 
 	key := "preview"
-	var label string
+	volLabel := "[preview_bgm_vol]"
+	// For loop=true, chain atrim to stop the infinite loop at maxSec.
+	atrimSuffix := ""
 	if entry.Loop {
-		// Apply volume and atrim together to stop the infinite loop at maxSec.
-		trimLabel := "[preview_bgm_trim]"
-		b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f,atrim=duration=%.3f%s", bgmIdx, entry.Volume, maxSec, trimLabel))
-		label = trimLabel
-	} else {
-		volLabel := "[preview_bgm_vol]"
-		b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f%s", bgmIdx, entry.Volume, volLabel))
-		label = volLabel
+		atrimSuffix = fmt.Sprintf(",atrim=duration=%.3f", maxSec)
 	}
+	b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f%s%s", bgmIdx, entry.Volume, atrimSuffix, volLabel))
+	label := volLabel
 
 	label = applyFadeIn(b, label, key, entry.EffectiveFadeIn())
 	label = applyFadeOut(b, label, key, entry.EffectiveFadeOut())

--- a/internal/assemble/preview.go
+++ b/internal/assemble/preview.go
@@ -1,0 +1,191 @@
+package assemble
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/config"
+)
+
+const (
+	defaultPreviewMaxLengthSec = 30.0
+	dummyNarrationToneSec      = 2.0
+	dummyNarrationSilSec       = 1.0
+	dummyNarrationFreq         = 440
+	dummyNarrationSampleRate   = 44100
+)
+
+// PreviewContext holds the parameters for a single-asset preview.
+type PreviewContext struct {
+	AssetType    string // "jingle", "se", or "bgm"
+	AssetKey     string // key in the assets map
+	Assets       config.AssetsConfig
+	OutPath      string
+	MaxLengthSec float64 // maximum output duration; <= 0 uses defaultPreviewMaxLengthSec
+}
+
+// Previewer executes a single-asset preview via ffmpeg.
+type Previewer struct {
+	runFFmpeg func(ctx context.Context, args []string, w io.Writer) error
+}
+
+// NewPreviewer creates a Previewer that calls ffmpeg.
+func NewPreviewer() *Previewer {
+	return &Previewer{runFFmpeg: runFFmpegCmd}
+}
+
+// Run builds ffmpeg args for the preview context and executes ffmpeg.
+func (p *Previewer) Run(ctx context.Context, pctx PreviewContext, w io.Writer) error {
+	ffArgs, err := BuildPreviewFFmpegArgs(pctx)
+	if err != nil {
+		return err
+	}
+	args := buildCmdArgs(ffArgs)
+	if w != nil {
+		_, _ = fmt.Fprintf(w, "--- ffmpeg command ---\nffmpeg %s\n--- ffmpeg output ---\n", strings.Join(args, " "))
+	}
+	return p.runFFmpeg(ctx, args, w)
+}
+
+// BuildPreviewFFmpegArgs constructs ffmpeg arguments for a single-asset preview.
+// Unlike BuildFFmpegArgs, loudnorm and alimiter are NOT applied.
+func BuildPreviewFFmpegArgs(ctx PreviewContext) (*FFmpegArgs, error) {
+	maxSec := ctx.MaxLengthSec
+	if maxSec <= 0 {
+		maxSec = defaultPreviewMaxLengthSec
+	}
+
+	b := &filterBuilder{}
+
+	var finalLabel string
+	var trimApplied bool
+	var err error
+
+	switch ctx.AssetType {
+	case "jingle":
+		finalLabel, err = buildJinglePreview(b, ctx)
+	case "se":
+		finalLabel, err = buildSEPreview(b, ctx)
+	case "bgm":
+		finalLabel, trimApplied, err = buildBGMPreview(b, ctx, maxSec)
+	default:
+		return nil, fmt.Errorf("unknown asset type %q: must be jingle, se, or bgm", ctx.AssetType)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if !trimApplied {
+		trimLabel := "[preview_out]"
+		b.addFilter(fmt.Sprintf("%satrim=duration=%.3f%s", finalLabel, maxSec, trimLabel))
+		finalLabel = trimLabel
+	}
+
+	return &FFmpegArgs{
+		Inputs:        b.inputs,
+		FilterComplex: strings.Join(b.filters, ";"),
+		OutputArgs:    []string{"-map", finalLabel, "-c:a", "libmp3lame", "-q:a", "2"},
+		OutputPath:    ctx.OutPath,
+	}, nil
+}
+
+func buildJinglePreview(b *filterBuilder, ctx PreviewContext) (string, error) {
+	entry, ok := ctx.Assets.Jingle[ctx.AssetKey]
+	if !ok {
+		return "", fmt.Errorf("jingle %q not found in assets", ctx.AssetKey)
+	}
+	idx := b.addInput(entry.File)
+	key := "preview"
+	label := applySilenceTrim(b, fmt.Sprintf("[%d:a]", idx), key, entry.EffectiveTrimSilence(), entry.EffectiveTrimSilenceThresholdDB())
+	label = applyFadeIn(b, label, key, entry.FadeIn)
+	label = applyFadeOut(b, label, key, entry.FadeOut)
+	return label, nil
+}
+
+func buildSEPreview(b *filterBuilder, ctx PreviewContext) (string, error) {
+	entry, ok := ctx.Assets.SE[ctx.AssetKey]
+	if !ok {
+		return "", fmt.Errorf("se %q not found in assets", ctx.AssetKey)
+	}
+	idx := b.addInput(entry.File)
+	key := "preview"
+	label := applySilenceTrim(b, fmt.Sprintf("[%d:a]", idx), key, entry.EffectiveTrimSilence(), entry.EffectiveTrimSilenceThresholdDB())
+	volLabel := "[preview_vol]"
+	b.addFilter(fmt.Sprintf("%svolume=%.2f%s", label, entry.Volume, volLabel))
+	return volLabel, nil
+}
+
+// buildBGMPreview builds the filter chain for a BGM asset preview.
+// Returns the final label, whether max-length trim was already applied (loop=true), and any error.
+func buildBGMPreview(b *filterBuilder, ctx PreviewContext, maxSec float64) (string, bool, error) {
+	entry, ok := ctx.Assets.BGM[ctx.AssetKey]
+	if !ok {
+		return "", false, fmt.Errorf("bgm %q not found in assets", ctx.AssetKey)
+	}
+
+	var bgmIdx int
+	if entry.Loop {
+		bgmIdx = b.addInput(entry.File, "-stream_loop", "-1")
+	} else {
+		bgmIdx = b.addInput(entry.File)
+	}
+
+	key := "preview"
+	var label string
+	if entry.Loop {
+		// Apply volume and atrim together to stop the infinite loop at maxSec.
+		trimLabel := "[preview_bgm_trim]"
+		b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f,atrim=duration=%.3f%s", bgmIdx, entry.Volume, maxSec, trimLabel))
+		label = trimLabel
+	} else {
+		volLabel := "[preview_bgm_vol]"
+		b.addFilter(fmt.Sprintf("[%d:a]volume=%.2f%s", bgmIdx, entry.Volume, volLabel))
+		label = volLabel
+	}
+
+	label = applyFadeIn(b, label, key, entry.EffectiveFadeIn())
+	label = applyFadeOut(b, label, key, entry.EffectiveFadeOut())
+
+	if entry.DuckRatio > 0 {
+		narrLabel := buildDummyNarration(b, maxSec)
+		duckedLabel := "[preview_ducked]"
+		b.addFilter(fmt.Sprintf("%s%ssidechaincompress=threshold=0.02:ratio=%.1f%s",
+			label, narrLabel, entry.DuckRatio, duckedLabel))
+		label = duckedLabel
+	}
+
+	return label, entry.Loop, nil
+}
+
+// buildDummyNarration generates a repeating tone/silence pattern as a sidechain signal for ducking.
+// The pattern alternates dummyNarrationToneSec-second tones with dummyNarrationSilSec-second silence.
+func buildDummyNarration(b *filterBuilder, durationSec float64) string {
+	const cycleSec = dummyNarrationToneSec + dummyNarrationSilSec
+	numCycles := int(math.Ceil(durationSec/cycleSec)) + 1
+
+	parts := make([]string, 0, numCycles*2)
+	for i := 0; i < numCycles; i++ {
+		toneLabel := fmt.Sprintf("[dummy_tone%d]", i)
+		silLabel := fmt.Sprintf("[dummy_sil%d]", i)
+		b.addFilter(fmt.Sprintf(
+			"sine=frequency=%d:sample_rate=%d,atrim=duration=%.3f%s",
+			dummyNarrationFreq, dummyNarrationSampleRate, dummyNarrationToneSec, toneLabel,
+		))
+		b.addFilter(fmt.Sprintf(
+			"anullsrc=cl=mono:r=%d,atrim=duration=%.3f%s",
+			dummyNarrationSampleRate, dummyNarrationSilSec, silLabel,
+		))
+		parts = append(parts, toneLabel, silLabel)
+	}
+
+	narrRawLabel := "[dummy_narr_raw]"
+	b.addFilter(fmt.Sprintf("%sconcat=n=%d:v=0:a=1%s", strings.Join(parts, ""), len(parts), narrRawLabel))
+
+	narrLabel := "[dummy_narr]"
+	b.addFilter(fmt.Sprintf("%satrim=duration=%.3f%s", narrRawLabel, durationSec, narrLabel))
+
+	return narrLabel
+}

--- a/internal/assemble/preview.go
+++ b/internal/assemble/preview.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/canpok1/vox-radio/internal/config"
@@ -39,6 +41,10 @@ func NewPreviewer() *Previewer {
 
 // Run builds ffmpeg args for the preview context and executes ffmpeg.
 func (p *Previewer) Run(ctx context.Context, pctx PreviewContext, w io.Writer) error {
+	if err := os.MkdirAll(filepath.Dir(pctx.OutPath), 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
 	ffArgs, err := BuildPreviewFFmpegArgs(pctx)
 	if err != nil {
 		return err

--- a/internal/assemble/preview_test.go
+++ b/internal/assemble/preview_test.go
@@ -3,6 +3,7 @@ package assemble
 import (
 	"context"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -325,6 +326,9 @@ func TestBuildPreviewFFmpegArgs_UnknownKey_ReturnsError(t *testing.T) {
 }
 
 func TestPreviewer_Run_InvokesFFmpegWithFilterComplex(t *testing.T) {
+	dir := t.TempDir()
+	outPath := dir + "/out.mp3"
+
 	assets := config.AssetsConfig{
 		SE: map[string]config.SEEntry{
 			"chime": {File: "/audio/chime.wav", Volume: 0.8},
@@ -343,7 +347,7 @@ func TestPreviewer_Run_InvokesFFmpegWithFilterComplex(t *testing.T) {
 		AssetType:    "se",
 		AssetKey:     "chime",
 		Assets:       assets,
-		OutPath:      "/out.mp3",
+		OutPath:      outPath,
 		MaxLengthSec: testMaxLengthSec,
 	}
 
@@ -362,7 +366,39 @@ func TestPreviewer_Run_InvokesFFmpegWithFilterComplex(t *testing.T) {
 		t.Errorf("expected -filter_complex in ffmpeg args, got: %v", capturedArgs)
 	}
 
-	if len(capturedArgs) == 0 || capturedArgs[len(capturedArgs)-1] != "/out.mp3" {
-		t.Errorf("expected /out.mp3 as last ffmpeg arg, got: %v", capturedArgs)
+	if len(capturedArgs) == 0 || capturedArgs[len(capturedArgs)-1] != outPath {
+		t.Errorf("expected %s as last ffmpeg arg, got: %v", outPath, capturedArgs)
+	}
+}
+
+func TestPreviewer_Run_CreatesOutputDirectory(t *testing.T) {
+	dir := t.TempDir()
+	outPath := dir + "/subdir/out.mp3"
+
+	assets := config.AssetsConfig{
+		SE: map[string]config.SEEntry{
+			"chime": {File: "/audio/chime.wav", Volume: 0.5},
+		},
+	}
+
+	p := &Previewer{
+		runFFmpeg: func(_ context.Context, _ []string, _ io.Writer) error { return nil },
+	}
+
+	pctx := PreviewContext{
+		AssetType:    "se",
+		AssetKey:     "chime",
+		Assets:       assets,
+		OutPath:      outPath,
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	err := p.Run(context.Background(), pctx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, statErr := os.Stat(dir + "/subdir"); os.IsNotExist(statErr) {
+		t.Errorf("expected output directory to be created, but it does not exist")
 	}
 }

--- a/internal/assemble/preview_test.go
+++ b/internal/assemble/preview_test.go
@@ -1,0 +1,370 @@
+package assemble
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+)
+
+func floatPtr(v float64) *float64 { return &v }
+
+const testMaxLengthSec = 10.0
+
+func TestBuildPreviewFFmpegArgs_Jingle_ContainsExpectedFilters(t *testing.T) {
+	assets := config.AssetsConfig{
+		Jingle: map[string]config.JingleEntry{
+			"opening": {
+				File:    "/audio/opening.mp3",
+				FadeIn:  0.5,
+				FadeOut: 0.5,
+			},
+		},
+	}
+	ctx := PreviewContext{
+		AssetType:    "jingle",
+		AssetKey:     "opening",
+		Assets:       assets,
+		OutPath:      "/out.mp3",
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	args, err := BuildPreviewFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(args.Inputs) < 1 || args.Inputs[0].Path != "/audio/opening.mp3" {
+		t.Errorf("expected input /audio/opening.mp3, got: %v", args.Inputs)
+	}
+
+	fc := args.FilterComplex
+	if !strings.Contains(fc, "silenceremove") {
+		t.Errorf("expected silenceremove in filter_complex (trim_silence defaults to true), got: %s", fc)
+	}
+	if !strings.Contains(fc, "afade=t=in") {
+		t.Errorf("expected afade=t=in in filter_complex, got: %s", fc)
+	}
+	if !strings.Contains(fc, "areverse") {
+		t.Errorf("expected areverse in filter_complex (fade_out), got: %s", fc)
+	}
+	if !strings.Contains(fc, "atrim=duration=") {
+		t.Errorf("expected atrim=duration= in filter_complex, got: %s", fc)
+	}
+	if strings.Contains(fc, "loudnorm") {
+		t.Errorf("filter_complex must not contain loudnorm, got: %s", fc)
+	}
+	if strings.Contains(fc, "alimiter") {
+		t.Errorf("filter_complex must not contain alimiter, got: %s", fc)
+	}
+
+	if args.OutputPath != "/out.mp3" {
+		t.Errorf("output path: got %s, want /out.mp3", args.OutputPath)
+	}
+	hasMP3Codec := false
+	for i, arg := range args.OutputArgs {
+		if arg == "-c:a" && i+1 < len(args.OutputArgs) && args.OutputArgs[i+1] == "libmp3lame" {
+			hasMP3Codec = true
+		}
+	}
+	if !hasMP3Codec {
+		t.Errorf("expected -c:a libmp3lame in output args, got: %v", args.OutputArgs)
+	}
+}
+
+func TestBuildPreviewFFmpegArgs_SE_ContainsExpectedFilters(t *testing.T) {
+	assets := config.AssetsConfig{
+		SE: map[string]config.SEEntry{
+			"chime": {
+				File:   "/audio/chime.wav",
+				Volume: 0.8,
+			},
+		},
+	}
+	ctx := PreviewContext{
+		AssetType:    "se",
+		AssetKey:     "chime",
+		Assets:       assets,
+		OutPath:      "/out.mp3",
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	args, err := BuildPreviewFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc := args.FilterComplex
+	if !strings.Contains(fc, "silenceremove") {
+		t.Errorf("expected silenceremove in filter_complex (trim_silence defaults to true), got: %s", fc)
+	}
+	if !strings.Contains(fc, "volume=0.80") {
+		t.Errorf("expected volume=0.80 in filter_complex, got: %s", fc)
+	}
+	if strings.Contains(fc, "loudnorm") {
+		t.Errorf("filter_complex must not contain loudnorm, got: %s", fc)
+	}
+}
+
+func TestBuildPreviewFFmpegArgs_BGM_ContainsExpectedFilters(t *testing.T) {
+	assets := config.AssetsConfig{
+		BGM: map[string]config.BGMEntry{
+			"talk": {
+				File:    "/audio/talk.mp3",
+				Volume:  0.3,
+				FadeIn:  floatPtr(1.0),
+				FadeOut: floatPtr(1.0),
+			},
+		},
+	}
+	ctx := PreviewContext{
+		AssetType:    "bgm",
+		AssetKey:     "talk",
+		Assets:       assets,
+		OutPath:      "/out.mp3",
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	args, err := BuildPreviewFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc := args.FilterComplex
+	if !strings.Contains(fc, "volume=0.30") {
+		t.Errorf("expected volume=0.30 in filter_complex, got: %s", fc)
+	}
+	if !strings.Contains(fc, "afade=t=in") {
+		t.Errorf("expected afade=t=in in filter_complex, got: %s", fc)
+	}
+	if !strings.Contains(fc, "areverse") {
+		t.Errorf("expected areverse in filter_complex (fade_out), got: %s", fc)
+	}
+	if !strings.Contains(fc, "atrim=duration=") {
+		t.Errorf("expected atrim=duration= in filter_complex, got: %s", fc)
+	}
+	if strings.Contains(fc, "loudnorm") {
+		t.Errorf("filter_complex must not contain loudnorm, got: %s", fc)
+	}
+}
+
+func TestBuildPreviewFFmpegArgs_BGM_LoopTrue_UsesStreamLoop(t *testing.T) {
+	assets := config.AssetsConfig{
+		BGM: map[string]config.BGMEntry{
+			"bgm": {
+				File:   "/audio/bgm.mp3",
+				Volume: 0.5,
+				Loop:   true,
+			},
+		},
+	}
+	ctx := PreviewContext{
+		AssetType:    "bgm",
+		AssetKey:     "bgm",
+		Assets:       assets,
+		OutPath:      "/out.mp3",
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	args, err := BuildPreviewFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !hasStreamLoop(args.Inputs, "/audio/bgm.mp3") {
+		t.Errorf("expected -stream_loop -1 for loop=true BGM, inputs: %v", args.Inputs)
+	}
+	if !strings.Contains(args.FilterComplex, "atrim=duration=") {
+		t.Errorf("expected atrim=duration= in filter_complex for loop BGM, got: %s", args.FilterComplex)
+	}
+}
+
+func TestBuildPreviewFFmpegArgs_BGM_DuckRatio_AddsSidechainCompress(t *testing.T) {
+	assets := config.AssetsConfig{
+		BGM: map[string]config.BGMEntry{
+			"bgm": {
+				File:      "/audio/bgm.mp3",
+				Volume:    0.5,
+				DuckRatio: 8.0,
+			},
+		},
+	}
+	ctx := PreviewContext{
+		AssetType:    "bgm",
+		AssetKey:     "bgm",
+		Assets:       assets,
+		OutPath:      "/out.mp3",
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	args, err := BuildPreviewFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	fc := args.FilterComplex
+	if !strings.Contains(fc, "sidechaincompress") {
+		t.Errorf("expected sidechaincompress in filter_complex for duck_ratio>0, got: %s", fc)
+	}
+	if !strings.Contains(fc, "ratio=8.0") {
+		t.Errorf("expected ratio=8.0 in sidechaincompress, got: %s", fc)
+	}
+	if !strings.Contains(fc, "threshold=0.02") {
+		t.Errorf("expected threshold=0.02 in sidechaincompress, got: %s", fc)
+	}
+	if !strings.Contains(fc, "sine") {
+		t.Errorf("expected sine in filter_complex for dummy narration, got: %s", fc)
+	}
+}
+
+func TestBuildPreviewFFmpegArgs_BGM_NoDuckRatio_NoSidechain(t *testing.T) {
+	assets := config.AssetsConfig{
+		BGM: map[string]config.BGMEntry{
+			"bgm": {
+				File:      "/audio/bgm.mp3",
+				Volume:    0.5,
+				DuckRatio: 0.0,
+			},
+		},
+	}
+	ctx := PreviewContext{
+		AssetType:    "bgm",
+		AssetKey:     "bgm",
+		Assets:       assets,
+		OutPath:      "/out.mp3",
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	args, err := BuildPreviewFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(args.FilterComplex, "sidechaincompress") {
+		t.Errorf("sidechaincompress must not be present when duck_ratio=0, got: %s", args.FilterComplex)
+	}
+}
+
+func TestBuildPreviewFFmpegArgs_DefaultMaxLengthSec_AppliesDefaultTrim(t *testing.T) {
+	assets := config.AssetsConfig{
+		SE: map[string]config.SEEntry{
+			"chime": {File: "/audio/chime.wav", Volume: 0.5},
+		},
+	}
+	ctx := PreviewContext{
+		AssetType:    "se",
+		AssetKey:     "chime",
+		Assets:       assets,
+		OutPath:      "/out.mp3",
+		MaxLengthSec: 0, // use default (30s)
+	}
+
+	args, err := BuildPreviewFFmpegArgs(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(args.FilterComplex, "atrim=duration=30.000") {
+		t.Errorf("expected atrim=duration=30.000 for default max length, got: %s", args.FilterComplex)
+	}
+}
+
+func TestBuildPreviewFFmpegArgs_UnknownType_ReturnsError(t *testing.T) {
+	ctx := PreviewContext{
+		AssetType:    "unknown",
+		AssetKey:     "foo",
+		Assets:       config.AssetsConfig{},
+		OutPath:      "/out.mp3",
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	_, err := BuildPreviewFFmpegArgs(ctx)
+	if err == nil {
+		t.Error("expected error for unknown asset type, got nil")
+	}
+}
+
+func TestBuildPreviewFFmpegArgs_UnknownKey_ReturnsError(t *testing.T) {
+	tests := []struct {
+		name      string
+		assetType string
+		assets    config.AssetsConfig
+	}{
+		{
+			name:      "jingle",
+			assetType: "jingle",
+			assets:    config.AssetsConfig{Jingle: map[string]config.JingleEntry{}},
+		},
+		{
+			name:      "se",
+			assetType: "se",
+			assets:    config.AssetsConfig{SE: map[string]config.SEEntry{}},
+		},
+		{
+			name:      "bgm",
+			assetType: "bgm",
+			assets:    config.AssetsConfig{BGM: map[string]config.BGMEntry{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := PreviewContext{
+				AssetType:    tt.assetType,
+				AssetKey:     "nonexistent",
+				Assets:       tt.assets,
+				OutPath:      "/out.mp3",
+				MaxLengthSec: testMaxLengthSec,
+			}
+			_, err := BuildPreviewFFmpegArgs(ctx)
+			if err == nil {
+				t.Errorf("expected error for unknown key in %s, got nil", tt.assetType)
+			}
+		})
+	}
+}
+
+func TestPreviewer_Run_InvokesFFmpegWithFilterComplex(t *testing.T) {
+	assets := config.AssetsConfig{
+		SE: map[string]config.SEEntry{
+			"chime": {File: "/audio/chime.wav", Volume: 0.8},
+		},
+	}
+
+	var capturedArgs []string
+	p := &Previewer{
+		runFFmpeg: func(_ context.Context, args []string, _ io.Writer) error {
+			capturedArgs = args
+			return nil
+		},
+	}
+
+	pctx := PreviewContext{
+		AssetType:    "se",
+		AssetKey:     "chime",
+		Assets:       assets,
+		OutPath:      "/out.mp3",
+		MaxLengthSec: testMaxLengthSec,
+	}
+
+	err := p.Run(context.Background(), pctx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	hasFilterComplex := false
+	for _, arg := range capturedArgs {
+		if arg == "-filter_complex" {
+			hasFilterComplex = true
+		}
+	}
+	if !hasFilterComplex {
+		t.Errorf("expected -filter_complex in ffmpeg args, got: %v", capturedArgs)
+	}
+
+	if len(capturedArgs) == 0 || capturedArgs[len(capturedArgs)-1] != "/out.mp3" {
+		t.Errorf("expected /out.mp3 as last ffmpeg arg, got: %v", capturedArgs)
+	}
+}

--- a/internal/assemble/preview_test.go
+++ b/internal/assemble/preview_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/config"
 )
 
-func floatPtr(v float64) *float64 { return &v }
-
 const testMaxLengthSec = 10.0
 
 func TestBuildPreviewFFmpegArgs_Jingle_ContainsExpectedFilters(t *testing.T) {
@@ -114,8 +112,8 @@ func TestBuildPreviewFFmpegArgs_BGM_ContainsExpectedFilters(t *testing.T) {
 			"talk": {
 				File:    "/audio/talk.mp3",
 				Volume:  0.3,
-				FadeIn:  floatPtr(1.0),
-				FadeOut: floatPtr(1.0),
+				FadeIn:  float64Ptr(1.0),
+				FadeOut: float64Ptr(1.0),
 			},
 		},
 	}

--- a/internal/cli/assets.go
+++ b/internal/cli/assets.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
+	"github.com/canpok1/vox-radio/internal/assemble"
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -14,9 +17,11 @@ func newAssetsCmd() *cobra.Command {
 		Long: `アセット設定ファイル（assets.yaml）の管理操作を提供します。
 
 サブコマンド:
-  check  アセット設定ファイルを strict モードで検証する`,
+  check    アセット設定ファイルを strict モードで検証する
+  preview  素材ID単体にパラメータを適用した音声をプレビュー生成する`,
 	}
 	cmd.AddCommand(newAssetsCheckCmd())
+	cmd.AddCommand(newAssetsPreviewCmd())
 	return cmd
 }
 
@@ -49,4 +54,56 @@ func newAssetsCheckCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newAssetsPreviewCmd() *cobra.Command {
+	var id string
+	var outPath string
+	var maxLengthSec float64
+
+	cmd := &cobra.Command{
+		Use:   "preview <path>",
+		Short: "素材ID単体にパラメータを適用した音声をプレビュー生成する",
+		Long: `指定した assets.yaml から素材IDを検索し、パラメータを適用したプレビュー音声を MP3 で生成します。
+
+loudnorm/alimiter は適用されないため、各パラメータの素の効果を確認できます。
+
+例:
+  vox-radio assets preview assets.yaml --id jingle:opening --out preview.mp3
+  vox-radio assets preview assets.yaml --id bgm:talk --out preview.mp3 --max-length-sec 15`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			assetsPath := args[0]
+
+			parts := strings.SplitN(id, ":", 2)
+			if len(parts) != 2 {
+				return fmt.Errorf("--id must be in the format type:key (e.g. jingle:opening), got %q", id)
+			}
+			assetType, assetKey := parts[0], parts[1]
+
+			assets, err := config.LoadAssetsFileStrict(assetsPath)
+			if err != nil {
+				return err
+			}
+
+			pctx := assemble.PreviewContext{
+				AssetType:    assetType,
+				AssetKey:     assetKey,
+				Assets:       assets,
+				OutPath:      outPath,
+				MaxLengthSec: maxLengthSec,
+			}
+
+			p := assemble.NewPreviewer()
+			return p.Run(context.Background(), pctx, cmd.ErrOrStderr())
+		},
+	}
+
+	cmd.Flags().StringVar(&id, "id", "", "{type}:{key} 形式の素材ID（type: jingle/se/bgm）（必須）")
+	cmd.Flags().StringVar(&outPath, "out", "", "MP3 出力先パス（必須）")
+	cmd.Flags().Float64Var(&maxLengthSec, "max-length-sec", 30, "プレビュー出力の最大長（秒）。出力がこれより長い場合に末尾を打ち切る")
+	_ = cmd.MarkFlagRequired("id")
+	_ = cmd.MarkFlagRequired("out")
+
+	return cmd
 }

--- a/internal/cli/assets_test.go
+++ b/internal/cli/assets_test.go
@@ -149,3 +149,89 @@ func TestAssetsCheck_MissingArg_Error(t *testing.T) {
 		t.Error("expected error when PATH argument is missing")
 	}
 }
+
+func TestAssetsHelp_ListsPreviewSubcommand(t *testing.T) {
+	cmd := cli.NewRootCmd()
+	buf := &bytes.Buffer{}
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"assets", "--help"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "\n  preview ") {
+		t.Errorf("assets help should list preview subcommand, got:\n%s", out)
+	}
+	if !strings.Contains(out, "\n  check ") {
+		t.Errorf("assets help should list check subcommand, got:\n%s", out)
+	}
+}
+
+func TestAssetsPreview_MissingIDFlag_Error(t *testing.T) {
+	assetsPath := buildValidAssetsYAML(t)
+	dir := filepath.Dir(assetsPath)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"assets", "preview", assetsPath, "--out", filepath.Join(dir, "out.mp3")})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when --id is missing")
+	}
+}
+
+func TestAssetsPreview_MissingOutFlag_Error(t *testing.T) {
+	assetsPath := buildValidAssetsYAML(t)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"assets", "preview", assetsPath, "--id", "bgm:talk"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when --out is missing")
+	}
+}
+
+func TestAssetsPreview_MissingPathArg_Error(t *testing.T) {
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"assets", "preview", "--id", "bgm:talk", "--out", "/tmp/out.mp3"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error when assets.yaml path argument is missing")
+	}
+}
+
+func TestAssetsPreview_InvalidIDFormat_Error(t *testing.T) {
+	assetsPath := buildValidAssetsYAML(t)
+	dir := filepath.Dir(assetsPath)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"assets", "preview", assetsPath, "--id", "invalidformat", "--out", filepath.Join(dir, "out.mp3")})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for --id without colon separator")
+	}
+}
+
+func TestAssetsPreview_InvalidType_Error(t *testing.T) {
+	assetsPath := buildValidAssetsYAML(t)
+	dir := filepath.Dir(assetsPath)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"assets", "preview", assetsPath, "--id", "badtype:opening", "--out", filepath.Join(dir, "out.mp3")})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for unknown asset type in --id")
+	}
+}
+
+func TestAssetsPreview_KeyNotFound_Error(t *testing.T) {
+	assetsPath := buildValidAssetsYAML(t)
+	dir := filepath.Dir(assetsPath)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"assets", "preview", assetsPath, "--id", "jingle:nonexistent", "--out", filepath.Join(dir, "out.mp3")})
+	err := cmd.Execute()
+	if err == nil {
+		t.Error("expected error for nonexistent key in assets.yaml")
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/assemble/preview.go`: `BuildPreviewFFmpegArgs` / `Previewer` を新規実装。`filter.go` の既存ヘルパー（`applySilenceTrim` / `applyFadeIn` / `applyFadeOut`）を再利用
- type 別パラメータ適用: jingle（trim_silence/fade_in/fade_out）、SE（trim_silence/volume）、BGM（volume/fade_in/fade_out/loop）
- BGM `duck_ratio > 0` の場合は ffmpeg `sine` による断続音ダミーナレーションを生成し、`sidechaincompress` でダッキング効果を確認できるようにした
- `--max-length-sec`（デフォルト 30s）で全 type 共通の出力長上限を設定。BGM `loop=true` は指定長までループ
- `loudnorm` / `alimiter` は適用しない（素のパラメータ効果を確認するため）
- `internal/cli/assets.go`: `newAssetsPreviewCmd()` を追加（`--id {type}:{key}` / `--out` / `--max-length-sec`）
- `docs/cli/` 再生成・README CLI セクション更新

Closes #261

---
🤖 Generated with [Claude Code](https://claude.ai/code)