### PR TITLE
refactor: JingleEntry/SEEntry/BGMEntry に Validate() メソッドを追加する

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,17 @@ func (e JingleEntry) EffectiveTrimSilenceThresholdDB() float64 {
 	return effectiveTrimSilenceThresholdDB(e.TrimSilenceThreshold)
 }
 
+// Validate checks that field values are in valid ranges.
+func (e JingleEntry) Validate() error {
+	if e.FadeIn < 0 {
+		return fmt.Errorf("fade_in: must be >= 0, got %v", e.FadeIn)
+	}
+	if e.FadeOut < 0 {
+		return fmt.Errorf("fade_out: must be >= 0, got %v", e.FadeOut)
+	}
+	return nil
+}
+
 type SEEntry struct {
 	File                 string   `yaml:"file"`
 	Volume               float64  `yaml:"volume"`
@@ -70,6 +81,14 @@ func (e SEEntry) EffectiveTrimSilenceThresholdDB() float64 {
 // EffectiveOverlay returns true only when Overlay is explicitly true.
 // Default (nil) is false: the SE plays to completion before the next dialogue.
 func (e SEEntry) EffectiveOverlay() bool { return e.Overlay != nil && *e.Overlay }
+
+// Validate checks that field values are in valid ranges.
+func (e SEEntry) Validate() error {
+	if e.Volume < 0 {
+		return fmt.Errorf("volume: must be >= 0, got %v", e.Volume)
+	}
+	return nil
+}
 
 // effectiveTrimSilence returns true when v is nil (default) or points to true.
 func effectiveTrimSilence(v *bool) bool {
@@ -122,6 +141,23 @@ func (e BGMEntry) EffectiveFadeIn() float64 { return effectiveFadeSec(e.FadeIn) 
 // EffectiveFadeOut returns the fade-out duration in seconds.
 // nil (unspecified) → DefaultBGMFadeSec; negative values are clamped to 0.
 func (e BGMEntry) EffectiveFadeOut() float64 { return effectiveFadeSec(e.FadeOut) }
+
+// Validate checks that field values are in valid ranges.
+func (e BGMEntry) Validate() error {
+	if e.Volume < 0 {
+		return fmt.Errorf("volume: must be >= 0, got %v", e.Volume)
+	}
+	if e.DuckRatio < 1 {
+		return fmt.Errorf("duck_ratio: must be >= 1, got %v", e.DuckRatio)
+	}
+	if e.FadeIn != nil && *e.FadeIn < 0 {
+		return fmt.Errorf("fade_in: must be >= 0, got %v", *e.FadeIn)
+	}
+	if e.FadeOut != nil && *e.FadeOut < 0 {
+		return fmt.Errorf("fade_out: must be >= 0, got %v", *e.FadeOut)
+	}
+	return nil
+}
 
 type AssetsConfig struct {
 	Jingle map[string]JingleEntry `yaml:"jingle"`
@@ -697,11 +733,8 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		if err := validateFileField("jingle", name, entry.File); err != nil {
 			return err
 		}
-		if entry.FadeIn < 0 {
-			return fmt.Errorf("jingle[%q].fade_in: must be >= 0, got %v", name, entry.FadeIn)
-		}
-		if entry.FadeOut < 0 {
-			return fmt.Errorf("jingle[%q].fade_out: must be >= 0, got %v", name, entry.FadeOut)
+		if err := entry.Validate(); err != nil {
+			return fmt.Errorf("jingle[%q]: %w", name, err)
 		}
 		if err := validateTrimSilenceThresholdDB("jingle", name, entry.TrimSilenceThreshold); err != nil {
 			return err
@@ -711,8 +744,8 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		if err := validateFileField("se", name, entry.File); err != nil {
 			return err
 		}
-		if entry.Volume < 0 {
-			return fmt.Errorf("se[%q].volume: must be >= 0, got %v", name, entry.Volume)
+		if err := entry.Validate(); err != nil {
+			return fmt.Errorf("se[%q]: %w", name, err)
 		}
 		if err := validateTrimSilenceThresholdDB("se", name, entry.TrimSilenceThreshold); err != nil {
 			return err
@@ -722,17 +755,8 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		if err := validateFileField("bgm", name, entry.File); err != nil {
 			return err
 		}
-		if entry.Volume < 0 {
-			return fmt.Errorf("bgm[%q].volume: must be >= 0, got %v", name, entry.Volume)
-		}
-		if entry.DuckRatio < 1 {
-			return fmt.Errorf("bgm[%q].duck_ratio: must be >= 1, got %v", name, entry.DuckRatio)
-		}
-		if entry.FadeIn != nil && *entry.FadeIn < 0 {
-			return fmt.Errorf("bgm[%q].fade_in: must be >= 0, got %v", name, *entry.FadeIn)
-		}
-		if entry.FadeOut != nil && *entry.FadeOut < 0 {
-			return fmt.Errorf("bgm[%q].fade_out: must be >= 0, got %v", name, *entry.FadeOut)
+		if err := entry.Validate(); err != nil {
+			return fmt.Errorf("bgm[%q]: %w", name, err)
 		}
 	}
 	return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,13 +52,10 @@ func (e JingleEntry) EffectiveTrimSilenceThresholdDB() float64 {
 
 // Validate checks that field values are in valid ranges.
 func (e JingleEntry) Validate() error {
-	if e.FadeIn < 0 {
-		return fmt.Errorf("fade_in: must be >= 0, got %v", e.FadeIn)
+	if err := validateNonNegative("fade_in", e.FadeIn); err != nil {
+		return err
 	}
-	if e.FadeOut < 0 {
-		return fmt.Errorf("fade_out: must be >= 0, got %v", e.FadeOut)
-	}
-	return nil
+	return validateNonNegative("fade_out", e.FadeOut)
 }
 
 type SEEntry struct {
@@ -84,10 +81,7 @@ func (e SEEntry) EffectiveOverlay() bool { return e.Overlay != nil && *e.Overlay
 
 // Validate checks that field values are in valid ranges.
 func (e SEEntry) Validate() error {
-	if e.Volume < 0 {
-		return fmt.Errorf("volume: must be >= 0, got %v", e.Volume)
-	}
-	return nil
+	return validateNonNegative("volume", e.Volume)
 }
 
 // effectiveTrimSilence returns true when v is nil (default) or points to true.
@@ -144,19 +138,16 @@ func (e BGMEntry) EffectiveFadeOut() float64 { return effectiveFadeSec(e.FadeOut
 
 // Validate checks that field values are in valid ranges.
 func (e BGMEntry) Validate() error {
-	if e.Volume < 0 {
-		return fmt.Errorf("volume: must be >= 0, got %v", e.Volume)
+	if err := validateNonNegative("volume", e.Volume); err != nil {
+		return err
 	}
 	if e.DuckRatio < 1 {
 		return fmt.Errorf("duck_ratio: must be >= 1, got %v", e.DuckRatio)
 	}
-	if e.FadeIn != nil && *e.FadeIn < 0 {
-		return fmt.Errorf("fade_in: must be >= 0, got %v", *e.FadeIn)
+	if err := validateOptionalNonNegative("fade_in", e.FadeIn); err != nil {
+		return err
 	}
-	if e.FadeOut != nil && *e.FadeOut < 0 {
-		return fmt.Errorf("fade_out: must be >= 0, got %v", *e.FadeOut)
-	}
-	return nil
+	return validateOptionalNonNegative("fade_out", e.FadeOut)
 }
 
 type AssetsConfig struct {
@@ -707,6 +698,22 @@ func loadAssetsFile(path string, strict bool) (AssetsConfig, error) {
 // Relative file paths are resolved relative to the assets file's directory.
 func LoadAssetsFileStrict(path string) (AssetsConfig, error) {
 	return loadAssetsFile(path, true)
+}
+
+// validateNonNegative returns an error if v < 0.
+func validateNonNegative(field string, v float64) error {
+	if v < 0 {
+		return fmt.Errorf("%s: must be >= 0, got %v", field, v)
+	}
+	return nil
+}
+
+// validateOptionalNonNegative returns an error if v is non-nil and *v < 0.
+func validateOptionalNonNegative(field string, v *float64) error {
+	if v != nil && *v < 0 {
+		return fmt.Errorf("%s: must be >= 0, got %v", field, *v)
+	}
+	return nil
 }
 
 // validateFileField checks that file is non-empty and exists on disk.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1566,3 +1566,73 @@ func TestSEEntry_EffectiveTrimSilenceThresholdDB(t *testing.T) {
 		})
 	}
 }
+
+func TestJingleEntry_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   config.JingleEntry
+		wantErr bool
+	}{
+		{"valid zero values", config.JingleEntry{FadeIn: 0, FadeOut: 0}, false},
+		{"valid positive values", config.JingleEntry{FadeIn: 0.5, FadeOut: 1.0}, false},
+		{"fade_in negative", config.JingleEntry{FadeIn: -1.0, FadeOut: 0}, true},
+		{"fade_out negative", config.JingleEntry{FadeIn: 0, FadeOut: -0.5}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.entry.Validate()
+			if (err != nil) != c.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestSEEntry_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   config.SEEntry
+		wantErr bool
+	}{
+		{"valid zero volume", config.SEEntry{Volume: 0}, false},
+		{"valid positive volume", config.SEEntry{Volume: 0.8}, false},
+		{"volume negative", config.SEEntry{Volume: -0.1}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.entry.Validate()
+			if (err != nil) != c.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestBGMEntry_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		entry   config.BGMEntry
+		wantErr bool
+	}{
+		{"valid minimum values", config.BGMEntry{Volume: 0, DuckRatio: 1}, false},
+		{"valid typical values", config.BGMEntry{Volume: 0.3, DuckRatio: 8}, false},
+		{"volume negative", config.BGMEntry{Volume: -1, DuckRatio: 8}, true},
+		{"duck_ratio zero", config.BGMEntry{Volume: 0.3, DuckRatio: 0}, true},
+		{"duck_ratio less than 1", config.BGMEntry{Volume: 0.3, DuckRatio: 0.5}, true},
+		{"fade_in nil is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: nil}, false},
+		{"fade_in zero is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: float64Ptr(0.0)}, false},
+		{"fade_in positive is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: float64Ptr(1.0)}, false},
+		{"fade_in negative", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: float64Ptr(-1.0)}, true},
+		{"fade_out nil is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeOut: nil}, false},
+		{"fade_out zero is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeOut: float64Ptr(0.0)}, false},
+		{"fade_out negative", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeOut: float64Ptr(-0.5)}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.entry.Validate()
+			if (err != nil) != c.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, c.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `JingleEntry.Validate() error` を追加（`fade_in`/`fade_out >= 0` チェック）
- `SEEntry.Validate() error` を追加（`volume >= 0` チェック）
- `BGMEntry.Validate() error` を追加（`volume >= 0` / `duck_ratio >= 1` / `fade_in`/`fade_out >= 0`（設定時）チェック）
- `ValidateAssetsConfig` をファイル実在確認 + 各エントリの `.Validate()` 呼び出しに整理
- `validateNonNegative` / `validateOptionalNonNegative` ヘルパーを抽出して Validate() 内の重複を削減

## 背景

Issue #228 の /simplify altitude 指摘（スコープ外スキップ）を独立 Issue 化したもの。
フィールド範囲チェック（fade_in/fade_out/volume/duck_ratio）はエントリ型自身の不変条件であり、
エントリ型の `Validate()` メソッドに移すのが適切。

## スコープ外

`TrimSilenceThreshold` の `Validate()` への移動は Issue #290 として後続対応予定。

Closes #230

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)