### PR TITLE
refactor: slack_spec.go の YAML decode を fileio.DecodeYAML に共通化

### DIFF
--- a/internal/model/slack_spec.go
+++ b/internal/model/slack_spec.go
@@ -3,9 +3,8 @@ package model
 import (
 	"errors"
 	"fmt"
-	"os"
 
-	"gopkg.in/yaml.v3"
+	"github.com/canpok1/vox-radio/internal/fileio"
 )
 
 const (
@@ -66,18 +65,9 @@ func LoadSlackSpecStrict(path string) (SlackSpec, error) {
 }
 
 func loadSlackSpecWith(path string, strict bool) (SlackSpec, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return SlackSpec{}, fmt.Errorf("read slack spec: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	dec := yaml.NewDecoder(f)
-	if strict {
-		dec.KnownFields(true)
-	}
 	var spec SlackSpec
-	if err := dec.Decode(&spec); err != nil {
-		return SlackSpec{}, fmt.Errorf("parse slack spec: %w", err)
+	if err := fileio.DecodeYAML(path, &spec, strict); err != nil {
+		return SlackSpec{}, fmt.Errorf("load slack spec: %w", err)
 	}
 	return spec, nil
 }


### PR DESCRIPTION
## 概要

`internal/model/slack_spec.go` の `loadSlackSpecWith` が `fileio.DecodeYAML` と同一パターン（`os.Open → yaml.NewDecoder → KnownFields → Decode`）を重複実装していたため、`fileio.DecodeYAML` の呼び出しに置き換えた。

Issue #226 で `config.go` と `feed_spec.go` の重複は解消済みだったが、`slack_spec.go` は対象外だったもの。`feed_spec.go` の `loadFeedSpecWith` と同じ形に揃えた。

## 変更内容

- `loadSlackSpecWith` の直接デコード処理（13行）を `fileio.DecodeYAML` の呼び出し（3行）に置き換え
- 不要になった `os` / `gopkg.in/yaml.v3` の import を削除し、`internal/fileio` を追加
- エラーメッセージを `read/parse slack spec` から `load slack spec` に統一（`feed_spec.go` と同様）

## 動作確認

- `go build ./...` 成功
- `go test ./internal/model/ ./internal/slack/` 成功（既存テストで網羅済み）
- `gofmt -l` / `go vet` 指摘なし
- ※ `golangci-lint` は実行環境の Go バージョン不整合（go1.25 build vs go1.26.1 target）により未実行

Closes #286

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0191cgVRfYCN4SjmBXCj6TLt)_