### PR TITLE
feat: init コマンドでアセット設定ファイル（assets/assets.yaml）の雛形も生成する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ check-samples: build
 	./$(BINARY_NAME) --config vox-radio.yaml config check
 	./$(BINARY_NAME) --config internal/cli/templates/vox-radio.yaml config check
 	cd internal/cli/templates && "$(CURDIR)/$(BINARY_NAME)" episodegen check episode-spec.yaml
+	cd internal/cli/templates && "$(CURDIR)/$(BINARY_NAME)" assets check assets/assets.yaml
 	for f in examples/*.yaml; do ./$(BINARY_NAME) episodegen check "$$f"; done
 
 release-check:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ collect → rundown → script → synth → assemble → manifest
 
 | コマンド | 概要 |
 |----------|------|
-| `init` | カレントディレクトリに `vox-radio.yaml`・`episode-spec.yaml`・`feed-spec.yaml` のテンプレートを生成する（初回セットアップ用） |
+| `init` | カレントディレクトリに `vox-radio.yaml`・`episode-spec.yaml`・`feed-spec.yaml`・`slack-spec.yaml`・`assets/assets.yaml` のテンプレートを生成する（初回セットアップ用） |
 | `install --skills` | LLM エージェント向けスキルファイル（SKILL.md + references/*.md）を `.claude/skills/vox-radio/` にインストールする |
 | `episodegen` | collect → rundown → script → synth → assemble → manifest の全パイプラインを一括実行し 1 本のエピソードを生成する |
 | `episodegen collect` | `corners[].source` に定義したフィード・URL からコーナーごとに記事を収集し `01_articles.json` を生成する |
@@ -124,7 +124,7 @@ collect → rundown → script → synth → assemble → manifest
 
 ### 設定ファイルの作成
 
-`vox-radio init` を実行すると、カレントディレクトリに `vox-radio.yaml`（共通設定）・`episode-spec.yaml`（エピソード仕様）・`feed-spec.yaml`（フィード生成設定）・`slack-spec.yaml`（Slack 投稿設定）のテンプレートが生成されます。
+`vox-radio init` を実行すると、カレントディレクトリに `vox-radio.yaml`（共通設定）・`episode-spec.yaml`（エピソード仕様）・`feed-spec.yaml`（フィード生成設定）・`slack-spec.yaml`（Slack 投稿設定）・`assets/assets.yaml`（アセット設定）のテンプレートが生成されます。
 
 ```bash
 # テンプレートを生成

--- a/docs/cli/vox-radio_init.md
+++ b/docs/cli/vox-radio_init.md
@@ -4,7 +4,7 @@
 
 ### Synopsis
 
-vox-radio.yaml（共通設定）・episode-spec.yaml（エピソード仕様）・feed-spec.yaml（フィード生成設定）・slack-spec.yaml（Slack 投稿設定）を
+vox-radio.yaml（共通設定）・episode-spec.yaml（エピソード仕様）・feed-spec.yaml（フィード生成設定）・slack-spec.yaml（Slack 投稿設定）・assets/assets.yaml（アセット設定）を
 カレントディレクトリに生成します。
 
 既存ファイルは上書きを防ぐため個別にスキップされます。

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"strings"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
@@ -38,7 +38,10 @@ func newInitCmd() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("read template %s: %w", path, err)
 				}
-				outPath := strings.TrimPrefix(path, "templates/")
+				outPath, err := filepath.Rel("templates", path)
+				if err != nil {
+					return fmt.Errorf("rel path: %w", err)
+				}
 				return writeFile(cmd, outPath, content, false)
 			})
 		},

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -3,18 +3,20 @@ package cli
 import (
 	"embed"
 	"fmt"
+	"io/fs"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
-//go:embed templates/*.yaml
+//go:embed all:templates
 var templatesFS embed.FS
 
 func newInitCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "カレントディレクトリにテンプレート設定ファイルを生成する",
-		Long: `vox-radio.yaml（共通設定）・episode-spec.yaml（エピソード仕様）・feed-spec.yaml（フィード生成設定）・slack-spec.yaml（Slack 投稿設定）を
+		Long: `vox-radio.yaml（共通設定）・episode-spec.yaml（エピソード仕様）・feed-spec.yaml（フィード生成設定）・slack-spec.yaml（Slack 投稿設定）・assets/assets.yaml（アセット設定）を
 カレントディレクトリに生成します。
 
 既存ファイルは上書きを防ぐため個別にスキップされます。
@@ -25,20 +27,20 @@ func newInitCmd() *cobra.Command {
 
   vox-radio episodegen --spec episode-spec.yaml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			entries, err := templatesFS.ReadDir("templates")
-			if err != nil {
-				return fmt.Errorf("read templates: %w", err)
-			}
-			for _, e := range entries {
-				content, err := templatesFS.ReadFile("templates/" + e.Name())
+			return fs.WalkDir(templatesFS, "templates", func(path string, d fs.DirEntry, err error) error {
 				if err != nil {
-					return fmt.Errorf("read template %s: %w", e.Name(), err)
-				}
-				if err := writeFile(cmd, e.Name(), content, false); err != nil {
 					return err
 				}
-			}
-			return nil
+				if d.IsDir() {
+					return nil
+				}
+				content, err := templatesFS.ReadFile(path)
+				if err != nil {
+					return fmt.Errorf("read template %s: %w", path, err)
+				}
+				outPath := strings.TrimPrefix(path, "templates/")
+				return writeFile(cmd, outPath, content, false)
+			})
 		},
 	}
 }

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -62,9 +62,7 @@ func TestInitCmd_AllGenerated(t *testing.T) {
 func TestInitCmd_ConfigExists_EpisodeSpecGenerated(t *testing.T) {
 	dir := chdirTemp(t)
 	existingContent := []byte("# existing")
-	if err := os.WriteFile(filepath.Join(dir, "vox-radio.yaml"), existingContent, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dir, "vox-radio.yaml", existingContent)
 	out, err := runInitCmd(t)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -87,9 +85,7 @@ func TestInitCmd_ConfigExists_EpisodeSpecGenerated(t *testing.T) {
 func TestInitCmd_EpisodeSpecExists_ConfigGenerated(t *testing.T) {
 	dir := chdirTemp(t)
 	existingContent := []byte("# existing")
-	if err := os.WriteFile(filepath.Join(dir, "episode-spec.yaml"), existingContent, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dir, "episode-spec.yaml", existingContent)
 	out, err := runInitCmd(t)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -131,9 +127,7 @@ func TestInitCmd_AllExist_NothingGenerated(t *testing.T) {
 func TestInitCmd_FeedSpecExists_Skipped(t *testing.T) {
 	dir := chdirTemp(t)
 	existingContent := []byte("# existing")
-	if err := os.WriteFile(filepath.Join(dir, "feed-spec.yaml"), existingContent, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dir, "feed-spec.yaml", existingContent)
 	out, err := runInitCmd(t)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -231,9 +225,7 @@ func TestInitCmd_GeneratedFilesLoadable(t *testing.T) {
 func TestInitCmd_SlackSpecExists_Skipped(t *testing.T) {
 	dir := chdirTemp(t)
 	existingContent := []byte("# existing")
-	if err := os.WriteFile(filepath.Join(dir, "slack-spec.yaml"), existingContent, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dir, "slack-spec.yaml", existingContent)
 	out, err := runInitCmd(t)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -25,6 +25,17 @@ func chdirTemp(t *testing.T) string {
 	return dir
 }
 
+func writeTestFile(t *testing.T, dir, name string, content []byte) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func runInitCmd(t *testing.T) (string, error) {
 	t.Helper()
 	cmd := cli.NewRootCmd()
@@ -41,7 +52,7 @@ func TestInitCmd_AllGenerated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	for _, name := range []string{"vox-radio.yaml", "episode-spec.yaml", "feed-spec.yaml", "slack-spec.yaml"} {
+	for _, name := range []string{"vox-radio.yaml", "episode-spec.yaml", "feed-spec.yaml", "slack-spec.yaml", "assets/assets.yaml"} {
 		if _, err := os.Stat(filepath.Join(dir, name)); os.IsNotExist(err) {
 			t.Errorf("%s was not generated", name)
 		}
@@ -101,11 +112,9 @@ func TestInitCmd_EpisodeSpecExists_ConfigGenerated(t *testing.T) {
 func TestInitCmd_AllExist_NothingGenerated(t *testing.T) {
 	dir := chdirTemp(t)
 	existingContent := []byte("# existing")
-	allFiles := []string{"vox-radio.yaml", "episode-spec.yaml", "feed-spec.yaml", "slack-spec.yaml"}
+	allFiles := []string{"vox-radio.yaml", "episode-spec.yaml", "feed-spec.yaml", "slack-spec.yaml", "assets/assets.yaml"}
 	for _, name := range allFiles {
-		if err := os.WriteFile(filepath.Join(dir, name), existingContent, 0644); err != nil {
-			t.Fatal(err)
-		}
+		writeTestFile(t, dir, name, existingContent)
 	}
 	_, err := runInitCmd(t)
 	if err != nil {
@@ -138,6 +147,23 @@ func TestInitCmd_FeedSpecExists_Skipped(t *testing.T) {
 	}
 }
 
+func TestInitCmd_AssetsYamlExists_Skipped(t *testing.T) {
+	dir := chdirTemp(t)
+	existingContent := []byte("# existing")
+	writeTestFile(t, dir, "assets/assets.yaml", existingContent)
+	out, err := runInitCmd(t)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "assets", "assets.yaml"))
+	if string(data) != string(existingContent) {
+		t.Error("assets/assets.yaml should not be overwritten")
+	}
+	if !strings.Contains(out, "skip") {
+		t.Errorf("expected skip message for assets/assets.yaml, got: %s", out)
+	}
+}
+
 func TestInitCmd_GeneratedFilesLoadable(t *testing.T) {
 	dir := chdirTemp(t)
 	_, err := runInitCmd(t)
@@ -167,6 +193,9 @@ func TestInitCmd_GeneratedFilesLoadable(t *testing.T) {
 	}
 	if err := config.ValidateEpisodeSpecCast(spec); err != nil {
 		t.Fatalf("ValidateEpisodeSpecCast failed: %v", err)
+	}
+	if err := config.ValidateEpisodeSpecAssets(spec); err != nil {
+		t.Fatalf("ValidateEpisodeSpecAssets failed: %v", err)
 	}
 
 	// cache フィールドのアサート

--- a/internal/cli/templates/assets/assets.yaml
+++ b/internal/cli/templates/assets/assets.yaml
@@ -1,0 +1,44 @@
+# assets.yaml - アセット設定ファイル
+# ジングル・SE・BGM の素材ファイルとパラメータを定義します。
+# 素材バイナリ（mp3/wav 等）は別途用意してください。
+# 検証は vox-radio assets check assets/assets.yaml で実行できます。
+# パスはこのファイルのディレクトリを基準に解決されます。
+# 素材が不要な場合は episode-spec.yaml の assets_files をコメントアウトまたは削除してください。
+
+# jingle:
+#   opening:
+#     file: jingle/opening.mp3
+#     fade_in: 0.5
+#     fade_out: 0.5
+#     # trim_silence: false  # 省略時は true（素材前後の無音を自動除去）。無効にしたい場合のみ記載
+#     # trim_silence_threshold: -50  # 省略時は -50（dB）。素材のノイズフロアに合わせて調整
+#     description: "番組冒頭で流すオープニングジングル"  # 省略可
+#   ending:
+#     file: jingle/ending.mp3
+#     fade_in: 0.5
+#     fade_out: 1.0
+#     # trim_silence: false  # 省略時は true
+#     # trim_silence_threshold: -50  # 省略時は -50（dB）
+# se:
+#   chime:
+#     file: se/chime.wav
+#     volume: 0.8
+#     # trim_silence: false  # 省略時は true（素材前後の無音を自動除去）。無効にしたい場合のみ記載
+#     # trim_silence_threshold: -50  # 省略時は -50（dB）。素材のノイズフロアに合わせて調整
+#     # overlay: true  # 省略時は false（SE が鳴り終わってから次のセリフを再生）。セリフに重ねたい場合のみ true
+#     description: "話題の切り替わりに鳴らす明るいチャイム音"  # 省略可
+#   transition:
+#     file: se/transition.wav
+#     volume: 0.8
+#     # trim_silence: false  # 省略時は true
+#     # trim_silence_threshold: -50  # 省略時は -50（dB）
+#     # overlay: true  # 省略時は false（順次再生）
+# bgm:
+#   talk_bgm:
+#     file: bgm/talk.mp3
+#     volume: 0.3
+#     duck_ratio: 8
+#     loop: true
+#     # fade_in: 1.0   # フェードイン秒数（省略時デフォルト 1.0 秒）
+#     # fade_out: 1.0  # フェードアウト秒数（省略時デフォルト 1.0 秒）。0 指定でフェードなし
+#     description: "雑談向けの落ち着いたBGM"  # 省略可

--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -116,44 +116,7 @@ corners:
 # アセット設定ファイルのパスはこのエピソード仕様ファイルからの相対パスで解決されます。
 # 素材ファイルのパスはアセット設定ファイルのディレクトリを基準に解決されます。
 # 複数ファイルを指定した場合は後勝ちでマージされます。
-# 素材が不要な場合はこのセクション全体をコメントアウトするか削除してください。
-# assets_files:
-#   - assets/assets.yaml
-# アセット設定ファイル（assets/assets.yaml）の内容例:
-# jingle:
-#   opening:
-#     file: jingle/opening.mp3
-#     fade_in: 0.5
-#     fade_out: 0.5
-#     # trim_silence: false  # 省略時は true（素材前後の無音を自動除去）。無効にしたい場合のみ記載
-#     # trim_silence_threshold: -50  # 省略時は -50（dB）。素材のノイズフロアに合わせて調整
-#     description: "番組冒頭で流すオープニングジングル"  # 省略可
-#   ending:
-#     file: jingle/ending.mp3
-#     fade_in: 0.5
-#     fade_out: 1.0
-#     # trim_silence: false  # 省略時は true
-#     # trim_silence_threshold: -50  # 省略時は -50（dB）
-# se:
-#   chime:
-#     file: se/chime.wav
-#     volume: 0.8
-#     # trim_silence: false  # 省略時は true（素材前後の無音を自動除去）。無効にしたい場合のみ記載
-#     # trim_silence_threshold: -50  # 省略時は -50（dB）。素材のノイズフロアに合わせて調整
-#     # overlay: true  # 省略時は false（SE が鳴り終わってから次のセリフを再生）。セリフに重ねたい場合のみ true
-#     description: "話題の切り替わりに鳴らす明るいチャイム音"  # 省略可
-#   transition:
-#     file: se/transition.wav
-#     volume: 0.8
-#     # trim_silence: false  # 省略時は true
-#     # trim_silence_threshold: -50  # 省略時は -50（dB）
-#     # overlay: true  # 省略時は false（順次再生）
-# bgm:
-#   talk_bgm:
-#     file: bgm/talk.mp3
-#     volume: 0.3
-#     duck_ratio: 8
-#     loop: true
-#     # fade_in: 1.0   # フェードイン秒数（省略時デフォルト 1.0 秒）
-#     # fade_out: 1.0  # フェードアウト秒数（省略時デフォルト 1.0 秒）。0 指定でフェードなし
-#     description: "雑談向けの落ち着いたBGM"  # 省略可
+# アセットの記入例は assets/assets.yaml のコメントを参照してください。
+# 素材が不要な場合は assets_files をコメントアウトするか削除してください。
+assets_files:
+  - assets/assets.yaml

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -687,6 +689,9 @@ func loadEpisodeSpecWith(path string, strict bool) (*EpisodeSpec, error) {
 func loadAssetsFile(path string, strict bool) (AssetsConfig, error) {
 	var assets AssetsConfig
 	if err := fileio.DecodeYAML(path, &assets, strict); err != nil {
+		if errors.Is(err, io.EOF) {
+			return assets, nil
+		}
 		return AssetsConfig{}, fmt.Errorf("loading asset file: %w", err)
 	}
 	resolveAssetPaths(filepath.Dir(path), &assets)

--- a/internal/fileio/paths.go
+++ b/internal/fileio/paths.go
@@ -2,9 +2,7 @@ package fileio
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -76,7 +74,6 @@ func ReadJSON(path string, v any) error {
 
 // DecodeYAML opens the YAML file at path and decodes it into dest.
 // When strict is true, unknown fields cause an error.
-// An empty or comments-only file is treated as valid and leaves dest unchanged.
 func DecodeYAML(path string, dest any, strict bool) error {
 	f, err := os.Open(path)
 	if err != nil {
@@ -88,9 +85,6 @@ func DecodeYAML(path string, dest any, strict bool) error {
 		dec.KnownFields(true)
 	}
 	if err := dec.Decode(dest); err != nil {
-		if errors.Is(err, io.EOF) {
-			return nil
-		}
 		return fmt.Errorf("decode %s: %w", path, err)
 	}
 	return nil

--- a/internal/fileio/paths.go
+++ b/internal/fileio/paths.go
@@ -2,7 +2,9 @@ package fileio
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -74,6 +76,7 @@ func ReadJSON(path string, v any) error {
 
 // DecodeYAML opens the YAML file at path and decodes it into dest.
 // When strict is true, unknown fields cause an error.
+// An empty or comments-only file is treated as valid and leaves dest unchanged.
 func DecodeYAML(path string, dest any, strict bool) error {
 	f, err := os.Open(path)
 	if err != nil {
@@ -85,6 +88,9 @@ func DecodeYAML(path string, dest any, strict bool) error {
 		dec.KnownFields(true)
 	}
 	if err := dec.Decode(dest); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
 		return fmt.Errorf("decode %s: %w", path, err)
 	}
 	return nil

--- a/internal/fileio/paths_test.go
+++ b/internal/fileio/paths_test.go
@@ -30,6 +30,16 @@ func TestDecodeYAML(t *testing.T) {
 		checkResult func(t *testing.T, path string)
 	}{
 		{
+			name:    "empty (comments-only) YAML is valid",
+			content: "# just a comment\n",
+			checkResult: func(t *testing.T, path string) {
+				var got struct{ Name string }
+				if err := fileio.DecodeYAML(path, &got, false); err != nil {
+					t.Errorf("unexpected error for comments-only YAML: %v", err)
+				}
+			},
+		},
+		{
 			name:    "decodes valid YAML",
 			content: "name: ずんだもん\nage: 3\n",
 			checkResult: func(t *testing.T, path string) {

--- a/internal/fileio/paths_test.go
+++ b/internal/fileio/paths_test.go
@@ -1,6 +1,8 @@
 package fileio_test
 
 import (
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -30,12 +32,17 @@ func TestDecodeYAML(t *testing.T) {
 		checkResult func(t *testing.T, path string)
 	}{
 		{
-			name:    "empty (comments-only) YAML is valid",
+			name:    "empty (comments-only) YAML returns wrapped io.EOF",
 			content: "# just a comment\n",
 			checkResult: func(t *testing.T, path string) {
 				var got struct{ Name string }
-				if err := fileio.DecodeYAML(path, &got, false); err != nil {
-					t.Errorf("unexpected error for comments-only YAML: %v", err)
+				err := fileio.DecodeYAML(path, &got, false)
+				if err == nil {
+					t.Error("expected error for comments-only YAML, got nil")
+					return
+				}
+				if !errors.Is(err, io.EOF) {
+					t.Errorf("expected io.EOF in error chain, got: %v", err)
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

- `internal/cli/templates/assets/assets.yaml` を新規追加（jingle/se/bgm のコメントアウト記入例＋説明コメント）
- `internal/cli/templates/episode-spec.yaml` の重複アセット例コメントを削除し、`assets_files: [assets/assets.yaml]` をデフォルト有効化
- `internal/cli/init.go` を `all:templates` + `fs.WalkDir` + `filepath.Rel` でサブディレクトリ対応に変更
- `internal/fileio/paths.go` の EOF 処理を除去し、`config.go/loadAssetsFile` に移動（空 assets のみ許可する契約を明確化）
- `Makefile` の `check-samples` に `vox-radio assets check assets/assets.yaml` を追加

## Test plan

- [x] `go test ./internal/cli/... ./internal/fileio/... ./internal/config/...` 全通過
- [x] `make check-samples` 通過（`episodegen check` + `assets check` 両方）
- [x] `gofmt -l .` 無出力
- [x] `golangci-lint run ./...` 無指摘
- [x] `/simplify` 指摘を全件対応
- [x] self-review 指摘なし

## Related

Closes #297

🤖 Generated with [Claude Code](https://claude.ai/claude-code)