### PR TITLE
feat: コーナー境界音声を start_audio/end_audio（type: jingle|se + id）へ再構成し SE の確定配置に対応する

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,11 +322,11 @@ vox-radio episodegen assemble --in work/intermediate/04_script.json --clips work
 | `length_sec` | int | 任意 | このコーナーの目標収録時間（秒）。台本生成時に文字数（≈7文字/秒）へ換算される |
 | `summary_length` | int | 任意 | コーナーサマリーの目安文字数。未指定時はデフォルト 100 文字 |
 | `source` | SourceConfig | 任意 | データソース（省略するとこのコーナーの収集はスキップ） |
-| `start_jingle` | string | 任意 | コーナー開始ジングルのキー名（`assets.jingle` のキーと一致させること）。コーナー本編の前に確定的に挿入される |
-| `end_jingle` | string | 任意 | コーナー終了ジングルのキー名（`assets.jingle` のキーと一致させること）。コーナー本編の後に確定的に挿入される |
+| `start_audio` | AudioRef | 任意 | コーナー開始境界音声。`type` に `jingle`（BGM停止後再生）または `se`（BGMの下で再生）を指定し、`id` に `assets` の該当マップのキーを指定する。コーナー本編の前に確定的に挿入される |
+| `end_audio` | AudioRef | 任意 | コーナー終了境界音声。`type`/`id` は `start_audio` と同様。コーナー本編の後に確定的に挿入される |
 | `bgm` | string | 任意 | コーナー中 BGM のキー名（`assets.bgm` のキーと一致させること）。コーナー本編を開始/停止セグメントで挟む |
-| `start_pause_sec` | float64 | 任意 | コーナー先頭（`start_jingle` より前）に挿入する無音時間（秒）。0 または省略時は挿入しない |
-| `end_pause_sec` | float64 | 任意 | コーナー末尾（`end_jingle` より後）に挿入する無音時間（秒）。0 または省略時は挿入しない |
+| `start_pause_sec` | float64 | 任意 | コーナー先頭（`start_audio` より前）に挿入する無音時間（秒）。0 または省略時は挿入しない |
+| `end_pause_sec` | float64 | 任意 | コーナー末尾（`end_audio` より後）に挿入する無音時間（秒）。0 または省略時は挿入しない |
 | `condition` | EpisodeCondition | 任意 | コーナーの出現条件（省略すると毎回必ず出る固定コーナー） |
 
 ##### `corners[].condition` サブフィールド
@@ -500,7 +500,7 @@ assets_files:
 | `trim_silence_threshold` | float64 | 任意 | 無音判定の振幅閾値（dB、負値のみ）。デフォルト: -50。素材のノイズフロアに合わせて調整 |
 | `description` | string | 任意 | アセットの説明（「何の音か・いつ使うか」）。LLM が挿入タイミングを判断する際の手がかりになる |
 
-ジングルはコーナー毎に `corners[].start_jingle` / `corners[].end_jingle` で設定します。script 生成ステップでコードがコーナー本編の前後へ確定的に挿入するため、生成された `04_script.json` にジングルセグメントが含まれます。BGM も `corners[].bgm` で同様にコーナー単位で管理します。
+ジングルおよびコーナー境界 SE はコーナー毎に `corners[].start_audio` / `corners[].end_audio`（`type: jingle` または `type: se`）で設定します。script 生成ステップでコードがコーナー本編の前後へ確定的に挿入するため、生成された `04_script.json` にジングル/SEセグメントが含まれます。`type: jingle` は BGM を停止してから再生し、`type: se` は BGM を継続したまま BGM の下で再生します。BGM も `corners[].bgm` で同様にコーナー単位で管理します。
 
 ##### アセット設定ファイル: `se` マップ値
 

--- a/docs/cli/vox-radio_episodegen_check.md
+++ b/docs/cli/vox-radio_episodegen_check.md
@@ -7,7 +7,7 @@
 指定したエピソード仕様ファイルを strict モードでパースし、以下を検証します:
 
   (a) strict パース: 未知キー（typo）をエラー化
-  (b) アセット参照: corners[].start_jingle / end_jingle / bgm が assets に存在するか
+  (b) アセット参照: corners[].start_audio / end_audio の type+id と bgm が assets に存在するか
   (c) corners[].cast のキーが casts に宣言済みであるか
   (d) casts のキャラ ID が共通設定ファイルの characters に存在するか、type/condition が正しいか
 

--- a/examples/tech.yaml
+++ b/examples/tech.yaml
@@ -55,7 +55,9 @@ corners:
       zundamon: "MC。元気に挨拶する進行役。ボケ担当。"
       metan: "MC。ずんだもんの相棒。ツッコミ担当。"
     length_sec: 30
-    start_jingle: opening  # コーナー開始ジングル
+    start_audio:           # コーナー開始境界音声
+      type: jingle         # jingle（BGM停止後再生）または se（BGMの下で再生）
+      id: opening          # assets の jingle マップのキー
   - title: "今日のテックニュース"
     content: "テック記事を2〜3本、漫才風に噛み砕いて紹介"
     cast:

