### PR TITLE
サンプルのepisode-specからassets_filesを参照させる

### DIFF
--- a/docs/adr/0041-sample-config-generation-command.md
+++ b/docs/adr/0041-sample-config-generation-command.md
@@ -20,7 +20,7 @@
 記入済みの「すぐ動くサンプル設定一式」をバイナリに `//go:embed` で同梱し、`vox-radio init --sample` で生成する。
 
 - スケルトン雛形を生成する従来の `vox-radio init`（フラグなし）はそのまま残す。`--sample` はゼロから作るユーザーではなく「まず動かして体験したい」ユーザー向けに、ずんだもん・めたんが MC を務める一般向けニュース番組（バラエティ風）の完成済み構成を生成する。
-- サンプルには音声バイナリを含めない（容量削減）。音声アセットに依存する設定（`corners[].start_audio` / `end_audio` / `bgm`、`assets_files`、`assets/assets.yaml` の中身）はコメントアウトした記入例として同梱し、ユーザーが音声素材を用意してから有効化できるようにする。
+- サンプルには音声バイナリを含めない（容量削減）。音声バイナリに依存する設定（`corners[].start_audio` / `end_audio` / `bgm`、`assets/assets.yaml` の中身）はコメントアウトした記入例として同梱し、ユーザーが音声素材を用意してから有効化できるようにする。一方 `episode-spec.yaml` の `assets_files` 参照は有効のままとし、中身が空（全コメント）の `assets/assets.yaml` を指す。これにより spec → アセット設定ファイルの配線をサンプルで示しつつ、ユーザーは `episode-spec.yaml` を編集せず `assets.yaml` のコメントを外すだけで音を追加できる（音声バイナリ非同梱でも `check` は空アセットとして通る）。
 - リポジトリ同梱の `examples/` ディレクトリ（`tech.yaml`・音声 mp3・README）を廃止する。`Makefile` の `run-sample` / `check-samples`、README、各コマンドの `Long` 例の参照は、`init --sample` で生成したサンプルを用いる形に置き換える。
 
 ## 結果

--- a/internal/cli/templates-sample/episode-spec.yaml
+++ b/internal/cli/templates-sample/episode-spec.yaml
@@ -125,7 +125,10 @@ corners:
     summary_length: 60
     # 末尾コーナーなので、この後の無音（end_pause_sec）は入れません。
 
-# 効果音やBGMを使う場合は、音声ファイルを用意したうえで、
-# 下の行頭の # を外し、各コーナーに start_audio / end_audio / bgm を追記してください。
-# assets_files:
-#   - assets/assets.yaml
+# 効果音やBGMの設定ファイル（ジングル・SE・BGM）の参照。
+# 音声ファイル（mp3 など）は別途自分で用意してください。
+# 書き方の例は assets/assets.yaml のコメントを参照し、
+# 使う音を各コーナーに start_audio / end_audio / bgm として追記してください。
+# 効果音やBGMが不要なら assets_files をコメントアウトするか削除してください。
+assets_files:
+  - assets/assets.yaml


### PR DESCRIPTION
## 概要

`init --sample` で生成する `episode-spec.yaml` の `assets_files` 参照がコメントアウトされており、spec からアセット設定ファイルを参照していませんでした（素の `templates/` 側は有効化されており食い違っていた）。

サンプルでも spec → アセット設定ファイルの配線を示すよう、`assets_files` を有効化します。

## 変更内容

- `internal/cli/templates-sample/episode-spec.yaml`: `assets_files: - assets/assets.yaml` を有効化（コメント解除）。`assets/assets.yaml` の中身（jingle / se / bgm）は記入例としてコメントのまま据え置き。
- `docs/adr/0041-sample-config-generation-command.md`: 「`assets_files` もコメントアウト」としていた記述を、「`assets_files` 参照は有効のまま、空（全コメント）の `assets.yaml` を指す」方針に補正。

## 補足

`assets/assets.yaml` の中身が全コメント＝空アセットのため、`assets_files` を有効化しても音声バイナリは不要で、`check` は空アセットとして通ります。ユーザーは `episode-spec.yaml` を編集せず `assets.yaml` のコメントを外すだけで音を追加できます。

## 動作確認

- `make check-samples` 全項目 OK（`init --sample` → `episodegen check sample/episode-spec.yaml` が有効化した `assets_files` 込みでパス）。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7aqnKiVe1XL1iwzmeVZMD)_