### PR TITLE
docs: README の Slack Bot スコープ表に files:read を追記する

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,10 @@ BGM の開始・停止は台本の `bgm` セグメントで制御します。`as
 |---------|------|
 | `chat:write` | スレッド返信の投稿 |
 | `files:write` | mp3 ファイルのアップロード |
+| `files:read` | アップロード完了確認・親メッセージ ts の取得（`files.info`） |
+
+> **スコープを追加した場合は、ワークスペースへのアプリ再インストールが必要です。**
+> Slack App の管理画面（OAuth & Permissions）でスコープを更新した後、「Install to Workspace」を再実行してください。
 
 #### Bot トークンの設定
 


### PR DESCRIPTION
## Summary

- 必要な Slack スコープ表に `files:read` を追加（用途: アップロード完了確認・親メッセージ ts の取得（`files.info`））
- スコープ追加後はワークスペースへのアプリ再インストールが必要である旨の注記を追加

## 背景

#275 で `files.info` API によるポーリングが導入されたが、必要スコープ表に `files:read` が記載されていなかった。
`files:read` を持たない Bot トークンで実行すると `missing_scope` エラーにより30秒タイムアウト後スレッド返信が失敗する障害が発生（2026-06-05 報告）。

Closes #277

---
🤖 Generated with [Claude Code](https://claude.ai/code)