### PR TITLE
refactor: slackpost_test / ingest_test のテストヘルパーを整理する

### DIFF
--- a/internal/cli/feedgen_check_test.go
+++ b/internal/cli/feedgen_check_test.go
@@ -2,8 +2,6 @@ package cli_test
 
 import (
 	"bytes"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -34,18 +32,13 @@ func TestFeedgenCheck_UnknownKey_Error(t *testing.T) {
 }
 
 func TestFeedgenCheck_MissingRequiredField_Error(t *testing.T) {
-	dir := t.TempDir()
-	specPath := filepath.Join(dir, "feed-spec.yaml")
 	// feed.language が欠落した feed-spec.yaml
-	content := []byte(`feed:
+	specPath := writeFeedSpecForTest(t, []byte(`feed:
   author: Test Author
   email: test@example.com
   site_url: https://example.com/
   audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"
-`)
-	if err := os.WriteFile(specPath, content, 0o644); err != nil {
-		t.Fatalf("write spec: %v", err)
-	}
+`))
 
 	cmd := cli.NewRootCmd()
 	errBuf := &bytes.Buffer{}
@@ -59,19 +52,14 @@ func TestFeedgenCheck_MissingRequiredField_Error(t *testing.T) {
 
 // program_id は FeedSpec から削除されたため、feedgen check で unknown key エラーになること
 func TestFeedgenCheck_ProgramID_RaisesUnknownKey(t *testing.T) {
-	dir := t.TempDir()
-	specPath := filepath.Join(dir, "feed-spec.yaml")
-	content := []byte(`program_id: my-radio
+	specPath := writeFeedSpecForTest(t, []byte(`program_id: my-radio
 feed:
   language: ja
   author: Test Author
   email: test@example.com
   site_url: https://example.com/
   audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"
-`)
-	if err := os.WriteFile(specPath, content, 0o644); err != nil {
-		t.Fatalf("write spec: %v", err)
-	}
+`))
 
 	cmd := cli.NewRootCmd()
 	cmd.SetArgs([]string{"feedgen", "check", specPath})

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -1,8 +1,10 @@
 package cli_test
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
+	"testing"
 )
 
 // cliTestSrcDir is the absolute path of this test file's directory, resolved at init time.
@@ -15,4 +17,14 @@ func init() {
 
 func configTestdataPath(rel string) string {
 	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
+}
+
+func writeFeedSpecForTest(t *testing.T, content []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "feed-spec.yaml")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write feed spec: %v", err)
+	}
+	return path
 }

--- a/internal/feed/ingest_test.go
+++ b/internal/feed/ingest_test.go
@@ -24,6 +24,14 @@ func writeFeedSpecYAML(t *testing.T, path string, cfg model.FeedSpec) {
 	}
 }
 
+func setupIngestDirs(t *testing.T) (cachePath, specPath, publicDir string) {
+	t.Helper()
+	dir := t.TempDir()
+	return filepath.Join(dir, "cache.jsonl"),
+		filepath.Join(dir, "feed-spec.yaml"),
+		filepath.Join(dir, "public")
+}
+
 func writeCacheJSONL(t *testing.T, path string, entries []cache.Entry) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
@@ -43,10 +51,7 @@ func writeCacheJSONL(t *testing.T, path string, entries []cache.Entry) {
 }
 
 func TestRun_GeneratesFeedXML(t *testing.T) {
-	dir := t.TempDir()
-	cachePath := filepath.Join(dir, "cache.jsonl")
-	specPath := filepath.Join(dir, "feed-spec.yaml")
-	publicDir := filepath.Join(dir, "public")
+	cachePath, specPath, publicDir := setupIngestDirs(t)
 
 	entries := []cache.Entry{
 		{
@@ -98,10 +103,7 @@ func TestRun_GeneratesFeedXML(t *testing.T) {
 
 // program_id フィルタが廃止されたため、cache の全エントリが対象になること
 func TestRun_AllEntriesIncluded_WhenProgramIDsDiffer(t *testing.T) {
-	dir := t.TempDir()
-	cachePath := filepath.Join(dir, "cache.jsonl")
-	specPath := filepath.Join(dir, "feed-spec.yaml")
-	publicDir := filepath.Join(dir, "public")
+	cachePath, specPath, publicDir := setupIngestDirs(t)
 
 	entries := []cache.Entry{
 		{
@@ -145,10 +147,7 @@ func TestRun_AllEntriesIncluded_WhenProgramIDsDiffer(t *testing.T) {
 }
 
 func TestRun_ErrorOnEpisodeNumberZero(t *testing.T) {
-	dir := t.TempDir()
-	cachePath := filepath.Join(dir, "cache.jsonl")
-	specPath := filepath.Join(dir, "feed-spec.yaml")
-	publicDir := filepath.Join(dir, "public")
+	cachePath, specPath, publicDir := setupIngestDirs(t)
 
 	entries := []cache.Entry{
 		{
@@ -179,10 +178,7 @@ func TestRun_ErrorOnEpisodeNumberZero(t *testing.T) {
 }
 
 func TestRun_EmptyCache(t *testing.T) {
-	dir := t.TempDir()
-	cachePath := filepath.Join(dir, "cache.jsonl")
-	specPath := filepath.Join(dir, "feed-spec.yaml")
-	publicDir := filepath.Join(dir, "public")
+	cachePath, specPath, publicDir := setupIngestDirs(t)
 
 	writeCacheJSONL(t, cachePath, []cache.Entry{})
 


### PR DESCRIPTION
## Summary

- `internal/feed/ingest_test.go`: 全4テストで繰り返されていた `dir/cachePath/specPath/publicDir` の4行セットアップを `setupIngestDirs(t)` ヘルパーに抽出
- `internal/cli/testhelper_test.go`: `writeFeedSpecForTest(t, content []byte)` ヘルパーを追加し、`feedgen_check_test.go` の2テストで繰り返されていた `t.TempDir` + `filepath.Join` + `os.WriteFile` の3行パターンを排除

Closes #319

---
🤖 Generated with [Claude Code](https://claude.ai/code)