### PR TITLE
refactor: CLIテストの *TestdataPath ヘルパーを testhelper_test.go に共通化する

### DIFF
--- a/internal/cli/assets_test.go
+++ b/internal/cli/assets_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/cli"
 )
 
-func assetsTestdataPath(rel string) string {
-	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
-}
-
 // buildValidAssetsYAML creates a temp dir with stub audio files and an assets.yaml referencing them.
 // Returns the path to the created assets.yaml.
 func buildValidAssetsYAML(t *testing.T) string {
@@ -112,7 +108,7 @@ func TestAssetsCheck_ValidYAML_Success(t *testing.T) {
 
 func TestAssetsCheck_Typo_Error(t *testing.T) {
 	cmd := cli.NewRootCmd()
-	cmd.SetArgs([]string{"assets", "check", assetsTestdataPath("assets_typo.yaml")})
+	cmd.SetArgs([]string{"assets", "check", configTestdataPath("assets_typo.yaml")})
 	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error for assets.yaml with unknown key (typo), got nil")

--- a/internal/cli/config_check_test.go
+++ b/internal/cli/config_check_test.go
@@ -2,25 +2,11 @@ package cli_test
 
 import (
 	"bytes"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/cli"
 )
-
-// cliTestSrcDir is the absolute path of this test file's directory, resolved at init time.
-var cliTestSrcDir string
-
-func init() {
-	_, file, _, _ := runtime.Caller(0)
-	cliTestSrcDir = filepath.Dir(file)
-}
-
-func configTestdataPath(rel string) string {
-	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
-}
 
 func TestConfigCheck_ValidYAML_Success(t *testing.T) {
 	cmd := cli.NewRootCmd()

--- a/internal/cli/episodegen_check_test.go
+++ b/internal/cli/episodegen_check_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/cli"
 )
 
-func episodeSpecTestdataPath(rel string) string {
-	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
-}
-
 // setupEpisodegenCheckDir creates a temp dir with vox-radio.yaml and changes cwd to it.
 func setupEpisodegenCheckDir(t *testing.T, configSrc string) {
 	t.Helper()
@@ -29,12 +25,12 @@ func setupEpisodegenCheckDir(t *testing.T, configSrc string) {
 }
 
 func TestEpisodegenCheck_ValidSpec_Success(t *testing.T) {
-	setupEpisodegenCheckDir(t, episodeSpecTestdataPath("config.yaml"))
+	setupEpisodegenCheckDir(t, configTestdataPath("config.yaml"))
 
 	cmd := cli.NewRootCmd()
 	buf := &bytes.Buffer{}
 	cmd.SetOut(buf)
-	cmd.SetArgs([]string{"episodegen", "check", episodeSpecTestdataPath("episode_spec.yaml")})
+	cmd.SetArgs([]string{"episodegen", "check", configTestdataPath("episode_spec.yaml")})
 	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -45,10 +41,10 @@ func TestEpisodegenCheck_ValidSpec_Success(t *testing.T) {
 }
 
 func TestEpisodegenCheck_UnknownKey_Error(t *testing.T) {
-	setupEpisodegenCheckDir(t, episodeSpecTestdataPath("config.yaml"))
+	setupEpisodegenCheckDir(t, configTestdataPath("config.yaml"))
 
 	cmd := cli.NewRootCmd()
-	cmd.SetArgs([]string{"episodegen", "check", episodeSpecTestdataPath("episode_spec_unknown_key.yaml")})
+	cmd.SetArgs([]string{"episodegen", "check", configTestdataPath("episode_spec_unknown_key.yaml")})
 	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error for unknown key in strict mode")
@@ -56,7 +52,7 @@ func TestEpisodegenCheck_UnknownKey_Error(t *testing.T) {
 }
 
 func TestEpisodegenCheck_UnknownCast_Error(t *testing.T) {
-	setupEpisodegenCheckDir(t, episodeSpecTestdataPath("config.yaml"))
+	setupEpisodegenCheckDir(t, configTestdataPath("config.yaml"))
 
 	// create a spec with an unknown cast character
 	dir := t.TempDir()
@@ -93,7 +89,7 @@ func TestEpisodegenCheck_MissingConfig_Error(t *testing.T) {
 	chdirTemp(t) // no vox-radio.yaml in cwd
 
 	cmd := cli.NewRootCmd()
-	cmd.SetArgs([]string{"episodegen", "check", episodeSpecTestdataPath("episode_spec.yaml")})
+	cmd.SetArgs([]string{"episodegen", "check", configTestdataPath("episode_spec.yaml")})
 	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error when vox-radio.yaml is missing in cwd")
@@ -110,10 +106,10 @@ func TestEpisodegenCheck_MissingSpecArg_Error(t *testing.T) {
 }
 
 func TestEpisodegenCheck_AssetsTypo_Error(t *testing.T) {
-	setupEpisodegenCheckDir(t, episodeSpecTestdataPath("config.yaml"))
+	setupEpisodegenCheckDir(t, configTestdataPath("config.yaml"))
 
 	cmd := cli.NewRootCmd()
-	cmd.SetArgs([]string{"episodegen", "check", episodeSpecTestdataPath("episode_spec_with_typo_assets.yaml")})
+	cmd.SetArgs([]string{"episodegen", "check", configTestdataPath("episode_spec_with_typo_assets.yaml")})
 	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error when assets_files contains typo in strict mode, got nil")
@@ -127,8 +123,8 @@ func TestEpisodegenCheck_ConfigFlag_DifferentDir(t *testing.T) {
 	buf := &bytes.Buffer{}
 	cmd.SetOut(buf)
 	cmd.SetArgs([]string{"episodegen", "check",
-		"--config", episodeSpecTestdataPath("config.yaml"),
-		episodeSpecTestdataPath("episode_spec.yaml"),
+		"--config", configTestdataPath("config.yaml"),
+		configTestdataPath("episode_spec.yaml"),
 	})
 	err := cmd.Execute()
 	if err != nil {

--- a/internal/cli/feedgen_check_test.go
+++ b/internal/cli/feedgen_check_test.go
@@ -10,15 +10,11 @@ import (
 	"github.com/canpok1/vox-radio/internal/cli"
 )
 
-func feedSpecTestdataPath(rel string) string {
-	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
-}
-
 func TestFeedgenCheck_ValidSpec_Success(t *testing.T) {
 	cmd := cli.NewRootCmd()
 	buf := &bytes.Buffer{}
 	cmd.SetOut(buf)
-	cmd.SetArgs([]string{"feedgen", "check", feedSpecTestdataPath("feed_spec.yaml")})
+	cmd.SetArgs([]string{"feedgen", "check", configTestdataPath("feed_spec.yaml")})
 	err := cmd.Execute()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -30,7 +26,7 @@ func TestFeedgenCheck_ValidSpec_Success(t *testing.T) {
 
 func TestFeedgenCheck_UnknownKey_Error(t *testing.T) {
 	cmd := cli.NewRootCmd()
-	cmd.SetArgs([]string{"feedgen", "check", feedSpecTestdataPath("feed_spec_unknown_key.yaml")})
+	cmd.SetArgs([]string{"feedgen", "check", configTestdataPath("feed_spec_unknown_key.yaml")})
 	err := cmd.Execute()
 	if err == nil {
 		t.Error("expected error for unknown key in strict mode")

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -1,0 +1,18 @@
+package cli_test
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+// cliTestSrcDir is the absolute path of this test file's directory, resolved at init time.
+var cliTestSrcDir string
+
+func init() {
+	_, file, _, _ := runtime.Caller(0)
+	cliTestSrcDir = filepath.Dir(file)
+}
+
+func configTestdataPath(rel string) string {
+	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
+}


### PR DESCRIPTION
## Summary

- `config_check_test.go` / `feedgen_check_test.go` / `episodegen_check_test.go` / `assets_test.go` に同一実装のテストデータパスヘルパーが4つ重複していた
- `internal/cli/testhelper_test.go` を新規作成し、`cliTestSrcDir` / `init()` / `configTestdataPath` を一箇所に集約した
- 各ファイルの重複定義（`feedSpecTestdataPath` / `episodeSpecTestdataPath` / `assetsTestdataPath`）を削除し、共通の `configTestdataPath` を呼ぶよう統一した

## /simplify スキップ記録

- `util_test.go` の `os.Chdir` パターン重複（スコープ外）→ Issue #288 として起票
- `configTestdataPath` リネーム → `config/testdata/` を指す正確な命名のためskip
- cross-package testdata 依存 → 設計上の大きな問題でスコープ外のためskip

Closes #229

---
🤖 Generated with [Claude Code](https://claude.ai/code)