--- a/internal/assemble/assemble_test.go
+++ b/internal/assemble/assemble_test.go
@@ -273,11 +273,11 @@ func TestAssembler_Run_RealYAMLKeys(t *testing.T) {
 	// Collect opening/ending jingle keys from corners (replacing program-level config).
 	var openingKey, endingKey string
 	for _, corner := range spec.Corners {
-		if openingKey == "" && corner.StartJingle != "" {
-			openingKey = corner.StartJingle
+		if openingKey == "" && corner.StartAudio != nil && corner.StartAudio.Type == "jingle" {
+			openingKey = corner.StartAudio.ID
 		}
-		if endingKey == "" && corner.EndJingle != "" {
-			endingKey = corner.EndJingle
+		if endingKey == "" && corner.EndAudio != nil && corner.EndAudio.Type == "jingle" {
+			endingKey = corner.EndAudio.ID
 		}
 	}
 	if openingKey == "" || endingKey == "" {

--- a/internal/cli/episodegen_check.go
+++ b/internal/cli/episodegen_check.go
@@ -14,7 +14,7 @@ func newEpisodegenCheckCmd() *cobra.Command {
 		Long: `指定したエピソード仕様ファイルを strict モードでパースし、以下を検証します:
 
   (a) strict パース: 未知キー（typo）をエラー化
-  (b) アセット参照: corners[].start_jingle / end_jingle / bgm が assets に存在するか
+  (b) アセット参照: corners[].start_audio / end_audio の type+id と bgm が assets に存在するか
   (c) corners[].cast のキーが casts に宣言済みであるか
   (d) casts のキャラ ID が共通設定ファイルの characters に存在するか、type/condition が正しいか
 

--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -55,8 +55,10 @@ corners:
     length_sec: 30
     # コーナーサマリーの目安文字数（任意。未指定時はデフォルト 100 文字）
     # summary_length: 100
-    # コーナー開始ジングル（assets.jingle のキー名。不要な場合は行ごと削除）
-    # start_jingle: opening
+    # コーナー境界音声（不要な場合は行ごと削除）
+    # start_audio:
+    #   type: jingle   # jingle（BGM停止後再生）または se（BGMの下で再生）
+    #   id: opening    # assets の該当マップのキー
     # コーナー開始前の無音時間（秒）。0 または省略時は挿入しない。
     # start_pause_sec: 1.0
     # コーナー終了後の無音時間（秒）。0 または省略時は挿入しない。
@@ -104,8 +106,10 @@ corners:
     length_sec: 30
     # コーナーサマリーの目安文字数（任意。未指定時はデフォルト 100 文字）
     # summary_length: 100
-    # コーナー終了ジングル（assets.jingle のキー名。不要な場合は行ごと削除）
-    # end_jingle: ending
+    # コーナー終了境界音声（不要な場合は行ごと削除）
+    # end_audio:
+    #   type: jingle   # jingle または se
+    #   id: ending     # assets の該当マップのキー
 
 # アセット設定ファイルの参照（ジングル・SE・BGM）
 # バイナリ素材ファイルは別途用意してください。

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -256,6 +256,12 @@ type SourceConfig struct {
 	Articles []string    `yaml:"articles"`
 }
 
+// AudioRef references a jingle or SE asset by type and asset ID.
+type AudioRef struct {
+	Type string `yaml:"type"` // "jingle" or "se"
+	ID   string `yaml:"id"`
+}
+
 // CornerConfig defines a fixed corner in the program structure.
 type CornerConfig struct {
 	Title         string            `yaml:"title"`
@@ -265,8 +271,8 @@ type CornerConfig struct {
 	LengthSec     int               `yaml:"length_sec"`
 	SummaryLength int               `yaml:"summary_length,omitempty"`
 	Source        *SourceConfig     `yaml:"source,omitempty"`
-	StartJingle   string            `yaml:"start_jingle,omitempty"`
-	EndJingle     string            `yaml:"end_jingle,omitempty"`
+	StartAudio    *AudioRef         `yaml:"start_audio,omitempty"`
+	EndAudio      *AudioRef         `yaml:"end_audio,omitempty"`
 	BGM           string            `yaml:"bgm,omitempty"`
 	StartPauseSec float64           `yaml:"start_pause_sec,omitempty"`
 	EndPauseSec   float64           `yaml:"end_pause_sec,omitempty"`
@@ -766,17 +772,17 @@ func ValidateEpisodeSpecCast(p *EpisodeSpec) error {
 	return nil
 }
 
-// ValidateEpisodeSpecAssets checks that corner-level jingle/bgm keys reference existing assets.
+// ValidateEpisodeSpecAssets checks that corner-level audio/bgm keys reference existing assets.
 func ValidateEpisodeSpecAssets(p *EpisodeSpec) error {
 	for _, corner := range p.Corners {
-		if corner.StartJingle != "" {
-			if _, ok := p.Assets.Jingle[corner.StartJingle]; !ok {
-				return fmt.Errorf("corners[%q].start_jingle: unknown jingle key %q", corner.Title, corner.StartJingle)
+		if corner.StartAudio != nil {
+			if err := validateAudioRef(corner.Title, "start_audio", corner.StartAudio, &p.Assets); err != nil {
+				return err
 			}
 		}
-		if corner.EndJingle != "" {
-			if _, ok := p.Assets.Jingle[corner.EndJingle]; !ok {
-				return fmt.Errorf("corners[%q].end_jingle: unknown jingle key %q", corner.Title, corner.EndJingle)
+		if corner.EndAudio != nil {
+			if err := validateAudioRef(corner.Title, "end_audio", corner.EndAudio, &p.Assets); err != nil {
+				return err
 			}
 		}
 		if corner.BGM != "" {
@@ -784,6 +790,22 @@ func ValidateEpisodeSpecAssets(p *EpisodeSpec) error {
 				return fmt.Errorf("corners[%q].bgm: unknown bgm key %q", corner.Title, corner.BGM)
 			}
 		}
+	}
+	return nil
+}
+
+func validateAudioRef(cornerTitle, field string, ref *AudioRef, assets *AssetsConfig) error {
+	switch ref.Type {
+	case "jingle":
+		if _, ok := assets.Jingle[ref.ID]; !ok {
+			return fmt.Errorf("corners[%q].%s: unknown jingle key %q", cornerTitle, field, ref.ID)
+		}
+	case "se":
+		if _, ok := assets.SE[ref.ID]; !ok {
+			return fmt.Errorf("corners[%q].%s: unknown se key %q", cornerTitle, field, ref.ID)
+		}
+	default:
+		return fmt.Errorf("corners[%q].%s: unknown type %q (must be jingle or se)", cornerTitle, field, ref.Type)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -77,22 +77,7 @@ func TestLoadEpisodeSpec(t *testing.T) {
 	})
 
 	t.Run("CornerAssets", func(t *testing.T) {
-		if len(spec.Corners) == 0 {
-			t.Fatal("Corners must not be empty")
-		}
-		corner0 := spec.Corners[0]
-		if corner0.StartJingle == "" {
-			t.Error("Corners[0].StartJingle must not be empty")
-		}
-		if len(spec.Corners) > 1 {
-			corner1 := spec.Corners[1]
-			if corner1.EndJingle == "" {
-				t.Error("Corners[1].EndJingle must not be empty")
-			}
-			if corner1.BGM == "" {
-				t.Error("Corners[1].BGM must not be empty")
-			}
-		}
+		checkCornerAssets(t, spec)
 	})
 
 	t.Run("Corners", func(t *testing.T) {
@@ -207,83 +192,154 @@ func TestLoadEpisodeSpec_MissingFile(t *testing.T) {
 	}
 }
 
-func TestValidateEpisodeSpecAssets_Valid(t *testing.T) {
-	p := &config.EpisodeSpec{
-		Corners: []config.CornerConfig{
-			{Title: "C1", StartJingle: "opening", EndJingle: "ending", BGM: "talk_bgm"},
-		},
-		Assets: config.AssetsConfig{
-			Jingle: map[string]config.JingleEntry{
-				"opening": {File: "opening.mp3"},
-				"ending":  {File: "ending.mp3"},
+func checkCornerAssets(t *testing.T, spec *config.EpisodeSpec) {
+	t.Helper()
+	if len(spec.Corners) == 0 {
+		t.Fatal("Corners must not be empty")
+	}
+	corner0 := spec.Corners[0]
+	if corner0.StartAudio == nil {
+		t.Error("Corners[0].StartAudio must not be nil")
+	} else {
+		if corner0.StartAudio.Type != "jingle" {
+			t.Errorf("Corners[0].StartAudio.Type: got %q, want jingle", corner0.StartAudio.Type)
+		}
+		if corner0.StartAudio.ID != "opening" {
+			t.Errorf("Corners[0].StartAudio.ID: got %q, want opening", corner0.StartAudio.ID)
+		}
+	}
+	if len(spec.Corners) <= 1 {
+		return
+	}
+	corner1 := spec.Corners[1]
+	if corner1.EndAudio == nil {
+		t.Error("Corners[1].EndAudio must not be nil")
+	} else {
+		if corner1.EndAudio.Type != "jingle" {
+			t.Errorf("Corners[1].EndAudio.Type: got %q, want jingle", corner1.EndAudio.Type)
+		}
+		if corner1.EndAudio.ID != "ending" {
+			t.Errorf("Corners[1].EndAudio.ID: got %q, want ending", corner1.EndAudio.ID)
+		}
+	}
+	if corner1.BGM == "" {
+		t.Error("Corners[1].BGM must not be empty")
+	}
+}
+
+func TestValidateEpisodeSpecAssets(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *config.EpisodeSpec
+		wantErr bool
+	}{
+		{
+			name: "valid start_audio jingle",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{
+					{Title: "C1", StartAudio: &config.AudioRef{Type: "jingle", ID: "opening"}, BGM: "talk_bgm"},
+				},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{"opening": {File: "opening.mp3"}},
+					BGM:    map[string]config.BGMEntry{"talk_bgm": {File: "bgm.mp3"}},
+				},
 			},
-			BGM: map[string]config.BGMEntry{
-				"talk_bgm": {File: "bgm.mp3"},
+		},
+		{
+			name: "valid end_audio se",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{
+					{Title: "C1", EndAudio: &config.AudioRef{Type: "se", ID: "chime"}},
+				},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{},
+					SE:     map[string]config.SEEntry{"chime": {File: "chime.wav"}},
+					BGM:    map[string]config.BGMEntry{},
+				},
 			},
 		},
-	}
-	if err := config.ValidateEpisodeSpecAssets(p); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-}
-
-func TestValidateEpisodeSpecAssets_UnknownStartJingle(t *testing.T) {
-	p := &config.EpisodeSpec{
-		Corners: []config.CornerConfig{
-			{Title: "C1", StartJingle: "nonexistent"},
+		{
+			name: "empty fields",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{Title: "C1"}},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{},
+					BGM:    map[string]config.BGMEntry{},
+				},
+			},
 		},
-		Assets: config.AssetsConfig{
-			Jingle: map[string]config.JingleEntry{},
-			BGM:    map[string]config.BGMEntry{},
+		{
+			name: "start_audio unknown jingle id",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{
+					{Title: "C1", StartAudio: &config.AudioRef{Type: "jingle", ID: "nonexistent"}},
+				},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{},
+					BGM:    map[string]config.BGMEntry{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "end_audio unknown jingle id",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{
+					{Title: "C1", EndAudio: &config.AudioRef{Type: "jingle", ID: "nonexistent"}},
+				},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{},
+					BGM:    map[string]config.BGMEntry{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "start_audio unknown se id",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{
+					{Title: "C1", StartAudio: &config.AudioRef{Type: "se", ID: "nonexistent"}},
+				},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{},
+					SE:     map[string]config.SEEntry{},
+					BGM:    map[string]config.BGMEntry{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "start_audio invalid type",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{
+					{Title: "C1", StartAudio: &config.AudioRef{Type: "bgm", ID: "something"}},
+				},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{},
+					BGM:    map[string]config.BGMEntry{},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown bgm",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{Title: "C1", BGM: "nonexistent"}},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{},
+					BGM:    map[string]config.BGMEntry{},
+				},
+			},
+			wantErr: true,
 		},
 	}
-	if err := config.ValidateEpisodeSpecAssets(p); err == nil {
-		t.Error("expected error for unknown start_jingle key")
-	}
-}
-
-func TestValidateEpisodeSpecAssets_UnknownEndJingle(t *testing.T) {
-	p := &config.EpisodeSpec{
-		Corners: []config.CornerConfig{
-			{Title: "C1", EndJingle: "nonexistent"},
-		},
-		Assets: config.AssetsConfig{
-			Jingle: map[string]config.JingleEntry{},
-			BGM:    map[string]config.BGMEntry{},
-		},
-	}
-	if err := config.ValidateEpisodeSpecAssets(p); err == nil {
-		t.Error("expected error for unknown end_jingle key")
-	}
-}
-
-func TestValidateEpisodeSpecAssets_UnknownBGM(t *testing.T) {
-	p := &config.EpisodeSpec{
-		Corners: []config.CornerConfig{
-			{Title: "C1", BGM: "nonexistent"},
-		},
-		Assets: config.AssetsConfig{
-			Jingle: map[string]config.JingleEntry{},
-			BGM:    map[string]config.BGMEntry{},
-		},
-	}
-	if err := config.ValidateEpisodeSpecAssets(p); err == nil {
-		t.Error("expected error for unknown bgm key")
-	}
-}
-
-func TestValidateEpisodeSpecAssets_EmptyFields_NoError(t *testing.T) {
-	p := &config.EpisodeSpec{
-		Corners: []config.CornerConfig{
-			{Title: "C1"},
-		},
-		Assets: config.AssetsConfig{
-			Jingle: map[string]config.JingleEntry{},
-			BGM:    map[string]config.BGMEntry{},
-		},
-	}
-	if err := config.ValidateEpisodeSpecAssets(p); err != nil {
-		t.Errorf("unexpected error for empty fields: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := config.ValidateEpisodeSpecAssets(tt.spec)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateEpisodeSpecAssets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/config/testdata/episode_spec.yaml
+++ b/internal/config/testdata/episode_spec.yaml
@@ -14,13 +14,17 @@ corners:
     cast:
       zundamon: "元気に挨拶する進行役"
     length_sec: 45
-    start_jingle: opening
+    start_audio:
+      type: jingle
+      id: opening
   - title: "ニュースコーナー"
     content: "テック記事を紹介"
     cast:
       zundamon: "司会"
     length_sec: 30
-    end_jingle: ending
+    end_audio:
+      type: jingle
+      id: ending
     bgm: talk_bgm
     source:
       feeds:

--- a/internal/model/line.go
+++ b/internal/model/line.go
@@ -14,18 +14,24 @@ type Lines struct {
 	Lines []Line `json:"lines"`
 }
 
+// CornerAudio holds a boundary audio reference for a corner (jingle or SE).
+type CornerAudio struct {
+	Type      SegmentType `json:"type"`
+	AssetName string      `json:"asset_name"`
+}
+
 // CornerLines holds the lines and direction for one corner.
-// Asset fields (StartJingle, EndJingle, BGM) and pause fields (StartPauseSec, EndPauseSec)
+// Asset fields (StartAudio, EndAudio, BGM) and pause fields (StartPauseSec, EndPauseSec)
 // are transferred from CornerConfig and persisted in 03_lines.json for deterministic segment injection.
 type CornerLines struct {
-	Title         string  `json:"title"`
-	Direction     string  `json:"direction,omitempty"`
-	Lines         []Line  `json:"lines"`
-	StartJingle   string  `json:"start_jingle,omitempty"`
-	EndJingle     string  `json:"end_jingle,omitempty"`
-	BGM           string  `json:"bgm,omitempty"`
-	StartPauseSec float64 `json:"start_pause_sec,omitempty"`
-	EndPauseSec   float64 `json:"end_pause_sec,omitempty"`
+	Title         string       `json:"title"`
+	Direction     string       `json:"direction,omitempty"`
+	Lines         []Line       `json:"lines"`
+	StartAudio    *CornerAudio `json:"start_audio,omitempty"`
+	EndAudio      *CornerAudio `json:"end_audio,omitempty"`
+	BGM           string       `json:"bgm,omitempty"`
+	StartPauseSec float64      `json:"start_pause_sec,omitempty"`
+	EndPauseSec   float64      `json:"end_pause_sec,omitempty"`
 }
 
 // ScriptLines is the root structure of 03_lines.json.

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -614,13 +614,13 @@ func TestManifest_ConversationNotesEmptyArrayNotNull(t *testing.T) {
 	}
 }
 
-func TestCornerLines_AssetFields_MarshaledAndUnmarshaled(t *testing.T) {
+func TestCornerLines_AudioFields_MarshaledAndUnmarshaled(t *testing.T) {
 	cl := model.CornerLines{
-		Title:       "C1",
-		StartJingle: "opening",
-		EndJingle:   "ending",
-		BGM:         "talk_bgm",
-		Lines:       []model.Line{{SpeakerRole: "host", Text: "hello"}},
+		Title:      "C1",
+		StartAudio: &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "opening"},
+		EndAudio:   &model.CornerAudio{Type: model.SegmentTypeSE, AssetName: "chime"},
+		BGM:        "talk_bgm",
+		Lines:      []model.Line{{SpeakerRole: "host", Text: "hello"}},
 	}
 	data, err := json.Marshal(cl)
 	if err != nil {
@@ -630,11 +630,23 @@ func TestCornerLines_AssetFields_MarshaledAndUnmarshaled(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal error: %v", err)
 	}
-	if got.StartJingle != "opening" {
-		t.Errorf("StartJingle: got %q, want opening", got.StartJingle)
+	if got.StartAudio == nil {
+		t.Fatal("StartAudio: got nil, want non-nil")
 	}
-	if got.EndJingle != "ending" {
-		t.Errorf("EndJingle: got %q, want ending", got.EndJingle)
+	if got.StartAudio.Type != model.SegmentTypeJingle {
+		t.Errorf("StartAudio.Type: got %q, want jingle", got.StartAudio.Type)
+	}
+	if got.StartAudio.AssetName != "opening" {
+		t.Errorf("StartAudio.AssetName: got %q, want opening", got.StartAudio.AssetName)
+	}
+	if got.EndAudio == nil {
+		t.Fatal("EndAudio: got nil, want non-nil")
+	}
+	if got.EndAudio.Type != model.SegmentTypeSE {
+		t.Errorf("EndAudio.Type: got %q, want se", got.EndAudio.Type)
+	}
+	if got.EndAudio.AssetName != "chime" {
+		t.Errorf("EndAudio.AssetName: got %q, want chime", got.EndAudio.AssetName)
 	}
 	if got.BGM != "talk_bgm" {
 		t.Errorf("BGM: got %q, want talk_bgm", got.BGM)
@@ -692,7 +704,7 @@ func TestCornerLines_EmptyAssetFields_OmittedFromJSON(t *testing.T) {
 		t.Fatalf("marshal error: %v", err)
 	}
 	jsonStr := string(data)
-	for _, field := range []string{`"start_jingle"`, `"end_jingle"`, `"bgm"`} {
+	for _, field := range []string{`"start_audio"`, `"end_audio"`, `"bgm"`} {
 		if strings.Contains(jsonStr, field) {
 			t.Errorf("field %q should be omitted when empty, got: %s", field, jsonStr)
 		}

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -61,7 +61,7 @@ var insertionsSchema = json.RawMessage(`{
 }`)
 
 // cornerLLMPayload is the subset of CornerLines sent to the LLM.
-// Asset fields (StartJingle, EndJingle, BGM) are excluded because
+// Asset fields (StartAudio, EndAudio, BGM) are excluded because
 // they are injected deterministically and must not influence SE/pause placement.
 type cornerLLMPayload struct {
 	Title     string       `json:"title"`
@@ -187,13 +187,7 @@ func buildScript(corners []model.CornerLines, insertions []insertion, pauseInser
 			})
 		}
 
-		if corner.StartJingle != "" {
-			segments = append(segments, model.ScriptSegment{
-				Type:      model.SegmentTypeJingle,
-				AssetName: corner.StartJingle,
-			})
-			activeBGM = ""
-		}
+		segments = appendBoundaryAudio(segments, corner.StartAudio, corner.BGM, &activeBGM)
 
 		if corner.BGM != activeBGM {
 			segments = append(segments, model.ScriptSegment{
@@ -232,13 +226,7 @@ func buildScript(corners []model.CornerLines, insertions []insertion, pauseInser
 			}
 		}
 
-		if corner.EndJingle != "" {
-			segments = append(segments, model.ScriptSegment{
-				Type:      model.SegmentTypeJingle,
-				AssetName: corner.EndJingle,
-			})
-			activeBGM = ""
-		}
+		segments = appendBoundaryAudio(segments, corner.EndAudio, "", &activeBGM)
 
 		if corner.EndPauseSec > 0 {
 			segments = append(segments, model.ScriptSegment{
@@ -249,4 +237,35 @@ func buildScript(corners []model.CornerLines, insertions []insertion, pauseInser
 	}
 
 	return model.Script{Segments: segments}
+}
+
+// appendBoundaryAudio emits segments for a corner boundary audio (start or end).
+// For type:jingle, emits a jingle segment and resets activeBGM.
+// For type:se, pre-emits BGM (if cornerBGM is non-empty and differs from activeBGM) then emits SE without resetting activeBGM.
+// Pass cornerBGM="" for end boundaries where BGM pre-emit is not desired.
+func appendBoundaryAudio(segments []model.ScriptSegment, audio *model.CornerAudio, cornerBGM string, activeBGM *string) []model.ScriptSegment {
+	if audio == nil {
+		return segments
+	}
+	switch audio.Type {
+	case model.SegmentTypeJingle:
+		segments = append(segments, model.ScriptSegment{
+			Type:      model.SegmentTypeJingle,
+			AssetName: audio.AssetName,
+		})
+		*activeBGM = ""
+	case model.SegmentTypeSE:
+		if cornerBGM != "" && cornerBGM != *activeBGM {
+			segments = append(segments, model.ScriptSegment{
+				Type:      model.SegmentTypeBGM,
+				AssetName: cornerBGM,
+			})
+			*activeBGM = cornerBGM
+		}
+		segments = append(segments, model.ScriptSegment{
+			Type:      model.SegmentTypeSE,
+			AssetName: audio.AssetName,
+		})
+	}
+	return segments
 }

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -145,16 +145,16 @@ func TestLLMDirector_Direct_CornerBGMWrapsContent(t *testing.T) {
 	}
 }
 
-func TestLLMDirector_Direct_CornerStartJinglePrependedFirst(t *testing.T) {
+func TestLLMDirector_Direct_StartAudio_Jingle_PrependedFirst(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"insertions":[]}`),
 	}
 	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
 	corners := []model.CornerLines{{
-		Title:       "C1",
-		StartJingle: "opening",
-		Lines:       []model.Line{{SpeakerRole: "host", Text: "話す"}},
+		Title:      "C1",
+		StartAudio: &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "opening"},
+		Lines:      []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
 	got, err := d.Direct(context.Background(), corners, emptyCatalog())
@@ -170,16 +170,16 @@ func TestLLMDirector_Direct_CornerStartJinglePrependedFirst(t *testing.T) {
 	}
 }
 
-func TestLLMDirector_Direct_CornerEndJingleAppendedLast(t *testing.T) {
+func TestLLMDirector_Direct_EndAudio_Jingle_AppendedLast(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"insertions":[]}`),
 	}
 	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
 	corners := []model.CornerLines{{
-		Title:     "C1",
-		EndJingle: "ending",
-		Lines:     []model.Line{{SpeakerRole: "host", Text: "話す"}},
+		Title:    "C1",
+		EndAudio: &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "ending"},
+		Lines:    []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
 	got, err := d.Direct(context.Background(), corners, emptyCatalog())
@@ -195,18 +195,18 @@ func TestLLMDirector_Direct_CornerEndJingleAppendedLast(t *testing.T) {
 	}
 }
 
-func TestLLMDirector_Direct_CornerAllAssets_CorrectOrder(t *testing.T) {
+func TestLLMDirector_Direct_CornerAllAssets_Jingle_CorrectOrder(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"insertions":[]}`),
 	}
 	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
 	corners := []model.CornerLines{{
-		Title:       "C1",
-		StartJingle: "op",
-		BGM:         "bgm1",
-		EndJingle:   "ed",
-		Lines:       []model.Line{{SpeakerRole: "host", Text: "話す"}},
+		Title:      "C1",
+		StartAudio: &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "op"},
+		BGM:        "bgm1",
+		EndAudio:   &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "ed"},
+		Lines:      []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
 	got, err := d.Direct(context.Background(), corners, emptyCatalog())
@@ -228,6 +228,96 @@ func TestLLMDirector_Direct_CornerAllAssets_CorrectOrder(t *testing.T) {
 	}
 	if got.Segments[3].Type != model.SegmentTypeJingle || got.Segments[3].AssetName != "ed" {
 		t.Errorf("Segment[3]: want jingle(ed), got %+v", got.Segments[3])
+	}
+}
+
+func TestLLMDirector_Direct_StartAudio_SE_AfterBGM_BGMContinues(t *testing.T) {
+	mc := &mockClient{
+		response: json.RawMessage(`{"insertions":[]}`),
+	}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	// type:se → BGM先行 → SE（activeBGM維持）
+	corners := []model.CornerLines{
+		{
+			Title:      "C1",
+			StartAudio: &model.CornerAudio{Type: model.SegmentTypeSE, AssetName: "chime"},
+			BGM:        "talk_bgm",
+			Lines:      []model.Line{{SpeakerRole: "host", Text: "話す"}},
+		},
+		{
+			Title: "C2",
+			BGM:   "talk_bgm",
+			Lines: []model.Line{{SpeakerRole: "host", Text: "続き"}},
+		},
+	}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// C1: [bgm(talk_bgm), se(chime), speech]
+	// C2: BGMが維持されているので bgm再開なし → [speech]
+	// 計 [bgm(talk_bgm), se(chime), speech, speech]
+	if len(got.Segments) != 4 {
+		t.Fatalf("Segments: got %d, want 4\nsegments: %+v", len(got.Segments), got.Segments)
+	}
+	if got.Segments[0].Type != model.SegmentTypeBGM || got.Segments[0].AssetName != "talk_bgm" {
+		t.Errorf("Segment[0]: want bgm(talk_bgm), got %+v", got.Segments[0])
+	}
+	if got.Segments[1].Type != model.SegmentTypeSE || got.Segments[1].AssetName != "chime" {
+		t.Errorf("Segment[1]: want se(chime), got %+v", got.Segments[1])
+	}
+	if got.Segments[2].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[2]: want speech, got %+v", got.Segments[2])
+	}
+	if got.Segments[3].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[3]: want speech, got %+v", got.Segments[3])
+	}
+}
+
+func TestLLMDirector_Direct_EndAudio_SE_BGMContinues(t *testing.T) {
+	mc := &mockClient{
+		response: json.RawMessage(`{"insertions":[]}`),
+	}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
+
+	// type:se の end_audio → SE後もactiveBGM維持
+	corners := []model.CornerLines{
+		{
+			Title:    "C1",
+			BGM:      "talk_bgm",
+			EndAudio: &model.CornerAudio{Type: model.SegmentTypeSE, AssetName: "chime"},
+			Lines:    []model.Line{{SpeakerRole: "host", Text: "話す"}},
+		},
+		{
+			Title: "C2",
+			BGM:   "talk_bgm",
+			Lines: []model.Line{{SpeakerRole: "host", Text: "続き"}},
+		},
+	}
+
+	got, err := d.Direct(context.Background(), corners, emptyCatalog())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// C1: [bgm(talk_bgm), speech, se(chime)]
+	// C2: BGMが維持されているので bgm再開なし → [speech]
+	// 計 [bgm(talk_bgm), speech, se(chime), speech]
+	if len(got.Segments) != 4 {
+		t.Fatalf("Segments: got %d, want 4\nsegments: %+v", len(got.Segments), got.Segments)
+	}
+	if got.Segments[0].Type != model.SegmentTypeBGM || got.Segments[0].AssetName != "talk_bgm" {
+		t.Errorf("Segment[0]: want bgm(talk_bgm), got %+v", got.Segments[0])
+	}
+	if got.Segments[1].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[1]: want speech, got %+v", got.Segments[1])
+	}
+	if got.Segments[2].Type != model.SegmentTypeSE || got.Segments[2].AssetName != "chime" {
+		t.Errorf("Segment[2]: want se(chime), got %+v", got.Segments[2])
+	}
+	if got.Segments[3].Type != model.SegmentTypeSpeech {
+		t.Errorf("Segment[3]: want speech, got %+v", got.Segments[3])
 	}
 }
 
