### PR TITLE
fix: slackpost で files.info ポーリング実装・ts 空ガード追加 (#275)

### DIFF
--- a/internal/slack/poster.go
+++ b/internal/slack/poster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	slackgo "github.com/slack-go/slack"
 )
@@ -35,12 +36,18 @@ type Poster interface {
 
 // realPoster is the production implementation of Poster backed by slack-go.
 type realPoster struct {
-	client *slackgo.Client
+	client       *slackgo.Client
+	pollInterval time.Duration
+	pollTimeout  time.Duration
 }
 
 // NewPoster creates a Poster backed by the real Slack API.
 func NewPoster(token string) Poster {
-	return &realPoster{client: slackgo.New(token)}
+	return &realPoster{
+		client:       slackgo.New(token),
+		pollInterval: time.Second,
+		pollTimeout:  30 * time.Second,
+	}
 }
 
 func (r *realPoster) UploadAudio(ctx context.Context, u UploadParams) (string, string, error) {
@@ -66,17 +73,56 @@ func (r *realPoster) UploadAudio(ctx context.Context, u UploadParams) (string, s
 	if err != nil {
 		return "", "", fmt.Errorf("upload audio: %w", err)
 	}
+	fileID := summary.ID
 
-	fileInfo, _, _, err := r.client.GetFileInfoContext(ctx, summary.ID, 0, 0)
+	ts, err := r.pollForTS(ctx, fileID, u.Channel)
 	if err != nil {
-		return summary.ID, "", nil
+		return fileID, "", err
 	}
+	return fileID, ts, nil
+}
 
-	ts := ""
-	if shares, ok := fileInfo.Shares.Public[u.Channel]; ok && len(shares) > 0 {
-		ts = shares[0].Ts
+func (r *realPoster) pollForTS(ctx context.Context, fileID, channel string) (string, error) {
+	pollCtx, cancel := context.WithTimeout(ctx, r.pollTimeout)
+	defer cancel()
+
+	var lastErr error
+	for {
+		select {
+		case <-pollCtx.Done():
+			return "", r.timeoutError(fileID, lastErr)
+		default:
+		}
+
+		fileInfo, _, _, err := r.client.GetFileInfoContext(pollCtx, fileID, 0, 0)
+		if err != nil {
+			lastErr = err
+		} else {
+			if shares, ok := fileInfo.Shares.Public[channel]; ok && len(shares) > 0 {
+				return shares[0].Ts, nil
+			}
+			if shares, ok := fileInfo.Shares.Private[channel]; ok && len(shares) > 0 {
+				return shares[0].Ts, nil
+			}
+		}
+
+		select {
+		case <-pollCtx.Done():
+			return "", r.timeoutError(fileID, lastErr)
+		case <-time.After(r.pollInterval):
+		}
 	}
-	return summary.ID, ts, nil
+}
+
+func (r *realPoster) timeoutError(fileID string, lastErr error) error {
+	msg := fmt.Sprintf(
+		"timed out waiting for ts (file_id=%s): audio is already uploaded — re-running will 二重投稿",
+		fileID,
+	)
+	if lastErr != nil {
+		return fmt.Errorf("%s: %w", msg, lastErr)
+	}
+	return fmt.Errorf("%s", msg)
 }
 
 func (r *realPoster) PostThreadReply(ctx context.Context, p ReplyParams) error {

--- a/internal/slack/poster.go
+++ b/internal/slack/poster.go
@@ -2,12 +2,15 @@ package slack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
 
 	slackgo "github.com/slack-go/slack"
 )
+
+const doublePostWarning = "audio is already uploaded — re-running will 二重投稿"
 
 // UploadParams holds parameters for uploading an audio file to Slack.
 type UploadParams struct {
@@ -86,14 +89,11 @@ func (r *realPoster) pollForTS(ctx context.Context, fileID, channel string) (str
 	pollCtx, cancel := context.WithTimeout(ctx, r.pollTimeout)
 	defer cancel()
 
+	timer := time.NewTimer(r.pollInterval)
+	defer timer.Stop()
+
 	var lastErr error
 	for {
-		select {
-		case <-pollCtx.Done():
-			return "", r.timeoutError(fileID, lastErr)
-		default:
-		}
-
 		fileInfo, _, _, err := r.client.GetFileInfoContext(pollCtx, fileID, 0, 0)
 		if err != nil {
 			lastErr = err
@@ -109,20 +109,18 @@ func (r *realPoster) pollForTS(ctx context.Context, fileID, channel string) (str
 		select {
 		case <-pollCtx.Done():
 			return "", r.timeoutError(fileID, lastErr)
-		case <-time.After(r.pollInterval):
+		case <-timer.C:
+			timer.Reset(r.pollInterval)
 		}
 	}
 }
 
 func (r *realPoster) timeoutError(fileID string, lastErr error) error {
-	msg := fmt.Sprintf(
-		"timed out waiting for ts (file_id=%s): audio is already uploaded — re-running will 二重投稿",
-		fileID,
-	)
+	msg := fmt.Sprintf("timed out waiting for ts (file_id=%s): %s", fileID, doublePostWarning)
 	if lastErr != nil {
 		return fmt.Errorf("%s: %w", msg, lastErr)
 	}
-	return fmt.Errorf("%s", msg)
+	return errors.New(msg)
 }
 
 func (r *realPoster) PostThreadReply(ctx context.Context, p ReplyParams) error {

--- a/internal/slack/poster_internal_test.go
+++ b/internal/slack/poster_internal_test.go
@@ -174,3 +174,34 @@ func TestRealPoster_UploadAudio_PollTimeout_ReturnsError(t *testing.T) {
 		t.Errorf("error should mention double-posting, got: %v", err)
 	}
 }
+
+func TestRealPoster_UploadAudio_GetFileInfoError_RetriesAndWrapsOnTimeout(t *testing.T) {
+	const channel = "C0123456789"
+
+	srv := newUploadTestServer(t, func(_ int32) any {
+		return map[string]any{"ok": false, "error": "file_not_found"}
+	})
+	defer srv.Close()
+
+	poster := newTestRealPoster(srv.URL+"/", 10*time.Millisecond, 100*time.Millisecond)
+	filePath := writeTempAudioFile(t)
+
+	_, _, err := poster.UploadAudio(context.Background(), UploadParams{
+		Channel:  channel,
+		FilePath: filePath,
+		Filename: "test.mp3",
+	})
+
+	if err == nil {
+		t.Fatal("UploadAudio should return error on poll timeout")
+	}
+	if !strings.Contains(err.Error(), "FTEST123") {
+		t.Errorf("error should contain fileID, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "二重投稿") {
+		t.Errorf("error should mention double-posting, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "file_not_found") {
+		t.Errorf("error should wrap last GetFileInfo error, got: %v", err)
+	}
+}

--- a/internal/slack/poster_internal_test.go
+++ b/internal/slack/poster_internal_test.go
@@ -1,0 +1,176 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	slackgo "github.com/slack-go/slack"
+)
+
+func writeTempAudioFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test.mp3")
+	if err := os.WriteFile(path, []byte("fake mp3 content"), 0o644); err != nil {
+		t.Fatalf("write temp audio: %v", err)
+	}
+	return path
+}
+
+func newUploadTestServer(t *testing.T, filesInfoHandler func(n int32) any) *httptest.Server {
+	t.Helper()
+	var callCount int32
+	var srvURL string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "files.getUploadURLExternal"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":         true,
+				"upload_url": srvURL + "/upload",
+				"file_id":    "FTEST123",
+			})
+		case r.URL.Path == "/upload":
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "files.completeUploadExternal"):
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ok":    true,
+				"files": []map[string]any{{"id": "FTEST123"}},
+			})
+		case strings.HasSuffix(r.URL.Path, "files.info"):
+			n := atomic.AddInt32(&callCount, 1)
+			_ = json.NewEncoder(w).Encode(filesInfoHandler(n))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	srvURL = srv.URL
+	return srv
+}
+
+func filesInfoResp(channel, ts string, isPrivate bool) map[string]any {
+	public := map[string]any{}
+	private := map[string]any{}
+	if ts != "" {
+		entry := []map[string]any{{"ts": ts}}
+		if isPrivate {
+			private[channel] = entry
+		} else {
+			public[channel] = entry
+		}
+	}
+	return map[string]any{
+		"ok": true,
+		"file": map[string]any{
+			"id":     "FTEST123",
+			"shares": map[string]any{"public": public, "private": private},
+		},
+		"paging": map[string]any{"count": 1, "total": 1, "page": 1, "pages": 1},
+	}
+}
+
+func newTestRealPoster(apiURL string, pollInterval, pollTimeout time.Duration) *realPoster {
+	return &realPoster{
+		client:       slackgo.New("xoxb-test", slackgo.OptionAPIURL(apiURL)),
+		pollInterval: pollInterval,
+		pollTimeout:  pollTimeout,
+	}
+}
+
+func TestRealPoster_UploadAudio_SuccessOnNthPoll(t *testing.T) {
+	const (
+		channel = "C0123456789"
+		wantTS  = "1234567890.123456"
+	)
+
+	srv := newUploadTestServer(t, func(n int32) any {
+		if n < 3 {
+			return filesInfoResp(channel, "", false)
+		}
+		return filesInfoResp(channel, wantTS, false)
+	})
+	defer srv.Close()
+
+	poster := newTestRealPoster(srv.URL+"/", 10*time.Millisecond, 5*time.Second)
+	filePath := writeTempAudioFile(t)
+
+	fileID, ts, err := poster.UploadAudio(context.Background(), UploadParams{
+		Channel:  channel,
+		FilePath: filePath,
+		Filename: "test.mp3",
+	})
+
+	if err != nil {
+		t.Fatalf("UploadAudio should succeed after retries: %v", err)
+	}
+	if fileID != "FTEST123" {
+		t.Errorf("fileID = %q, want %q", fileID, "FTEST123")
+	}
+	if ts != wantTS {
+		t.Errorf("ts = %q, want %q", ts, wantTS)
+	}
+}
+
+func TestRealPoster_UploadAudio_PrivateChannel_Success(t *testing.T) {
+	const (
+		channel = "C9876543210"
+		wantTS  = "9999999999.999999"
+	)
+
+	srv := newUploadTestServer(t, func(_ int32) any {
+		return filesInfoResp(channel, wantTS, true)
+	})
+	defer srv.Close()
+
+	poster := newTestRealPoster(srv.URL+"/", 10*time.Millisecond, 5*time.Second)
+	filePath := writeTempAudioFile(t)
+
+	_, ts, err := poster.UploadAudio(context.Background(), UploadParams{
+		Channel:  channel,
+		FilePath: filePath,
+		Filename: "test.mp3",
+	})
+
+	if err != nil {
+		t.Fatalf("UploadAudio should succeed for private channel: %v", err)
+	}
+	if ts != wantTS {
+		t.Errorf("ts = %q, want %q", ts, wantTS)
+	}
+}
+
+func TestRealPoster_UploadAudio_PollTimeout_ReturnsError(t *testing.T) {
+	const channel = "C0123456789"
+
+	srv := newUploadTestServer(t, func(_ int32) any {
+		return filesInfoResp(channel, "", false)
+	})
+	defer srv.Close()
+
+	poster := newTestRealPoster(srv.URL+"/", 10*time.Millisecond, 100*time.Millisecond)
+	filePath := writeTempAudioFile(t)
+
+	_, _, err := poster.UploadAudio(context.Background(), UploadParams{
+		Channel:  channel,
+		FilePath: filePath,
+		Filename: "test.mp3",
+	})
+
+	if err == nil {
+		t.Fatal("UploadAudio should return error on poll timeout")
+	}
+	if !strings.Contains(err.Error(), "FTEST123") {
+		t.Errorf("error should contain fileID, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "二重投稿") {
+		t.Errorf("error should mention double-posting, got: %v", err)
+	}
+}

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -91,7 +91,7 @@ func Run(opts Options, poster Poster) error {
 
 	if len(blocks) > 0 {
 		if ts == "" {
-			return fmt.Errorf("cannot post thread reply: ts is empty (file_id=%s); audio is already uploaded — re-running will 二重投稿", fileID)
+			return fmt.Errorf("cannot post thread reply: ts is empty (file_id=%s); %s", fileID, doublePostWarning)
 		}
 		replyParams := ReplyParams{
 			Channel:  spec.Slack.Channel,

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -90,6 +90,9 @@ func Run(opts Options, poster Poster) error {
 	}
 
 	if len(blocks) > 0 {
+		if ts == "" {
+			return fmt.Errorf("cannot post thread reply: ts is empty (file_id=%s); audio is already uploaded — re-running will 二重投稿", fileID)
+		}
 		replyParams := ReplyParams{
 			Channel:  spec.Slack.Channel,
 			ThreadTS: ts,

--- a/internal/slack/slack_test.go
+++ b/internal/slack/slack_test.go
@@ -280,7 +280,7 @@ func TestRun_PostMode_WithSummaryCallsThreadReply(t *testing.T) {
 	}
 }
 
-func TestRun_TsEmpty_ThreadPostedWithoutTS(t *testing.T) {
+func TestRun_TsEmpty_ReturnsError(t *testing.T) {
 	dir := t.TempDir()
 
 	manifest := map[string]any{
@@ -312,7 +312,7 @@ func TestRun_TsEmpty_ThreadPostedWithoutTS(t *testing.T) {
 		DryRun:       false,
 		Out:          os.Stdout,
 	}, mock)
-	if err != nil {
-		t.Fatalf("Run should not fail when ts is empty: %v", err)
+	if err == nil {
+		t.Fatal("Run should return error when ts is empty and thread blocks are present")
 	}
 }


### PR DESCRIPTION
## Summary

- `UploadAudio` 内で `files.info` をリトライポーリングし、`shares` に `ts` が現れるまで待機するよう修正
- `Shares.Public` / `Shares.Private` の両方を参照し、プライベートチャンネルにも対応
- ポーリングタイムアウト時は fileID と二重投稿注意を含むエラーを返す
- `GetFileInfoContext` のエラーはリトライ対象とし、タイムアウト時は最後のエラーを wrap
- `Run` に blocks あり + `ts=""` のときエラーを返す防御的ガードを追加
- `TestRun_TsEmpty_ThreadPostedWithoutTS` を `TestRun_TsEmpty_ReturnsError` に改名・仕様変更
- `poster_internal_test.go` を新規追加（ポーリング 4 ケース）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/slack/poster.go` | `realPoster` に `pollInterval`/`pollTimeout` 追加、`pollForTS` ポーリング実装、`Shares.Private` 参照、エラー握りつぶし除去 |
| `internal/slack/slack.go` | `ts=""` + blocks あり のときエラー返すガード追加 |
| `internal/slack/slack_test.go` | `TestRun_TsEmpty_ThreadPostedWithoutTS` → `TestRun_TsEmpty_ReturnsError` に改名・仕様変更 |
| `internal/slack/poster_internal_test.go` | 新規追加：N回目で shares 出現→成功 / プライベートチャンネル / タイムアウト / GetFileInfo エラー wrap |

Closes #275

---
🤖 Generated with [Claude Code](https://claude.ai/code)