### PR TITLE
fix: slackpost の ts 取得ポーリングでリトライ不能エラー（missing_scope 等）を即時失敗させる

### DIFF
--- a/internal/slack/poster.go
+++ b/internal/slack/poster.go
@@ -140,17 +140,20 @@ func (r *realPoster) pollForTS(ctx context.Context, fileID, channel string) (str
 	}
 }
 
+func pollingTerminalError(fileID, reason string, cause error) error {
+	msg := fmt.Sprintf("%s waiting for ts (file_id=%s): %s", reason, fileID, doublePostWarning)
+	if cause != nil {
+		return fmt.Errorf("%s: %w", msg, cause)
+	}
+	return errors.New(msg)
+}
+
 func (r *realPoster) nonRetryableError(fileID string, err error) error {
-	msg := fmt.Sprintf("non-retryable Slack error waiting for ts (file_id=%s): %s", fileID, doublePostWarning)
-	return fmt.Errorf("%s: %w", msg, err)
+	return pollingTerminalError(fileID, "non-retryable Slack error", err)
 }
 
 func (r *realPoster) timeoutError(fileID string, lastErr error) error {
-	msg := fmt.Sprintf("timed out waiting for ts (file_id=%s): %s", fileID, doublePostWarning)
-	if lastErr != nil {
-		return fmt.Errorf("%s: %w", msg, lastErr)
-	}
-	return errors.New(msg)
+	return pollingTerminalError(fileID, "timed out", lastErr)
 }
 
 func (r *realPoster) PostThreadReply(ctx context.Context, p ReplyParams) error {

--- a/internal/slack/poster.go
+++ b/internal/slack/poster.go
@@ -85,6 +85,28 @@ func (r *realPoster) UploadAudio(ctx context.Context, u UploadParams) (string, s
 	return fileID, ts, nil
 }
 
+// nonRetryableCodes is the set of Slack API error codes that will never resolve on retry.
+var nonRetryableCodes = map[string]struct{}{
+	"missing_scope":    {},
+	"not_authed":       {},
+	"invalid_auth":     {},
+	"account_inactive": {},
+	"token_revoked":    {},
+	"token_expired":    {},
+	"no_permission":    {},
+	"file_not_found":   {},
+	"file_deleted":     {},
+}
+
+func isNonRetryable(err error) bool {
+	var slackErr slackgo.SlackErrorResponse
+	if !errors.As(err, &slackErr) {
+		return false
+	}
+	_, ok := nonRetryableCodes[slackErr.Err]
+	return ok
+}
+
 func (r *realPoster) pollForTS(ctx context.Context, fileID, channel string) (string, error) {
 	pollCtx, cancel := context.WithTimeout(ctx, r.pollTimeout)
 	defer cancel()
@@ -96,6 +118,9 @@ func (r *realPoster) pollForTS(ctx context.Context, fileID, channel string) (str
 	for {
 		fileInfo, _, _, err := r.client.GetFileInfoContext(pollCtx, fileID, 0, 0)
 		if err != nil {
+			if isNonRetryable(err) {
+				return "", r.nonRetryableError(fileID, err)
+			}
 			lastErr = err
 		} else {
 			if shares, ok := fileInfo.Shares.Public[channel]; ok && len(shares) > 0 {
@@ -113,6 +138,11 @@ func (r *realPoster) pollForTS(ctx context.Context, fileID, channel string) (str
 			timer.Reset(r.pollInterval)
 		}
 	}
+}
+
+func (r *realPoster) nonRetryableError(fileID string, err error) error {
+	msg := fmt.Sprintf("non-retryable Slack error waiting for ts (file_id=%s): %s", fileID, doublePostWarning)
+	return fmt.Errorf("%s: %w", msg, err)
 }
 
 func (r *realPoster) timeoutError(fileID string, lastErr error) error {

--- a/internal/slack/poster_internal_test.go
+++ b/internal/slack/poster_internal_test.go
@@ -175,11 +175,12 @@ func TestRealPoster_UploadAudio_PollTimeout_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestRealPoster_UploadAudio_GetFileInfoError_RetriesAndWrapsOnTimeout(t *testing.T) {
+func TestRealPoster_UploadAudio_RetryableError_WrapsOnTimeout(t *testing.T) {
 	const channel = "C0123456789"
 
+	// service_error is not in the non-retryable list — polling should continue until timeout.
 	srv := newUploadTestServer(t, func(_ int32) any {
-		return map[string]any{"ok": false, "error": "file_not_found"}
+		return map[string]any{"ok": false, "error": "service_error"}
 	})
 	defer srv.Close()
 
@@ -201,7 +202,43 @@ func TestRealPoster_UploadAudio_GetFileInfoError_RetriesAndWrapsOnTimeout(t *tes
 	if !strings.Contains(err.Error(), "二重投稿") {
 		t.Errorf("error should mention double-posting, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "file_not_found") {
+	if !strings.Contains(err.Error(), "service_error") {
 		t.Errorf("error should wrap last GetFileInfo error, got: %v", err)
+	}
+}
+
+func TestRealPoster_UploadAudio_NonRetryableError_ImmediateFailure(t *testing.T) {
+	const channel = "C0123456789"
+
+	var infoCallCount int32
+	srv := newUploadTestServer(t, func(n int32) any {
+		atomic.StoreInt32(&infoCallCount, n)
+		return map[string]any{"ok": false, "error": "missing_scope"}
+	})
+	defer srv.Close()
+
+	poster := newTestRealPoster(srv.URL+"/", 10*time.Millisecond, 200*time.Millisecond)
+	filePath := writeTempAudioFile(t)
+
+	_, _, err := poster.UploadAudio(context.Background(), UploadParams{
+		Channel:  channel,
+		FilePath: filePath,
+		Filename: "test.mp3",
+	})
+
+	if err == nil {
+		t.Fatal("UploadAudio should return error for non-retryable Slack error")
+	}
+	if !strings.Contains(err.Error(), "FTEST123") {
+		t.Errorf("error should contain fileID, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "二重投稿") {
+		t.Errorf("error should mention double-posting, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing_scope") {
+		t.Errorf("error should wrap original Slack error, got: %v", err)
+	}
+	if n := atomic.LoadInt32(&infoCallCount); n != 1 {
+		t.Errorf("files.info should be called exactly once for non-retryable error, got %d calls", n)
 	}
 }

--- a/internal/slack/poster_internal_test.go
+++ b/internal/slack/poster_internal_test.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -240,5 +241,32 @@ func TestRealPoster_UploadAudio_NonRetryableError_ImmediateFailure(t *testing.T)
 	}
 	if n := atomic.LoadInt32(&infoCallCount); n != 1 {
 		t.Errorf("files.info should be called exactly once for non-retryable error, got %d calls", n)
+	}
+}
+
+func TestIsNonRetryable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"missing_scope", slackgo.SlackErrorResponse{Err: "missing_scope"}, true},
+		{"not_authed", slackgo.SlackErrorResponse{Err: "not_authed"}, true},
+		{"invalid_auth", slackgo.SlackErrorResponse{Err: "invalid_auth"}, true},
+		{"account_inactive", slackgo.SlackErrorResponse{Err: "account_inactive"}, true},
+		{"token_revoked", slackgo.SlackErrorResponse{Err: "token_revoked"}, true},
+		{"token_expired", slackgo.SlackErrorResponse{Err: "token_expired"}, true},
+		{"no_permission", slackgo.SlackErrorResponse{Err: "no_permission"}, true},
+		{"file_not_found", slackgo.SlackErrorResponse{Err: "file_not_found"}, true},
+		{"file_deleted", slackgo.SlackErrorResponse{Err: "file_deleted"}, true},
+		{"unknown Slack code is retryable", slackgo.SlackErrorResponse{Err: "service_error"}, false},
+		{"non-Slack error is retryable", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isNonRetryable(tt.err); got != tt.want {
+				t.Errorf("isNonRetryable(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- `internal/slack/pollForTS` において、`GetFileInfoContext` から返る Slack API エラーが認証・権限・ファイル消失系の「リトライ不能コード」（`missing_scope` / `not_authed` / `file_not_found` 等 9 種）である場合、`pollTimeout`（30 秒）を待たずに即時エラーを返すようにした
- `isNonRetryable(err error) bool` ヘルパーと `nonRetryableCodes` マップを追加し、`errors.As` で `SlackErrorResponse` を取り出してコード照合する
- 上記以外（ネットワークエラー、`RateLimitedError`、未知コード）は従来どおりリトライ継続（安全側）
- `/simplify` 指摘対応: `nonRetryableError` / `timeoutError` の共通メッセージ組み立てを `pollingTerminalError` ヘルパーに抽出
- self-review 指摘対応: `isNonRetryable` の直接ユニットテスト（テーブル駆動 11 ケース）を追加

## Test plan

- [x] `TestRealPoster_UploadAudio_NonRetryableError_ImmediateFailure`: `missing_scope` が 1 回で即時失敗すること・エラーに fileID / 二重投稿注意 / エラーコードが含まれること
- [x] `TestRealPoster_UploadAudio_RetryableError_WrapsOnTimeout`: `service_error`（リトライ可能未知コード）がタイムアウトまでリトライし続けること
- [x] `TestIsNonRetryable`: 全 9 種非リトライコードで true / 未知コード・非SlackError で false
- [x] 既存の正常系・タイムアウト系テストが引き続き PASS

Closes #278

---
🤖 Generated with [Claude Code](https://claude.ai/code)