@@ -261,11 +351,11 @@ func TestLLMDirector_Direct_CornerAssetFields_NotInLLMPayload(t *testing.T) {
 	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
 	corners := []model.CornerLines{{
-		Title:       "C1",
-		StartJingle: "opening",
-		EndJingle:   "ending",
-		BGM:         "talk_bgm",
-		Lines:       []model.Line{{SpeakerRole: "host", Text: "hello"}},
+		Title:      "C1",
+		StartAudio: &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "opening"},
+		EndAudio:   &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "ending"},
+		BGM:        "talk_bgm",
+		Lines:      []model.Line{{SpeakerRole: "host", Text: "hello"}},
 	}}
 
 	_, err := d.Direct(context.Background(), corners, emptyCatalog())
@@ -273,7 +363,7 @@ func TestLLMDirector_Direct_CornerAssetFields_NotInLLMPayload(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, key := range []string{"start_jingle", "end_jingle", "bgm"} {
+	for _, key := range []string{"start_audio", "end_audio", "bgm"} {
 		if strings.Contains(capturedPrompt, `"`+key+`"`) {
 			t.Errorf("field %q should not appear in LLM payload, got: %s", key, capturedPrompt)
 		}
@@ -398,12 +488,12 @@ func TestLLMDirector_Direct_SpeechSegmentFields(t *testing.T) {
 	}
 }
 
-func TestBuildScript_StartPauseSec_InjectedBeforeStartJingle(t *testing.T) {
+func TestBuildScript_StartPauseSec_InjectedBeforeStartAudio(t *testing.T) {
 	d := noInsertionDirector()
 
 	corners := []model.CornerLines{{
 		Title:         "C1",
-		StartJingle:   "opening",
+		StartAudio:    &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "opening"},
 		StartPauseSec: 1.0,
 		Lines:         []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
@@ -427,12 +517,12 @@ func TestBuildScript_StartPauseSec_InjectedBeforeStartJingle(t *testing.T) {
 	}
 }
 
-func TestBuildScript_EndPauseSec_InjectedAfterEndJingle(t *testing.T) {
+func TestBuildScript_EndPauseSec_InjectedAfterEndAudio(t *testing.T) {
 	d := noInsertionDirector()
 
 	corners := []model.CornerLines{{
 		Title:       "C1",
-		EndJingle:   "ending",
+		EndAudio:    &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "ending"},
 		EndPauseSec: 2.0,
 		Lines:       []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
@@ -877,13 +967,13 @@ func TestBuildScript_LastCorner_NoBGMStop(t *testing.T) {
 	}
 }
 
-// TestBuildScript_EndJingle_ResetsBGM verifies that an EndJingle resets activeBGM,
+// TestBuildScript_EndAudio_Jingle_ResetsBGM verifies that an EndAudio with type:jingle resets activeBGM,
 // causing the same BGM to restart after the jingle.
-func TestBuildScript_EndJingle_ResetsBGM(t *testing.T) {
+func TestBuildScript_EndAudio_Jingle_ResetsBGM(t *testing.T) {
 	d := noInsertionDirector()
 
 	corners := []model.CornerLines{
-		{Title: "C1", BGM: "talk_bgm", EndJingle: "jingle", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
+		{Title: "C1", BGM: "talk_bgm", EndAudio: &model.CornerAudio{Type: model.SegmentTypeJingle, AssetName: "jingle"}, Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
 		{Title: "C2", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
 	}
 

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -200,7 +200,7 @@ func (g *LLMScriptGenerator) saveIntermediate(filename string, v any) error {
 }
 
 // BuildScriptLines converts per-corner config and line slices into a []model.CornerLines.
-// Asset fields (StartJingle, EndJingle, BGM) are transferred from CornerConfig
+// Asset fields (StartAudio, EndAudio, BGM) are transferred from CornerConfig
 // so they are available during deterministic segment injection in the direct step.
 func BuildScriptLines(corners []config.CornerConfig, cornerLines [][]model.Line) []model.CornerLines {
 	result := make([]model.CornerLines, len(corners))
@@ -209,14 +209,24 @@ func BuildScriptLines(corners []config.CornerConfig, cornerLines [][]model.Line)
 			Title:         corner.Title,
 			Direction:     corner.Direction,
 			Lines:         cornerLines[i],
-			StartJingle:   corner.StartJingle,
-			EndJingle:     corner.EndJingle,
+			StartAudio:    audioRefToCornerAudio(corner.StartAudio),
+			EndAudio:      audioRefToCornerAudio(corner.EndAudio),
 			BGM:           corner.BGM,
 			StartPauseSec: corner.StartPauseSec,
 			EndPauseSec:   corner.EndPauseSec,
 		}
 	}
 	return result
+}
+
+func audioRefToCornerAudio(ref *config.AudioRef) *model.CornerAudio {
+	if ref == nil {
+		return nil
+	}
+	return &model.CornerAudio{
+		Type:      model.SegmentType(ref.Type),
+		AssetName: ref.ID,
+	}
 }
 
 func countChars(lines []model.Line) int {

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -368,30 +368,50 @@ func TestLLMScriptGenerator_Generate_LinesFileUsesCornerStructure(t *testing.T) 
 	}
 }
 
-func TestBuildScriptLines_TransfersCornerAssets(t *testing.T) {
+func TestBuildScriptLines_TransfersCornerAudio(t *testing.T) {
 	corners := []config.CornerConfig{
-		{Title: "OP", Direction: "dir", StartJingle: "opening", BGM: "bgm1"},
-		{Title: "ED", EndJingle: "ending"},
+		{
+			Title:      "OP",
+			Direction:  "dir",
+			StartAudio: &config.AudioRef{Type: "jingle", ID: "opening"},
+			BGM:        "bgm1",
+		},
+		{
+			Title:    "ED",
+			EndAudio: &config.AudioRef{Type: "se", ID: "chime"},
+		},
 	}
 	lines := [][]model.Line{
 		{{SpeakerRole: "host", Text: "A"}},
 		{{SpeakerRole: "host", Text: "B"}},
 	}
 	got := script.BuildScriptLines(corners, lines)
-	if got[0].StartJingle != "opening" {
-		t.Errorf("Corners[0].StartJingle: got %q, want opening", got[0].StartJingle)
+	if got[0].StartAudio == nil {
+		t.Fatal("Corners[0].StartAudio: got nil, want non-nil")
+	}
+	if got[0].StartAudio.Type != model.SegmentTypeJingle {
+		t.Errorf("Corners[0].StartAudio.Type: got %q, want jingle", got[0].StartAudio.Type)
+	}
+	if got[0].StartAudio.AssetName != "opening" {
+		t.Errorf("Corners[0].StartAudio.AssetName: got %q, want opening", got[0].StartAudio.AssetName)
 	}
 	if got[0].BGM != "bgm1" {
 		t.Errorf("Corners[0].BGM: got %q, want bgm1", got[0].BGM)
 	}
-	if got[0].EndJingle != "" {
-		t.Errorf("Corners[0].EndJingle: got %q, want empty", got[0].EndJingle)
+	if got[0].EndAudio != nil {
+		t.Errorf("Corners[0].EndAudio: got %+v, want nil", got[0].EndAudio)
 	}
-	if got[1].EndJingle != "ending" {
-		t.Errorf("Corners[1].EndJingle: got %q, want ending", got[1].EndJingle)
+	if got[1].EndAudio == nil {
+		t.Fatal("Corners[1].EndAudio: got nil, want non-nil")
 	}
-	if got[1].StartJingle != "" {
-		t.Errorf("Corners[1].StartJingle: got %q, want empty", got[1].StartJingle)
+	if got[1].EndAudio.Type != model.SegmentTypeSE {
+		t.Errorf("Corners[1].EndAudio.Type: got %q, want se", got[1].EndAudio.Type)
+	}
+	if got[1].EndAudio.AssetName != "chime" {
+		t.Errorf("Corners[1].EndAudio.AssetName: got %q, want chime", got[1].EndAudio.AssetName)
+	}
+	if got[1].StartAudio != nil {
+		t.Errorf("Corners[1].StartAudio: got %+v, want nil", got[1].StartAudio)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `corners[].start_jingle` / `end_jingle`（文字列）を廃止し、`start_audio` / `end_audio`（`AudioRef{type, id}`）へ置き換え
- `type: jingle` — BGM を停止してからジングルを再生し、`activeBGM` をリセット
- `type: se` — BGM を継続したまま SE を再生（`activeBGM` を維持）
  - start_audio の場合: コーナー BGM が未起動なら SE 前に BGM を先行起動する
- config 層に `AudioRef{Type, ID}`、model 層に `CornerAudio{Type SegmentType, AssetName}` を追加
- `validateAudioRef` ヘルパーで type 列挙 + アセット ID の存在検証を共通化
- `appendBoundaryAudio` ヘルパーで start/end の重複 switch を排除（/simplify 対応）
- `ValidateEpisodeSpecAssets` のテストをテーブル駆動に統合
- README・CLI ドキュメント・テンプレート・サンプルを新フォーマットに更新

Closes #273

---
🤖 Generated with [Claude Code](https://claude.ai/code)