### PR TITLE
refactor: internal package CLIテストの os.Chdir パターンを chdirTemp ヘルパーに集約

### DIFF
--- a/internal/cli/internal_testhelper_test.go
+++ b/internal/cli/internal_testhelper_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"os"
+	"testing"
+)
+
+// chdirTemp は一時ディレクトリを作成してそこへ cwd を移動し、作成した
+// ディレクトリのパスを返す。テスト終了時に元の cwd へ自動で復帰する。
+// os.Chdir はプロセス全体の cwd を変更するため、利用するテストは並列禁止。
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	return dir
+}

--- a/internal/cli/util_test.go
+++ b/internal/cli/util_test.go
@@ -50,13 +50,7 @@ func TestResolveEpisodeNumber_EmptyProgramID(t *testing.T) {
 }
 
 func TestResolveEpisodeNumber_FirstEpisode(t *testing.T) {
-	// os.Chdir はプロセス全体の cwd を変更するため並列禁止
-	origDir, _ := os.Getwd()
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	chdirTemp(t)
 
 	cfg := &config.Config{Cache: config.CacheConfig{Enabled: true}}
 	// キャッシュファイルが存在しない場合は第1回
@@ -67,12 +61,7 @@ func TestResolveEpisodeNumber_FirstEpisode(t *testing.T) {
 }
 
 func TestResolveEpisodeNumber_WithExistingCache(t *testing.T) {
-	origDir, _ := os.Getwd()
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	tmpDir := chdirTemp(t)
 
 	writeCacheJSONL(t, tmpDir, "prog", []cache.Entry{
 		{EpisodeNumber: 3},
@@ -86,18 +75,7 @@ func TestResolveEpisodeNumber_WithExistingCache(t *testing.T) {
 }
 
 func TestSetupLogger_DefaultLogDir(t *testing.T) {
-	// os.Chdir changes the process-wide cwd, so no t.Parallel().
-	origDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatalf("chdir to tmpDir: %v", err)
-	}
-	defer func() {
-		_ = os.Chdir(origDir)
-	}()
+	tmpDir := chdirTemp(t)
 
 	logger, f, err := setupLogger("collect", "")
 	if err != nil {
@@ -216,12 +194,7 @@ func TestLoadCacheEntries_EmptyProgramID(t *testing.T) {
 }
 
 func TestLoadCacheEntries_ReturnsEntriesAndEpisodeNumber(t *testing.T) {
-	origDir, _ := os.Getwd()
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	defer func() { _ = os.Chdir(origDir) }()
+	tmpDir := chdirTemp(t)
 
 	writeCacheJSONL(t, tmpDir, "prog", []cache.Entry{
 		{EpisodeNumber: 5, Casts: []cache.CastEntry{


### PR DESCRIPTION
## 概要

`internal/cli/util_test.go` (`package cli`) に4回コピーされていた `os.Chdir` パターンを、`package cli` 専用の `chdirTemp` テストヘルパーに集約しました。

Closes #288

## 背景

- `internal/cli/util_test.go` に以下の `os.Chdir` パターンが4箇所コピーされていた:
  - `TestResolveEpisodeNumber_FirstEpisode`
  - `TestResolveEpisodeNumber_WithExistingCache`
  - `TestSetupLogger_DefaultLogDir`
  - `TestLoadCacheEntries_ReturnsEntriesAndEpisodeNumber`
- 3箇所では `origDir, _ := os.Getwd()` でエラーを無視し、1箇所では `err` をチェックしており一貫性がなかった。
- `init_test.go` の `chdirTemp` ヘルパーは `package cli_test` にあるため `package cli` からは参照できない。

## 変更内容

- `internal/cli/internal_testhelper_test.go` を新規作成し、`package cli` 用の `chdirTemp(t *testing.T) string` ヘルパーを追加。
  - 一時ディレクトリ作成 → `os.Chdir` → `t.Cleanup` で元の cwd へ復帰 → 作成した dir を返却。
  - エラーハンドリングを `t.Fatal` に統一。
- `util_test.go` の4箇所を `chdirTemp(t)` 呼び出しに置換。

## 確認

- `go test ./internal/cli/` パス
- `go vet ./internal/cli/` パス
- `gofmt -l` 差分なし
- `golangci-lint` は実行環境の Go バージョン制約（プロジェクトが go1.26.1 を要求、利用可能な lint バイナリが古い Go でビルド済み）により実行不可。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017g3oUAupeR4taFUCv4QVrZ)_