### PR TITLE
feat: AppearanceCount を「今回含む出演回数（初登場=1）」に変更し境界で逆変換する

### DIFF
--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -120,7 +120,7 @@ func newLLMClient(cfg *config.Config) llm.Client {
 func selectCasts(casts map[string]config.CastConfig, episodeNumber int, counts map[string]int, logger *slog.Logger) []model.RundownCast {
 	selected := cast.Select(casts, episodeNumber)
 	for i, c := range selected {
-		selected[i].AppearanceCount = counts[c.CharacterID]
+		selected[i].AppearanceCount = counts[c.CharacterID] + 1
 	}
 	if episodeNumber == 0 {
 		for _, c := range casts {

--- a/internal/cli/util_test.go
+++ b/internal/cli/util_test.go
@@ -261,11 +261,11 @@ func TestSelectCasts_InjectsAppearanceCount(t *testing.T) {
 	for _, c := range selected {
 		countByID[c.CharacterID] = c.AppearanceCount
 	}
-	if countByID["zundamon"] != 10 {
-		t.Errorf("zundamon AppearanceCount: got %d, want 10", countByID["zundamon"])
+	if countByID["zundamon"] != 11 {
+		t.Errorf("zundamon AppearanceCount: got %d, want 11 (counts[id]+1)", countByID["zundamon"])
 	}
-	if countByID["guest1"] != 2 {
-		t.Errorf("guest1 AppearanceCount: got %d, want 2", countByID["guest1"])
+	if countByID["guest1"] != 3 {
+		t.Errorf("guest1 AppearanceCount: got %d, want 3 (counts[id]+1)", countByID["guest1"])
 	}
 }
 
@@ -281,8 +281,8 @@ func TestSelectCasts_UnknownCharHasZeroCount(t *testing.T) {
 		t.Fatal("expected at least one cast member")
 	}
 	for _, c := range selected {
-		if c.CharacterID == "zundamon" && c.AppearanceCount != 0 {
-			t.Errorf("zundamon AppearanceCount: got %d, want 0 (not in counts)", c.AppearanceCount)
+		if c.CharacterID == "zundamon" && c.AppearanceCount != 1 {
+			t.Errorf("zundamon AppearanceCount: got %d, want 1 (not in counts: 0+1)", c.AppearanceCount)
 		}
 	}
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -235,6 +235,27 @@ func TestBuild_CastsCopiedFromRundown(t *testing.T) {
 	}
 }
 
+func TestBuild_CastsFirstAppearancePreserved(t *testing.T) {
+	// 新定義: AppearanceCount=1 は初登場（今回含む出演回数）
+	program := config.ProgramConfig{Title: "テスト番組", Description: "説明"}
+	corners := []config.CornerConfig{{Title: "コーナー1"}}
+	rundown := model.Rundown{
+		Casts: []model.RundownCast{
+			{CharacterID: "guest1", Role: "ゲスト", Type: "guest", AppearanceCount: 1},
+		},
+	}
+
+	got := manifest.Build(program, corners, rundown, "episode.mp3", fixedTime, "", nil, nil, 0, "")
+
+	if len(got.Casts) != 1 {
+		t.Fatalf("Casts: got %d, want 1", len(got.Casts))
+	}
+	// 新定義値（1=初登場）がマニフェストにそのまま保持される
+	if got.Casts[0].AppearanceCount != 1 {
+		t.Errorf("Casts[0].AppearanceCount: got %d, want 1 (初登場=1 in new definition)", got.Casts[0].AppearanceCount)
+	}
+}
+
 func TestBuild_CastsNeverNil(t *testing.T) {
 	program := config.ProgramConfig{Title: "テスト番組", Description: "説明"}
 	corners := []config.CornerConfig{{Title: "コーナー1"}}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -694,6 +694,66 @@ func TestRundown_Casts_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestRundownCast_PastAppearanceCount(t *testing.T) {
+	tests := []struct {
+		name            string
+		appearanceCount int
+		want            int
+	}{
+		{"初登場（1）は0を返す", 1, 0},
+		{"4回目（4）は3を返す", 4, 3},
+		{"0のとき0クランプ", 0, 0},
+		{"負値のとき0クランプ", -1, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := model.RundownCast{AppearanceCount: tt.appearanceCount}
+			got := c.PastAppearanceCount()
+			if got != tt.want {
+				t.Errorf("PastAppearanceCount() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCastsForLLM_ConvertsAppearanceCount(t *testing.T) {
+	original := []model.RundownCast{
+		{CharacterID: "zundamon", Role: "MC", Type: "regular", AppearanceCount: 5},
+		{CharacterID: "guest1", Role: "ゲスト", Type: "guest", AppearanceCount: 1},
+	}
+
+	got := model.CastsForLLM(original)
+
+	if len(got) != 2 {
+		t.Fatalf("CastsForLLM: got %d items, want 2", len(got))
+	}
+	if got[0].AppearanceCount != 4 {
+		t.Errorf("got[0].AppearanceCount = %d, want 4 (5-1)", got[0].AppearanceCount)
+	}
+	if got[1].AppearanceCount != 0 {
+		t.Errorf("got[1].AppearanceCount = %d, want 0 (1-1)", got[1].AppearanceCount)
+	}
+}
+
+func TestCastsForLLM_DoesNotModifyOriginal(t *testing.T) {
+	original := []model.RundownCast{
+		{CharacterID: "zundamon", Role: "MC", Type: "regular", AppearanceCount: 5},
+	}
+
+	_ = model.CastsForLLM(original)
+
+	if original[0].AppearanceCount != 5 {
+		t.Errorf("original[0].AppearanceCount modified: got %d, want 5", original[0].AppearanceCount)
+	}
+}
+
+func TestCastsForLLM_Empty(t *testing.T) {
+	got := model.CastsForLLM([]model.RundownCast{})
+	if len(got) != 0 {
+		t.Errorf("CastsForLLM(empty) should return empty slice, got %d items", len(got))
+	}
+}
+
 func TestCornerLines_EmptyAssetFields_OmittedFromJSON(t *testing.T) {
 	cl := model.CornerLines{
 		Title: "C1",

--- a/internal/model/rundown.go
+++ b/internal/model/rundown.go
@@ -25,10 +25,7 @@ type RundownCast struct {
 // PastAppearanceCount returns the number of past appearances (excluding this episode).
 // This is the LLM-facing value: AppearanceCount - 1, clamped to 0.
 func (c RundownCast) PastAppearanceCount() int {
-	if c.AppearanceCount <= 1 {
-		return 0
-	}
-	return c.AppearanceCount - 1
+	return max(0, c.AppearanceCount-1)
 }
 
 // CastsForLLM returns a copy of casts with AppearanceCount replaced by PastAppearanceCount()
@@ -36,8 +33,8 @@ func (c RundownCast) PastAppearanceCount() int {
 func CastsForLLM(casts []RundownCast) []RundownCast {
 	result := make([]RundownCast, len(casts))
 	for i, c := range casts {
+		c.AppearanceCount = c.PastAppearanceCount()
 		result[i] = c
-		result[i].AppearanceCount = c.PastAppearanceCount()
 	}
 	return result
 }

--- a/internal/model/rundown.go
+++ b/internal/model/rundown.go
@@ -19,7 +19,27 @@ type RundownCast struct {
 	CharacterID     string `json:"character_id"`
 	Role            string `json:"role"`
 	Type            string `json:"type"`             // "regular" | "guest"
-	AppearanceCount int    `json:"appearance_count"` // 過去の出演エピソード数（今回含まず）。0 = 初登場
+	AppearanceCount int    `json:"appearance_count"` // その回を含めた出演回数。1 = 初登場（その回に初めて出演）
+}
+
+// PastAppearanceCount returns the number of past appearances (excluding this episode).
+// This is the LLM-facing value: AppearanceCount - 1, clamped to 0.
+func (c RundownCast) PastAppearanceCount() int {
+	if c.AppearanceCount <= 1 {
+		return 0
+	}
+	return c.AppearanceCount - 1
+}
+
+// CastsForLLM returns a copy of casts with AppearanceCount replaced by PastAppearanceCount()
+// for each element, converting from the persisted definition to the LLM-facing definition.
+func CastsForLLM(casts []RundownCast) []RundownCast {
+	result := make([]RundownCast, len(casts))
+	for i, c := range casts {
+		result[i] = c
+		result[i].AppearanceCount = c.PastAppearanceCount()
+	}
+	return result
 }
 
 type Rundown struct {

--- a/internal/rundown/flow/flow.go
+++ b/internal/rundown/flow/flow.go
@@ -105,13 +105,9 @@ func (d *LLMDesigner) DesignFlow(ctx context.Context, corner config.CornerConfig
 			Articles:        c.Articles,
 		}
 	}
-	casts := rundown.Casts
-	if casts == nil {
-		casts = make([]model.RundownCast, 0)
-	}
 	prog := programForPrompt{
 		Corners: programCorners,
-		Casts:   casts,
+		Casts:   model.CastsForLLM(rundown.Casts),
 	}
 	programJSON, err := json.Marshal(prog)
 	if err != nil {

--- a/internal/rundown/flow/flow_test.go
+++ b/internal/rundown/flow/flow_test.go
@@ -250,3 +250,31 @@ func TestLLMDesigner_DesignFlow_AppearanceCountIncludedInProgram(t *testing.T) {
 		t.Errorf("program JSON should contain appearance_count field for cast, got: %s", prompt)
 	}
 }
+
+func TestLLMDesigner_DesignFlow_AppearanceCountIsConverted(t *testing.T) {
+	// appearance_count in prompt should be PastAppearanceCount() (new_count - 1), not raw value
+	mc := &mockClient{
+		response: json.RawMessage(`{"flow":"フロー"}`),
+	}
+	d := flow.NewLLMDesigner(mc, "{{program}}", 0)
+
+	corner := config.CornerConfig{Title: "テック"}
+	target := model.RundownCorner{Title: "テック"}
+	rd := model.Rundown{
+		Corners: []model.RundownCorner{target},
+		Casts: []model.RundownCast{
+			{CharacterID: "zundamon", Role: "MC", Type: "regular", AppearanceCount: 5},
+		},
+	}
+
+	_, _ = d.DesignFlow(context.Background(), corner, flow.PositionOpening, target, rd)
+
+	if len(mc.captured) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	prompt := mc.captured[0].Messages[0].Content
+	// AppearanceCount=5 → PastAppearanceCount()=4 should appear in prompt
+	if !strings.Contains(prompt, `"appearance_count":4`) {
+		t.Errorf("program JSON should contain appearance_count:4 (converted from 5), got: %s", prompt)
+	}
+}

--- a/internal/rundown/select/select.go
+++ b/internal/rundown/select/select.go
@@ -87,11 +87,7 @@ func (s *LLMSelector) Select(ctx context.Context, corner config.CornerConfig, ar
 		return SelectResult{}, fmt.Errorf("marshal articles: %w", err)
 	}
 
-	casts := s.casts
-	if casts == nil {
-		casts = make([]model.RundownCast, 0)
-	}
-	castsJSON, err := json.Marshal(casts)
+	castsJSON, err := json.Marshal(model.CastsForLLM(s.casts))
 	if err != nil {
 		return SelectResult{}, fmt.Errorf("marshal casts: %w", err)
 	}

--- a/internal/rundown/select/select_test.go
+++ b/internal/rundown/select/select_test.go
@@ -113,6 +113,28 @@ func TestLLMSelector_SetCasts_PromptContainsCastInfo(t *testing.T) {
 	}
 }
 
+func TestLLMSelector_SetCasts_AppearanceCountIsConverted(t *testing.T) {
+	// appearance_count in prompt should be PastAppearanceCount() (new_count - 1), not the raw value
+	mc := &mockClient{
+		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),
+	}
+	s := sel.NewLLMSelector(mc, "{{casts}}", 0)
+	s.SetCasts([]model.RundownCast{
+		{CharacterID: "zundamon", Role: "MC", Type: "regular", AppearanceCount: 5},
+	})
+
+	_, _ = s.Select(context.Background(), config.CornerConfig{Title: "t"}, []model.Article{{URL: "u"}})
+
+	if len(mc.captured) == 0 {
+		t.Fatal("LLM was not called")
+	}
+	prompt := mc.captured[0].Messages[0].Content
+	// AppearanceCount=5 → PastAppearanceCount()=4 should appear in prompt
+	if !strings.Contains(prompt, `"appearance_count":4`) {
+		t.Errorf("prompt should contain appearance_count:4 (converted from 5), got: %s", prompt)
+	}
+}
+
 func TestLLMSelector_NoCasts_PromptHasEmptyArray(t *testing.T) {
 	mc := &mockClient{
 		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),

--- a/internal/script/write/format_test.go
+++ b/internal/script/write/format_test.go
@@ -19,8 +19,9 @@ func TestFormatCastInfo_NoGuests_ReturnsNoGuestMessage(t *testing.T) {
 }
 
 func TestFormatCastInfo_GuestFirstAppearance(t *testing.T) {
+	// AppearanceCount: 1 = 初登場（新定義: 今回含む出演回数）
 	casts := []model.RundownCast{
-		{CharacterID: "guest1", Role: "ゲスト", Type: "guest", AppearanceCount: 0},
+		{CharacterID: "guest1", Role: "ゲスト", Type: "guest", AppearanceCount: 1},
 	}
 	got := formatCastInfo(casts)
 	if !strings.Contains(got, "今回が初出演") {
@@ -29,8 +30,9 @@ func TestFormatCastInfo_GuestFirstAppearance(t *testing.T) {
 }
 
 func TestFormatCastInfo_GuestReturningAppearance(t *testing.T) {
+	// AppearanceCount: 4 = 今回が4回目（新定義）→ 過去3回出演
 	casts := []model.RundownCast{
-		{CharacterID: "guest1", Role: "ゲスト", Type: "guest", AppearanceCount: 3},
+		{CharacterID: "guest1", Role: "ゲスト", Type: "guest", AppearanceCount: 4},
 	}
 	got := formatCastInfo(casts)
 	if !strings.Contains(got, "過去3回出演") {
@@ -41,7 +43,7 @@ func TestFormatCastInfo_GuestReturningAppearance(t *testing.T) {
 func TestFormatCastInfo_NoDirectionRules(t *testing.T) {
 	// 演出ルールは追加しない
 	casts := []model.RundownCast{
-		{CharacterID: "guest1", Role: "ゲスト", Type: "guest", AppearanceCount: 0},
+		{CharacterID: "guest1", Role: "ゲスト", Type: "guest", AppearanceCount: 1},
 	}
 	got := formatCastInfo(casts)
 	// 演出ルール（初出演時に必ずリアクションする等）は含まれない

--- a/internal/script/write/write.go
+++ b/internal/script/write/write.go
@@ -309,8 +309,8 @@ func formatCastInfo(casts []model.RundownCast) string {
 	sb.WriteString("この回は以下のゲストが番組を通して（最初から最後まで）出演します:\n")
 	for _, g := range guests {
 		appearanceInfo := "（今回が初出演）"
-		if g.AppearanceCount > 0 {
-			appearanceInfo = fmt.Sprintf("（過去%d回出演）", g.AppearanceCount)
+		if past := g.PastAppearanceCount(); past > 0 {
+			appearanceInfo = fmt.Sprintf("（過去%d回出演）", past)
 		}
 		fmt.Fprintf(&sb, "- %s（役割: %s）%s\n", g.CharacterID, g.Role, appearanceInfo)
 	}


### PR DESCRIPTION
## Summary

- `RundownCast.AppearanceCount` の定義を「過去の出演回数（今回含まず・0始まり）」から「今回を含めた出演回数（1始まり）」に変更
- LLM へ渡す直前に逆変換（-1 クランプ）して、プロンプトの意味・文言は現状維持
- `PastAppearanceCount()` メソッドと `CastsForLLM()` ヘルパーを `model` 層に追加し、3経路（select / flow / write）で共通して利用
- `selectCasts` を `counts[id] + 1` に変更して永続値を新定義で生成

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/model/rundown.go` | `AppearanceCount` コメント更新・`PastAppearanceCount()`・`CastsForLLM()` 追加 |
| `internal/cli/util.go` | `selectCasts` を `counts[id]+1` に変更 |
| `internal/rundown/select/select.go` | `CastsForLLM()` 適用 |
| `internal/rundown/flow/flow.go` | `CastsForLLM()` 適用 |
| `internal/script/write/write.go` | `PastAppearanceCount()` 適用 |

ADR-0040（#295）で設計判断を記録済み。

Closes #293

---
🤖 Generated with [Claude Code](https://claude.ai/code)