### PR TITLE
refactor: JingleEntry/SEEntry の Validate() に TrimSilenceThreshold チェックを移動する

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -61,7 +61,7 @@ func (e JingleEntry) Validate() error {
 	if err := validateNonNegative("fade_out", e.FadeOut); err != nil {
 		return err
 	}
-	return validateNegativeDB("trim_silence_threshold", e.TrimSilenceThreshold)
+	return validateOptionalNegative("trim_silence_threshold", e.TrimSilenceThreshold)
 }
 
 type SEEntry struct {
@@ -90,7 +90,7 @@ func (e SEEntry) Validate() error {
 	if err := validateNonNegative("volume", e.Volume); err != nil {
 		return err
 	}
-	return validateNegativeDB("trim_silence_threshold", e.TrimSilenceThreshold)
+	return validateOptionalNegative("trim_silence_threshold", e.TrimSilenceThreshold)
 }
 
 // effectiveTrimSilence returns true when v is nil (default) or points to true.
@@ -776,9 +776,8 @@ func validateFileField(category, name, file string) error {
 	return nil
 }
 
-// validateNegativeDB returns an error if v is non-nil and *v >= 0.
-// Used for dB threshold fields that must be strictly negative.
-func validateNegativeDB(field string, v *float64) error {
+// validateOptionalNegative returns an error if v is non-nil and *v >= 0.
+func validateOptionalNegative(field string, v *float64) error {
 	if v != nil && *v >= 0 {
 		return fmt.Errorf("%s: must be < 0 (dB), got %v", field, *v)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,7 +58,10 @@ func (e JingleEntry) Validate() error {
 	if err := validateNonNegative("fade_in", e.FadeIn); err != nil {
 		return err
 	}
-	return validateNonNegative("fade_out", e.FadeOut)
+	if err := validateNonNegative("fade_out", e.FadeOut); err != nil {
+		return err
+	}
+	return validateNegativeDB("trim_silence_threshold", e.TrimSilenceThreshold)
 }
 
 type SEEntry struct {
@@ -84,7 +87,10 @@ func (e SEEntry) EffectiveOverlay() bool { return e.Overlay != nil && *e.Overlay
 
 // Validate checks that field values are in valid ranges.
 func (e SEEntry) Validate() error {
-	return validateNonNegative("volume", e.Volume)
+	if err := validateNonNegative("volume", e.Volume); err != nil {
+		return err
+	}
+	return validateNegativeDB("trim_silence_threshold", e.TrimSilenceThreshold)
 }
 
 // effectiveTrimSilence returns true when v is nil (default) or points to true.
@@ -770,9 +776,11 @@ func validateFileField(category, name, file string) error {
 	return nil
 }
 
-func validateTrimSilenceThresholdDB(category, name string, v *float64) error {
+// validateNegativeDB returns an error if v is non-nil and *v >= 0.
+// Used for dB threshold fields that must be strictly negative.
+func validateNegativeDB(field string, v *float64) error {
 	if v != nil && *v >= 0 {
-		return fmt.Errorf("%s[%q].trim_silence_threshold: must be < 0 (dB), got %v", category, name, *v)
+		return fmt.Errorf("%s: must be < 0 (dB), got %v", field, *v)
 	}
 	return nil
 }
@@ -786,9 +794,6 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		if err := entry.Validate(); err != nil {
 			return fmt.Errorf("jingle[%q]: %w", name, err)
 		}
-		if err := validateTrimSilenceThresholdDB("jingle", name, entry.TrimSilenceThreshold); err != nil {
-			return err
-		}
 	}
 	for name, entry := range assets.SE {
 		if err := validateFileField("se", name, entry.File); err != nil {
@@ -796,9 +801,6 @@ func ValidateAssetsConfig(assets *AssetsConfig) error {
 		}
 		if err := entry.Validate(); err != nil {
 			return fmt.Errorf("se[%q]: %w", name, err)
-		}
-		if err := validateTrimSilenceThresholdDB("se", name, entry.TrimSilenceThreshold); err != nil {
-			return err
 		}
 	}
 	for name, entry := range assets.BGM {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1674,6 +1674,10 @@ func TestJingleEntry_Validate(t *testing.T) {
 		{"valid positive values", config.JingleEntry{FadeIn: 0.5, FadeOut: 1.0}, false},
 		{"fade_in negative", config.JingleEntry{FadeIn: -1.0, FadeOut: 0}, true},
 		{"fade_out negative", config.JingleEntry{FadeIn: 0, FadeOut: -0.5}, true},
+		{"trim_silence_threshold nil is valid", config.JingleEntry{TrimSilenceThreshold: nil}, false},
+		{"trim_silence_threshold negative is valid", config.JingleEntry{TrimSilenceThreshold: float64Ptr(-40.0)}, false},
+		{"trim_silence_threshold zero is invalid", config.JingleEntry{TrimSilenceThreshold: float64Ptr(0.0)}, true},
+		{"trim_silence_threshold positive is invalid", config.JingleEntry{TrimSilenceThreshold: float64Ptr(1.0)}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -1694,6 +1698,10 @@ func TestSEEntry_Validate(t *testing.T) {
 		{"valid zero volume", config.SEEntry{Volume: 0}, false},
 		{"valid positive volume", config.SEEntry{Volume: 0.8}, false},
 		{"volume negative", config.SEEntry{Volume: -0.1}, true},
+		{"trim_silence_threshold nil is valid", config.SEEntry{TrimSilenceThreshold: nil}, false},
+		{"trim_silence_threshold negative is valid", config.SEEntry{TrimSilenceThreshold: float64Ptr(-40.0)}, false},
+		{"trim_silence_threshold zero is invalid", config.SEEntry{TrimSilenceThreshold: float64Ptr(0.0)}, true},
+		{"trim_silence_threshold positive is invalid", config.SEEntry{TrimSilenceThreshold: float64Ptr(1.0)}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `JingleEntry.Validate()` と `SEEntry.Validate()` に `trim_silence_threshold < 0 (dB)` チェックを追加
- `ValidateAssetsConfig` から `validateTrimSilenceThresholdDB` の直接呼び出しを除去し、`entry.Validate()` に委譲
- `validateTrimSilenceThresholdDB` を汎用ヘルパー `validateOptionalNegative` に置き換え（`validateOptionalNonNegative` との命名一貫性確保）

### 背景

フィールド範囲チェックを各エントリ型の `Validate()` に集約する設計方針に一貫させる。
従来は `ValidateAssetsConfig` が `validateTrimSilenceThresholdDB` を直接呼んでおり、
`Validate()` を直接呼ぶコードが書かれた場合に `TrimSilenceThreshold` の検査が抜け落ちるリスクがあった。

Closes #290

---
🤖 Generated with [Claude Code](https://claude.ai/code)