### PR TITLE
refactor: YAML decode ヘルパーを fileio.DecodeYAML に共通化する

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 
-	"gopkg.in/yaml.v3"
+	"github.com/canpok1/vox-radio/internal/fileio"
 )
 
 // CharsPerSec is the approximate number of characters spoken per second,
@@ -556,7 +556,7 @@ func LoadConfig(path string) (*Config, error) {
 
 func loadConfigWith(path string, strict bool) (*Config, error) {
 	cfg := &Config{}
-	if err := decodeYAML(path, cfg, strict); err != nil {
+	if err := fileio.DecodeYAML(path, cfg, strict); err != nil {
 		return nil, err
 	}
 	if err := validateConfig(cfg); err != nil {
@@ -642,7 +642,7 @@ func LoadEpisodeSpec(path string) (*EpisodeSpec, error) {
 
 func loadEpisodeSpecWith(path string, strict bool) (*EpisodeSpec, error) {
 	p := &EpisodeSpec{}
-	if err := decodeYAML(path, p, strict); err != nil {
+	if err := fileio.DecodeYAML(path, p, strict); err != nil {
 		return nil, err
 	}
 	specDir := filepath.Dir(path)
@@ -659,7 +659,7 @@ func loadEpisodeSpecWith(path string, strict bool) (*EpisodeSpec, error) {
 
 func loadAssetsFile(path string, strict bool) (AssetsConfig, error) {
 	var assets AssetsConfig
-	if err := decodeYAML(path, &assets, strict); err != nil {
+	if err := fileio.DecodeYAML(path, &assets, strict); err != nil {
 		return AssetsConfig{}, fmt.Errorf("loading asset file %q: %w", path, err)
 	}
 	resolveAssetPaths(filepath.Dir(path), &assets)
@@ -843,17 +843,4 @@ func LoadConfigStrict(path string) (*Config, error) {
 // Relative asset file paths are resolved relative to the spec file's directory.
 func LoadEpisodeSpecStrict(path string) (*EpisodeSpec, error) {
 	return loadEpisodeSpecWith(path, true)
-}
-
-func decodeYAML(path string, dest any, strict bool) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-	dec := yaml.NewDecoder(f)
-	if strict {
-		dec.KnownFields(true)
-	}
-	return dec.Decode(dest)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -660,7 +660,7 @@ func loadEpisodeSpecWith(path string, strict bool) (*EpisodeSpec, error) {
 func loadAssetsFile(path string, strict bool) (AssetsConfig, error) {
 	var assets AssetsConfig
 	if err := fileio.DecodeYAML(path, &assets, strict); err != nil {
-		return AssetsConfig{}, fmt.Errorf("loading asset file %q: %w", path, err)
+		return AssetsConfig{}, fmt.Errorf("loading asset file: %w", err)
 	}
 	resolveAssetPaths(filepath.Dir(path), &assets)
 	return assets, nil

--- a/internal/fileio/paths.go
+++ b/internal/fileio/paths.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -68,6 +70,21 @@ func ReadJSON(path string, v any) error {
 		return fmt.Errorf("unmarshal %s: %w", path, err)
 	}
 	return nil
+}
+
+// DecodeYAML opens the YAML file at path and decodes it into dest.
+// When strict is true, unknown fields cause an error.
+func DecodeYAML(path string, dest any, strict bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	dec := yaml.NewDecoder(f)
+	if strict {
+		dec.KnownFields(true)
+	}
+	return dec.Decode(dest)
 }
 
 // WriteJSON marshals v to indented JSON and writes it to path,

--- a/internal/fileio/paths.go
+++ b/internal/fileio/paths.go
@@ -77,14 +77,17 @@ func ReadJSON(path string, v any) error {
 func DecodeYAML(path string, dest any, strict bool) error {
 	f, err := os.Open(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
 	dec := yaml.NewDecoder(f)
 	if strict {
 		dec.KnownFields(true)
 	}
-	return dec.Decode(dest)
+	if err := dec.Decode(dest); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+	return nil
 }
 
 // WriteJSON marshals v to indented JSON and writes it to path,

--- a/internal/fileio/paths_test.go
+++ b/internal/fileio/paths_test.go
@@ -27,14 +27,11 @@ func TestDecodeYAML(t *testing.T) {
 	tests := []struct {
 		name        string
 		content     string
-		strict      bool
-		wantErr     bool
 		checkResult func(t *testing.T, path string)
 	}{
 		{
 			name:    "decodes valid YAML",
 			content: "name: ずんだもん\nage: 3\n",
-			strict:  false,
 			checkResult: func(t *testing.T, path string) {
 				var got nameAge
 				if err := fileio.DecodeYAML(path, &got, false); err != nil {
@@ -51,7 +48,6 @@ func TestDecodeYAML(t *testing.T) {
 		{
 			name:    "unknown field ignored when non-strict",
 			content: "name: foo\nunknown_key: bar\n",
-			strict:  false,
 			checkResult: func(t *testing.T, path string) {
 				var got nameOnly
 				if err := fileio.DecodeYAML(path, &got, false); err != nil {
@@ -62,7 +58,6 @@ func TestDecodeYAML(t *testing.T) {
 		{
 			name:    "unknown field rejected when strict",
 			content: "name: foo\nunknown_key: bar\n",
-			strict:  true,
 			checkResult: func(t *testing.T, path string) {
 				var got nameOnly
 				if err := fileio.DecodeYAML(path, &got, true); err == nil {

--- a/internal/fileio/paths_test.go
+++ b/internal/fileio/paths_test.go
@@ -8,30 +8,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/fileio"
 )
 
-func TestDecodeYAML(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "test.yaml")
-
-	type payload struct {
-		Name string `yaml:"name"`
-		Age  int    `yaml:"age"`
-	}
-	if err := os.WriteFile(path, []byte("name: ずんだもん\nage: 3\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	var got payload
-	if err := fileio.DecodeYAML(path, &got, false); err != nil {
-		t.Fatalf("DecodeYAML: %v", err)
-	}
-	if got.Name != "ずんだもん" {
-		t.Errorf("Name: got %q, want %q", got.Name, "ずんだもん")
-	}
-	if got.Age != 3 {
-		t.Errorf("Age: got %d, want %d", got.Age, 3)
-	}
-}
-
 func TestDecodeYAML_MissingFile(t *testing.T) {
 	var v any
 	err := fileio.DecodeYAML(filepath.Join(t.TempDir(), "nonexistent.yaml"), &v, false)
@@ -40,37 +16,69 @@ func TestDecodeYAML_MissingFile(t *testing.T) {
 	}
 }
 
-func TestDecodeYAML_UnknownField_NonStrict(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "test.yaml")
-
-	type payload struct {
+func TestDecodeYAML(t *testing.T) {
+	type nameOnly struct {
 		Name string `yaml:"name"`
 	}
-	if err := os.WriteFile(path, []byte("name: foo\nunknown_key: bar\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	var got payload
-	if err := fileio.DecodeYAML(path, &got, false); err != nil {
-		t.Errorf("DecodeYAML (non-strict): unexpected error: %v", err)
-	}
-}
-
-func TestDecodeYAML_UnknownField_Strict(t *testing.T) {
-	tmp := t.TempDir()
-	path := filepath.Join(tmp, "test.yaml")
-
-	type payload struct {
+	type nameAge struct {
 		Name string `yaml:"name"`
+		Age  int    `yaml:"age"`
 	}
-	if err := os.WriteFile(path, []byte("name: foo\nunknown_key: bar\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
+	tests := []struct {
+		name        string
+		content     string
+		strict      bool
+		wantErr     bool
+		checkResult func(t *testing.T, path string)
+	}{
+		{
+			name:    "decodes valid YAML",
+			content: "name: ずんだもん\nage: 3\n",
+			strict:  false,
+			checkResult: func(t *testing.T, path string) {
+				var got nameAge
+				if err := fileio.DecodeYAML(path, &got, false); err != nil {
+					t.Fatalf("DecodeYAML: %v", err)
+				}
+				if got.Name != "ずんだもん" {
+					t.Errorf("Name: got %q, want %q", got.Name, "ずんだもん")
+				}
+				if got.Age != 3 {
+					t.Errorf("Age: got %d, want %d", got.Age, 3)
+				}
+			},
+		},
+		{
+			name:    "unknown field ignored when non-strict",
+			content: "name: foo\nunknown_key: bar\n",
+			strict:  false,
+			checkResult: func(t *testing.T, path string) {
+				var got nameOnly
+				if err := fileio.DecodeYAML(path, &got, false); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name:    "unknown field rejected when strict",
+			content: "name: foo\nunknown_key: bar\n",
+			strict:  true,
+			checkResult: func(t *testing.T, path string) {
+				var got nameOnly
+				if err := fileio.DecodeYAML(path, &got, true); err == nil {
+					t.Error("expected error for unknown field, got nil")
+				}
+			},
+		},
 	}
-
-	var got payload
-	if err := fileio.DecodeYAML(path, &got, true); err == nil {
-		t.Error("DecodeYAML (strict): expected error for unknown field, got nil")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "test.yaml")
+			if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+				t.Fatalf("WriteFile: %v", err)
+			}
+			tt.checkResult(t, path)
+		})
 	}
 }
 

--- a/internal/fileio/paths_test.go
+++ b/internal/fileio/paths_test.go
@@ -8,6 +8,72 @@ import (
 	"github.com/canpok1/vox-radio/internal/fileio"
 )
 
+func TestDecodeYAML(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.yaml")
+
+	type payload struct {
+		Name string `yaml:"name"`
+		Age  int    `yaml:"age"`
+	}
+	if err := os.WriteFile(path, []byte("name: ずんだもん\nage: 3\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var got payload
+	if err := fileio.DecodeYAML(path, &got, false); err != nil {
+		t.Fatalf("DecodeYAML: %v", err)
+	}
+	if got.Name != "ずんだもん" {
+		t.Errorf("Name: got %q, want %q", got.Name, "ずんだもん")
+	}
+	if got.Age != 3 {
+		t.Errorf("Age: got %d, want %d", got.Age, 3)
+	}
+}
+
+func TestDecodeYAML_MissingFile(t *testing.T) {
+	var v any
+	err := fileio.DecodeYAML(filepath.Join(t.TempDir(), "nonexistent.yaml"), &v, false)
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestDecodeYAML_UnknownField_NonStrict(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.yaml")
+
+	type payload struct {
+		Name string `yaml:"name"`
+	}
+	if err := os.WriteFile(path, []byte("name: foo\nunknown_key: bar\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var got payload
+	if err := fileio.DecodeYAML(path, &got, false); err != nil {
+		t.Errorf("DecodeYAML (non-strict): unexpected error: %v", err)
+	}
+}
+
+func TestDecodeYAML_UnknownField_Strict(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "test.yaml")
+
+	type payload struct {
+		Name string `yaml:"name"`
+	}
+	if err := os.WriteFile(path, []byte("name: foo\nunknown_key: bar\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var got payload
+	if err := fileio.DecodeYAML(path, &got, true); err == nil {
+		t.Error("DecodeYAML (strict): expected error for unknown field, got nil")
+	}
+}
+
 func TestClipFileName(t *testing.T) {
 	tests := []struct {
 		n    int

--- a/internal/model/feed_spec.go
+++ b/internal/model/feed_spec.go
@@ -5,10 +5,9 @@ import (
 	"fmt"
 	"net/mail"
 	"net/url"
-	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/canpok1/vox-radio/internal/fileio"
 )
 
 const DefaultPublicDir = "public"
@@ -58,18 +57,9 @@ func LoadFeedSpecStrict(path string) (FeedSpec, error) {
 }
 
 func loadFeedSpecWith(path string, strict bool) (FeedSpec, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return FeedSpec{}, fmt.Errorf("read feed spec: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	dec := yaml.NewDecoder(f)
-	if strict {
-		dec.KnownFields(true)
-	}
 	var cfg FeedSpec
-	if err := dec.Decode(&cfg); err != nil {
-		return FeedSpec{}, fmt.Errorf("parse feed spec: %w", err)
+	if err := fileio.DecodeYAML(path, &cfg, strict); err != nil {
+		return FeedSpec{}, fmt.Errorf("load feed spec: %w", err)
 	}
 	return cfg, nil
 }


### PR DESCRIPTION
## Summary

- `internal/config/config.go` の `decodeYAML` と `internal/model/feed_spec.go` の `loadFeedSpecWith` が同一パターン（`os.Open → yaml.NewDecoder → KnownFields → Decode`）を重複実装していたため、`internal/fileio` パッケージに `DecodeYAML` を切り出して両者から共通利用するよう変更
- `DecodeYAML` はエラーにパスコンテキストを付与し、既存の `ReadJSON` / `WriteJSON` と一貫したエラーラッピングスタイルに統一
- テストはテーブル駆動形式で整理

## Changes

- `internal/fileio/paths.go`: `DecodeYAML(path, dest, strict)` を追加
- `internal/config/config.go`: `decodeYAML` を削除し `fileio.DecodeYAML` に置き換え
- `internal/model/feed_spec.go`: `loadFeedSpecWith` 内のデコード処理を `fileio.DecodeYAML` に置き換え

Closes #226

🤖 Generated with [Claude Code](https://claude.ai/code)