### PR TITLE
refactor: flow/select 間で重複する cornerForPrompt を prompt パッケージへ共通抽出

### DIFF
--- a/internal/rundown/flow/flow.go
+++ b/internal/rundown/flow/flow.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/rundown/prompt"
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
 
@@ -46,13 +47,6 @@ type Designer interface {
 	DesignFlow(ctx context.Context, corner config.CornerConfig, position Position, target model.RundownCorner, rundown model.Rundown) (string, error)
 }
 
-// cornerForPrompt はプロンプトに渡すコーナー情報（body 除外）。
-type cornerForPrompt struct {
-	Title                 string `json:"title"`
-	Content               string `json:"content"`
-	TargetDurationSeconds int    `json:"target_duration_seconds"`
-}
-
 // cornerForProgram はプロンプトに渡す番組全体コーナー情報。
 type cornerForProgram struct {
 	Title           string                 `json:"title"`
@@ -82,11 +76,7 @@ func NewLLMDesigner(client llm.Client, promptTemplate string, temperature float6
 }
 
 func (d *LLMDesigner) DesignFlow(ctx context.Context, corner config.CornerConfig, position Position, target model.RundownCorner, rundown model.Rundown) (string, error) {
-	cp := cornerForPrompt{
-		Title:                 corner.Title,
-		Content:               corner.Content,
-		TargetDurationSeconds: corner.LengthSec,
-	}
+	cp := prompt.NewCornerForPrompt(corner)
 	cornerJSON, err := json.Marshal(cp)
 	if err != nil {
 		return "", fmt.Errorf("marshal corner: %w", err)

--- a/internal/rundown/prompt/prompt.go
+++ b/internal/rundown/prompt/prompt.go
@@ -1,0 +1,22 @@
+// Package prompt は rundown の flow / select サブパッケージで共有する
+// LLM プロンプト用のデータ型を提供する。
+package prompt
+
+import "github.com/canpok1/vox-radio/internal/config"
+
+// CornerForPrompt はプロンプトに渡すコーナー情報（body 除外）。
+// flow / select の両サブパッケージで共通利用する。
+type CornerForPrompt struct {
+	Title                 string `json:"title"`
+	Content               string `json:"content"`
+	TargetDurationSeconds int    `json:"target_duration_seconds"`
+}
+
+// NewCornerForPrompt は config.CornerConfig から CornerForPrompt を構築する。
+func NewCornerForPrompt(corner config.CornerConfig) CornerForPrompt {
+	return CornerForPrompt{
+		Title:                 corner.Title,
+		Content:               corner.Content,
+		TargetDurationSeconds: corner.LengthSec,
+	}
+}

--- a/internal/rundown/prompt/prompt_test.go
+++ b/internal/rundown/prompt/prompt_test.go
@@ -1,0 +1,29 @@
+package prompt
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+)
+
+func TestNewCornerForPrompt(t *testing.T) {
+	corner := config.CornerConfig{Title: "コーナー1", Content: "内容", LengthSec: 30}
+	got := NewCornerForPrompt(corner)
+	want := CornerForPrompt{Title: "コーナー1", Content: "内容", TargetDurationSeconds: 30}
+	if got != want {
+		t.Errorf("NewCornerForPrompt() = %+v, want %+v", got, want)
+	}
+}
+
+func TestCornerForPrompt_JSONTags(t *testing.T) {
+	cp := CornerForPrompt{Title: "タイトル", Content: "本文", TargetDurationSeconds: 45}
+	b, err := json.Marshal(cp)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	want := `{"title":"タイトル","content":"本文","target_duration_seconds":45}`
+	if got := string(b); got != want {
+		t.Errorf("Marshal() = %s, want %s", got, want)
+	}
+}

--- a/internal/rundown/select/select.go
+++ b/internal/rundown/select/select.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/rundown/prompt"
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
 
@@ -38,13 +39,6 @@ type articleForPrompt struct {
 	Title string `json:"title"`
 }
 
-// cornerForPrompt is the subset of corner data passed to the LLM.
-type cornerForPrompt struct {
-	Title                 string `json:"title"`
-	Content               string `json:"content"`
-	TargetDurationSeconds int    `json:"target_duration_seconds"`
-}
-
 type selectResponse struct {
 	SelectedURLs    []string `json:"selected_urls"`
 	SelectionReason string   `json:"selection_reason"`
@@ -68,11 +62,7 @@ func (s *LLMSelector) SetCasts(casts []model.RundownCast) {
 }
 
 func (s *LLMSelector) Select(ctx context.Context, corner config.CornerConfig, articles []model.Article) (SelectResult, error) {
-	cp := cornerForPrompt{
-		Title:                 corner.Title,
-		Content:               corner.Content,
-		TargetDurationSeconds: corner.LengthSec,
-	}
+	cp := prompt.NewCornerForPrompt(corner)
 	cornerJSON, err := json.Marshal(cp)
 	if err != nil {
 		return SelectResult{}, fmt.Errorf("marshal corner: %w", err)


### PR DESCRIPTION
## 概要

Issue #269 の対応。`internal/rundown/flow` と `internal/rundown/select` に存在した同一構造の `cornerForPrompt` 型を、新規 `internal/rundown/prompt` パッケージへ共通抽出した。

## 背景

- `flow.go` / `select.go` にフィールドが完全一致（`Title` / `Content` / `TargetDurationSeconds`、JSONタグも同一）の `cornerForPrompt` 型が重複していた。
- 親パッケージ `internal/rundown` は両サブパッケージを import しているため共通型の置き場所にできず、新規サブパッケージ `internal/rundown/prompt` として切り出した。

## 変更内容

- `internal/rundown/prompt/prompt.go` を新設
  - `CornerForPrompt` 型を定義
  - `config.CornerConfig` から構築する `NewCornerForPrompt` ヘルパーを追加（`LengthSec → TargetDurationSeconds` の詰め替えも共通化）
- `flow.go` / `select.go` のローカル `cornerForPrompt` 型を削除し、`prompt.NewCornerForPrompt(corner)` に置換
- `internal/rundown/prompt/prompt_test.go` を追加（構築テスト・JSONタグ契約テスト）

## 設計判断（不採用案）

Issue 本文の対応方針候補2「`config.CornerConfig` を直接 marshal」は不採用とした。理由:

- `CornerConfig` は `yaml` タグのみで `json` タグを持たず、直接 marshal するとプロンプトが期待する `target_duration_seconds` キーにならない
- `Direction` / `Cast` / `Source` 等の余計なフィールドが LLM に渡り、「body 除外でトークン節約」という設計目的に反する

`internal/model/` への配置も検討したが、`model` は `config` 非依存の最下層であり、`config.CornerConfig` に依存する本型を置くと層構造を壊すため見送った。`script/write` がプロンプトDTOをローカルに持つ既存慣行とも整合する。

## テスト

- `go test ./internal/rundown/...` 全通過
- `gofmt -l` / `go vet` クリーン
- ※ `golangci-lint` はローカル環境の Go バージョン不整合（go1.25 でビルドされた lint が go1.26.1 を解釈できず）で実行不可。CI で確認する。

Closes #269

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADJYvxb9ymct1jdPkkBr5Y)_