### PR TITLE
feat: 組み込みプロンプト評価フレームワークを導入する（proofread.md の LLM-as-judge 評価）

### DIFF
--- a/.github/workflows/prompt-eval.yml
+++ b/.github/workflows/prompt-eval.yml
@@ -1,0 +1,23 @@
+name: prompt-eval
+
+on:
+  schedule:
+    - cron: '0 2 * * 0'  # 週次 (UTC 日曜 02:00)
+  workflow_dispatch:
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+
+    env:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run prompt evaluation
+        run: make eval

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ check-samples: build
 release-check:
 	goreleaser check
 
+eval:
+	go test -tags=eval -count=1 -v ./internal/eval/...
+
 all: build
 
-.PHONY: all setup build clean test fmt lint install docs check-samples run-sample release-check
+.PHONY: all setup build clean test fmt lint install docs check-samples run-sample release-check eval

--- a/README.md
+++ b/README.md
@@ -25,6 +25,39 @@
 
 > **注意:** `.devcontainer/.env` には秘密情報が含まれるため、コミットしないこと（`.gitignore` で除外済み）。
 
+## プロンプト品質評価フレームワーク
+
+組み込みプロンプト（`internal/cli/prompts/*.md`）の品質を LLM-as-judge 方式で自動採点します。
+第一弾として `proofread.md`（発音校正プロンプト）を対象にしています。
+
+### 実行方法
+
+```bash
+export GEMINI_API_KEY=<your-api-key>
+make eval
+```
+
+### 主な環境変数
+
+| 変数名 | 説明 | デフォルト |
+|---|---|---|
+| `GEMINI_API_KEY` | Gemini API キー（必須） | — |
+| `VOX_EVAL_MODEL` | 対象実行・judge に使うモデル | `gemini-3.1-flash-lite` |
+| `VOX_EVAL_JUDGE_MODEL` | judge のみモデルを上書き | `VOX_EVAL_MODEL` と同じ |
+| `VOX_EVAL_MIN_INTERVAL_MS` | API 呼び出しの最低間隔（ms） | `4500` |
+| `VOX_EVAL_PROOFREAD_THRESHOLD` | 合否閾値（全体平均スコア） | `4.0` |
+| `VOX_EVAL_SAMPLE_SIZE` | 汎化プールからのサンプル数 | `8` |
+| `VOX_EVAL_SAMPLE_SEED` | サンプリング seed（省略時 = ISO 週番号） | ISO 週番号 |
+
+### 評価の仕組み（二層データセット）
+
+- **回帰セット**（`testdata/proofread_regression_cases.json`）: 連濁・熟字訓など既知の致命的誤読を必ず検出することを保証する固定ケース。毎回全件実行し、`expectation`（正解説明）付きで採点します。
+- **汎化プール**（`testdata/proofread_pool_cases.json`）: 多様な語彙・文型を貯めたプールから週番号 seed でサンプリングし、judge が `original_text` から自律採点します。同一週は再現可能、週またぎで対象が入れ替わり固定データへの過適応を防ぎます。
+
+4 観点（検出網羅性・誤検出抑制・修正正確さ・理由妥当性）を各 1〜5 点で採点し、全ケース×全観点の平均が閾値（デフォルト 4.0）以上で合格です。レートリミット・API エラーは inconclusive（`t.Skip`）扱いで fail にしません。
+
+評価は週次の GitHub Actions ワークフロー（`.github/workflows/prompt-eval.yml`）でも自動実行されます。通常の開発 CI（`build.yml`）は変更せず、実 API を叩きません。
+
 ## リリース設定の検証
 
 `.goreleaser.yaml` を編集した後は、CI を待たずにローカルで構文・設定を検証できます。

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -1,0 +1,132 @@
+package eval
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// Criterion represents a scoring dimension for LLM-as-judge evaluation.
+type Criterion string
+
+const (
+	CriterionDetectionRecall          Criterion = "detection_recall"
+	CriterionFalsePositiveSuppression Criterion = "false_positive_suppression"
+	CriterionCorrectionAccuracy       Criterion = "correction_accuracy"
+	CriterionReasonValidity           Criterion = "reason_validity"
+)
+
+// AllCriteria lists all scoring dimensions in canonical order.
+var AllCriteria = []Criterion{
+	CriterionDetectionRecall,
+	CriterionFalsePositiveSuppression,
+	CriterionCorrectionAccuracy,
+	CriterionReasonValidity,
+}
+
+// ScoreEntry holds the score and reason for one criterion.
+type ScoreEntry struct {
+	Criterion Criterion `json:"criterion"`
+	Score     int       `json:"score"`
+	Reason    string    `json:"reason"`
+}
+
+// CaseResult holds the judge scores for one evaluation case.
+type CaseResult struct {
+	CaseName string
+	SetType  string // "regression" or "generalization"
+	Scores   []ScoreEntry
+}
+
+// Aggregation holds aggregated scores.
+type Aggregation struct {
+	Overall     float64
+	ByCriterion map[Criterion]float64
+}
+
+// AggregateScores computes the overall average and per-criterion averages.
+func AggregateScores(results []CaseResult) Aggregation {
+	if len(results) == 0 {
+		return Aggregation{ByCriterion: make(map[Criterion]float64)}
+	}
+
+	sums := make(map[Criterion]float64)
+	counts := make(map[Criterion]int)
+	total := 0.0
+	totalN := 0
+
+	for _, r := range results {
+		for _, s := range r.Scores {
+			sums[s.Criterion] += float64(s.Score)
+			counts[s.Criterion]++
+			total += float64(s.Score)
+			totalN++
+		}
+	}
+
+	byC := make(map[Criterion]float64, len(sums))
+	for c, sum := range sums {
+		byC[c] = sum / float64(counts[c])
+	}
+
+	return Aggregation{
+		Overall:     total / float64(totalN),
+		ByCriterion: byC,
+	}
+}
+
+// inconclusivePatterns are error substrings that indicate infrastructure failures
+// rather than quality failures.
+var inconclusivePatterns = []string{
+	"http do:",
+	"dial tcp",
+	"connection refused",
+	"status 429",
+	"rate limit",
+	"context deadline exceeded",
+	"context canceled",
+	"timeout",
+	"EOF",
+	"no such host",
+	"status 5",
+}
+
+// IsInconclusive returns true when err represents a transient infrastructure
+// problem (network, rate limit, API outage) rather than a quality failure.
+func IsInconclusive(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, p := range inconclusivePatterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// BuildLLMConfig constructs an llm.Config from environment variables.
+// apiKeyEnv, modelEnv, intervalEnv are the names of the env vars to read.
+func BuildLLMConfig(apiKeyEnv, modelEnv, intervalEnv string) llm.Config {
+	model := os.Getenv(modelEnv)
+	if model == "" {
+		model = llm.DefaultModel
+	}
+
+	intervalMS := config.DefaultMinRequestIntervalMS
+	if v := os.Getenv(intervalEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			intervalMS = n
+		}
+	}
+
+	return llm.Config{
+		APIKey:               os.Getenv(apiKeyEnv),
+		Model:                model,
+		MinRequestIntervalMS: intervalMS,
+	}
+}

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -1,0 +1,118 @@
+package eval
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCriterionValues(t *testing.T) {
+	criteria := []Criterion{
+		CriterionDetectionRecall,
+		CriterionFalsePositiveSuppression,
+		CriterionCorrectionAccuracy,
+		CriterionReasonValidity,
+	}
+	for _, c := range criteria {
+		if c == "" {
+			t.Errorf("criterion should not be empty string")
+		}
+	}
+}
+
+func TestAggregateScores_Average(t *testing.T) {
+	results := []CaseResult{
+		{
+			CaseName: "case1",
+			Scores: []ScoreEntry{
+				{Criterion: CriterionDetectionRecall, Score: 5},
+				{Criterion: CriterionFalsePositiveSuppression, Score: 4},
+			},
+		},
+		{
+			CaseName: "case2",
+			Scores: []ScoreEntry{
+				{Criterion: CriterionDetectionRecall, Score: 3},
+				{Criterion: CriterionFalsePositiveSuppression, Score: 4},
+			},
+		},
+	}
+
+	agg := AggregateScores(results)
+	// overall: (5+4+3+4)/4 = 4.0
+	if agg.Overall != 4.0 {
+		t.Errorf("overall = %v, want 4.0", agg.Overall)
+	}
+	// detection_recall: (5+3)/2 = 4.0
+	if agg.ByCriterion[CriterionDetectionRecall] != 4.0 {
+		t.Errorf("detection_recall = %v, want 4.0", agg.ByCriterion[CriterionDetectionRecall])
+	}
+	// false_positive_suppression: (4+4)/2 = 4.0
+	if agg.ByCriterion[CriterionFalsePositiveSuppression] != 4.0 {
+		t.Errorf("false_positive = %v, want 4.0", agg.ByCriterion[CriterionFalsePositiveSuppression])
+	}
+}
+
+func TestAggregateScores_Empty(t *testing.T) {
+	agg := AggregateScores(nil)
+	if agg.Overall != 0 {
+		t.Errorf("overall for empty = %v, want 0", agg.Overall)
+	}
+}
+
+func TestIsInconclusive_NetworkError(t *testing.T) {
+	err := errors.New("http do: dial tcp: connection refused")
+	if !IsInconclusive(err) {
+		t.Error("network error should be inconclusive")
+	}
+}
+
+func TestIsInconclusive_RateLimitStatus(t *testing.T) {
+	err := errors.New("api error (status 429): rate limit exceeded")
+	if !IsInconclusive(err) {
+		t.Error("rate limit error should be inconclusive")
+	}
+}
+
+func TestIsInconclusive_QualityFailure(t *testing.T) {
+	err := errors.New("quality below threshold: 3.5 < 4.0")
+	if IsInconclusive(err) {
+		t.Error("quality failure should not be inconclusive")
+	}
+}
+
+func TestIsInconclusive_Nil(t *testing.T) {
+	if IsInconclusive(nil) {
+		t.Error("nil error should not be inconclusive")
+	}
+}
+
+func TestBuildLLMConfig_Defaults(t *testing.T) {
+	t.Setenv("TEST_API_KEY", "test-key")
+	t.Setenv("TEST_MODEL", "")
+	t.Setenv("TEST_INTERVAL_MS", "")
+
+	cfg := BuildLLMConfig("TEST_API_KEY", "TEST_MODEL", "TEST_INTERVAL_MS")
+	if cfg.APIKey != "test-key" {
+		t.Errorf("APIKey = %q, want test-key", cfg.APIKey)
+	}
+	if cfg.Model != "gemini-3.1-flash-lite" {
+		t.Errorf("Model = %q, want gemini-3.1-flash-lite", cfg.Model)
+	}
+	if cfg.MinRequestIntervalMS != 4500 {
+		t.Errorf("MinRequestIntervalMS = %d, want 4500", cfg.MinRequestIntervalMS)
+	}
+}
+
+func TestBuildLLMConfig_EnvOverride(t *testing.T) {
+	t.Setenv("TEST_API_KEY2", "key123")
+	t.Setenv("TEST_MODEL2", "gemini-2.0-flash")
+	t.Setenv("TEST_INTERVAL_MS2", "2000")
+
+	cfg := BuildLLMConfig("TEST_API_KEY2", "TEST_MODEL2", "TEST_INTERVAL_MS2")
+	if cfg.Model != "gemini-2.0-flash" {
+		t.Errorf("Model = %q, want gemini-2.0-flash", cfg.Model)
+	}
+	if cfg.MinRequestIntervalMS != 2000 {
+		t.Errorf("MinRequestIntervalMS = %d, want 2000", cfg.MinRequestIntervalMS)
+	}
+}

--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -1,0 +1,81 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// judgeSchema is the JSON schema for the judge LLM output.
+var judgeSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["scores"],
+  "properties": {
+    "scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["criterion", "score", "reason"],
+        "properties": {
+          "criterion": {
+            "type": "string",
+            "enum": ["detection_recall", "false_positive_suppression", "correction_accuracy", "reason_validity"]
+          },
+          "score": {"type": "integer", "minimum": 1, "maximum": 5},
+          "reason": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
+
+// judgeResponse is the parsed judge LLM output.
+type judgeResponse struct {
+	Scores []ScoreEntry `json:"scores"`
+}
+
+// JudgeInput holds the inputs for a single judge call.
+type JudgeInput struct {
+	LinesJSON       string // JSON representation of the input lines
+	CorrectionsJSON string // JSON representation of proofread output
+	Expectation     string // optional expected result (empty if generalization set)
+}
+
+// Judge calls the LLM with the judge prompt and returns scored criteria.
+// judgePrompt may contain {{lines}}, {{corrections}}, and {{expectation}} placeholders.
+func Judge(ctx context.Context, client llm.Client, judgePrompt string, input JudgeInput, model string) ([]ScoreEntry, error) {
+	expectation := input.Expectation
+	if expectation == "" {
+		expectation = "（なし）"
+	}
+
+	prompt := strings.NewReplacer(
+		"{{lines}}", input.LinesJSON,
+		"{{corrections}}", input.CorrectionsJSON,
+		"{{expectation}}", expectation,
+	).Replace(judgePrompt)
+
+	req := llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: judgeSchema,
+	}
+	if model != "" {
+		req.Model = model
+	}
+
+	raw, err := client.Complete(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("judge llm: %w", err)
+	}
+
+	var resp judgeResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal judge response: %w", err)
+	}
+	return resp.Scores, nil
+}

--- a/internal/eval/judge.go
+++ b/internal/eval/judge.go
@@ -48,7 +48,8 @@ type JudgeInput struct {
 
 // Judge calls the LLM with the judge prompt and returns scored criteria.
 // judgePrompt may contain {{lines}}, {{corrections}}, and {{expectation}} placeholders.
-func Judge(ctx context.Context, client llm.Client, judgePrompt string, input JudgeInput, model string) ([]ScoreEntry, error) {
+// The model is determined by the client's configuration.
+func Judge(ctx context.Context, client llm.Client, judgePrompt string, input JudgeInput) ([]ScoreEntry, error) {
 	expectation := input.Expectation
 	if expectation == "" {
 		expectation = "（なし）"
@@ -60,15 +61,10 @@ func Judge(ctx context.Context, client llm.Client, judgePrompt string, input Jud
 		"{{expectation}}", expectation,
 	).Replace(judgePrompt)
 
-	req := llm.CompletionRequest{
+	raw, err := client.Complete(ctx, llm.CompletionRequest{
 		Messages:   []llm.Message{{Role: "user", Content: prompt}},
 		JSONSchema: judgeSchema,
-	}
-	if model != "" {
-		req.Model = model
-	}
-
-	raw, err := client.Complete(ctx, req)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("judge llm: %w", err)
 	}

--- a/internal/eval/judge_test.go
+++ b/internal/eval/judge_test.go
@@ -1,0 +1,83 @@
+package eval
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// mockLLMClient is a minimal llm.Client stub for unit tests.
+type mockLLMClient struct {
+	response json.RawMessage
+	err      error
+}
+
+func (m *mockLLMClient) Complete(_ context.Context, _ llm.CompletionRequest) (json.RawMessage, error) {
+	return m.response, m.err
+}
+
+func TestJudge_ParsesScores(t *testing.T) {
+	resp := json.RawMessage(`{"scores":[
+		{"criterion":"detection_recall","score":5,"reason":"全て検出"},
+		{"criterion":"false_positive_suppression","score":4,"reason":"誤検出なし"},
+		{"criterion":"correction_accuracy","score":5,"reason":"正確"},
+		{"criterion":"reason_validity","score":4,"reason":"妥当"}
+	]}`)
+	client := &mockLLMClient{response: resp}
+
+	scores, err := Judge(context.Background(), client, "{{lines}} {{corrections}} {{expectation}}", JudgeInput{
+		LinesJSON:       `[]`,
+		CorrectionsJSON: `{"corrections":[]}`,
+		Expectation:     "corrections は空であるべき",
+	})
+	if err != nil {
+		t.Fatalf("Judge: %v", err)
+	}
+	if len(scores) != 4 {
+		t.Errorf("len(scores) = %d, want 4", len(scores))
+	}
+	if scores[0].Criterion != CriterionDetectionRecall {
+		t.Errorf("scores[0].Criterion = %q, want %q", scores[0].Criterion, CriterionDetectionRecall)
+	}
+	if scores[0].Score != 5 {
+		t.Errorf("scores[0].Score = %d, want 5", scores[0].Score)
+	}
+}
+
+func TestJudge_EmptyExpectationFilled(t *testing.T) {
+	client := &mockLLMClient{
+		response: json.RawMessage(`{"scores":[
+			{"criterion":"detection_recall","score":5,"reason":"ok"},
+			{"criterion":"false_positive_suppression","score":5,"reason":"ok"},
+			{"criterion":"correction_accuracy","score":5,"reason":"ok"},
+			{"criterion":"reason_validity","score":5,"reason":"ok"}
+		]}`),
+	}
+
+	// Empty Expectation should use "（なし）" as fallback without error.
+	scores, err := Judge(context.Background(), client, "{{expectation}}", JudgeInput{
+		LinesJSON:       `[]`,
+		CorrectionsJSON: `{}`,
+		Expectation:     "",
+	})
+	if err != nil {
+		t.Fatalf("Judge with empty expectation: %v", err)
+	}
+	if len(scores) == 0 {
+		t.Error("expected scores from judge")
+	}
+}
+
+func TestJudge_LLMError(t *testing.T) {
+	client := &mockLLMClient{err: errors.New("http do: connection refused")}
+	_, err := Judge(context.Background(), client, "prompt", JudgeInput{
+		LinesJSON:       `[]`,
+		CorrectionsJSON: `{}`,
+	})
+	if err == nil {
+		t.Fatal("expected error from Judge when LLM fails")
+	}
+}

--- a/internal/eval/prompt.go
+++ b/internal/eval/prompt.go
@@ -1,0 +1,29 @@
+package eval
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// LoadPrompt reads the shipped prompt file internal/cli/prompts/{name}.md.
+// It resolves the path relative to this source file using runtime.Caller,
+// so no duplicate copy of the prompt is created.
+func LoadPrompt(name string) (string, error) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller failed")
+	}
+	// prompt.go lives at internal/eval/prompt.go.
+	// Prompts live at internal/cli/prompts/{name}.md.
+	evalDir := filepath.Dir(thisFile)
+	internalDir := filepath.Dir(evalDir)
+	promptPath := filepath.Join(internalDir, "cli", "prompts", name+".md")
+
+	data, err := os.ReadFile(promptPath)
+	if err != nil {
+		return "", fmt.Errorf("load prompt %q: %w", name, err)
+	}
+	return string(data), nil
+}

--- a/internal/eval/prompt_test.go
+++ b/internal/eval/prompt_test.go
@@ -1,0 +1,26 @@
+package eval
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadPrompt_ContainsExpectedContent(t *testing.T) {
+	content, err := LoadPrompt("proofread")
+	if err != nil {
+		t.Fatalf("LoadPrompt: %v", err)
+	}
+	if !strings.Contains(content, "{{lines}}") {
+		t.Error("proofread.md should contain {{lines}} placeholder")
+	}
+	if !strings.Contains(content, "corrections") {
+		t.Error("proofread.md should contain 'corrections'")
+	}
+}
+
+func TestLoadPrompt_NotFound(t *testing.T) {
+	_, err := LoadPrompt("nonexistent_prompt_xyz")
+	if err == nil {
+		t.Error("expected error for nonexistent prompt")
+	}
+}

--- a/internal/eval/proofread_eval_test.go
+++ b/internal/eval/proofread_eval_test.go
@@ -1,0 +1,272 @@
+//go:build eval
+
+package eval_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/eval"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// proofreadLine mirrors the input format for proofread.md.
+type proofreadLine struct {
+	CornerIndex   int    `json:"corner_index"`
+	LineIndex     int    `json:"line_index"`
+	OriginalText  string `json:"original_text"`
+	ConvertedText string `json:"converted_text"`
+}
+
+// proofreadCase is one entry in the testdata files.
+type proofreadCase struct {
+	Name        string          `json:"name"`
+	Category    string          `json:"category"`
+	Lines       []proofreadLine `json:"lines"`
+	Expectation string          `json:"expectation,omitempty"`
+}
+
+func loadCases(t *testing.T, filename string) []proofreadCase {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	path := filepath.Join(filepath.Dir(thisFile), "testdata", filename)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+	var cases []proofreadCase
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("parse %s: %v", filename, err)
+	}
+	return cases
+}
+
+func loadJudgePrompt(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	path := filepath.Join(filepath.Dir(thisFile), "testdata", "proofread_judge.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read judge prompt: %v", err)
+	}
+	return string(data)
+}
+
+func mustJSONString(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func runProofread(ctx context.Context, t *testing.T, client llm.Client, proofreadPrompt string, lines []proofreadLine, model string) json.RawMessage {
+	t.Helper()
+
+	linesJSON := mustJSONString(t, lines)
+	prompt := strings.NewReplacer("{{lines}}", linesJSON).Replace(proofreadPrompt)
+
+	correctionsSchema := json.RawMessage(`{
+		"type": "object",
+		"required": ["corrections"],
+		"properties": {
+			"corrections": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"required": ["corner_index", "line_index", "text"],
+					"properties": {
+						"corner_index": {"type": "integer", "minimum": 0},
+						"line_index":   {"type": "integer", "minimum": 0},
+						"text":         {"type": "string"},
+						"reason":       {"type": "string"}
+					},
+					"additionalProperties": false
+				}
+			}
+		},
+		"additionalProperties": false
+	}`)
+
+	req := llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: correctionsSchema,
+	}
+	if model != "" {
+		req.Model = model
+	}
+
+	raw, err := client.Complete(ctx, req)
+	if err != nil {
+		return nil
+	}
+	return raw
+}
+
+func TestProofreadEval(t *testing.T) {
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		t.Skip("GEMINI_API_KEY not set")
+	}
+
+	// Build LLM clients.
+	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	targetCfg.MaxRetries = 2
+	targetClient := llm.NewClient(targetCfg)
+
+	// Judge model can be overridden via VOX_EVAL_JUDGE_MODEL.
+	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
+		judgeCfg.Model = jm
+	}
+	judgeCfg.MaxRetries = 2
+	judgeClient := llm.NewClient(judgeCfg)
+
+	// Threshold.
+	threshold := 4.0
+	if v := os.Getenv("VOX_EVAL_PROOFREAD_THRESHOLD"); v != "" {
+		if _, err := fmt.Sscanf(v, "%f", &threshold); err != nil {
+			t.Fatalf("parse VOX_EVAL_PROOFREAD_THRESHOLD: %v", err)
+		}
+	}
+
+	// Sample size.
+	sampleSize := 8
+	if v := os.Getenv("VOX_EVAL_SAMPLE_SIZE"); v != "" {
+		if _, err := fmt.Sscanf(v, "%d", &sampleSize); err != nil {
+			t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
+		}
+	}
+
+	// Seed.
+	seed := eval.DefaultSeed()
+	if v := os.Getenv("VOX_EVAL_SAMPLE_SEED"); v != "" {
+		if _, err := fmt.Sscanf(v, "%d", &seed); err != nil {
+			t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
+		}
+	}
+
+	proofreadPrompt, err := eval.LoadPrompt("proofread")
+	if err != nil {
+		t.Fatalf("load proofread prompt: %v", err)
+	}
+
+	judgePrompt := loadJudgePrompt(t)
+
+	// Load test sets.
+	regressionCases := loadCases(t, "proofread_regression_cases.json")
+	poolCases := loadCases(t, "proofread_pool_cases.json")
+
+	sampled := eval.Sample(poolCases, sampleSize, seed, func(c proofreadCase) string { return c.Name })
+	sampledNames := make([]string, len(sampled))
+	for i, c := range sampled {
+		sampledNames[i] = c.Name
+	}
+	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
+
+	// Bundle all cases: regression (all) + generalization (sampled).
+	type evaluationCase struct {
+		proofreadCase
+		setType string
+	}
+	var allCases []evaluationCase
+	for _, c := range regressionCases {
+		allCases = append(allCases, evaluationCase{c, "regression"})
+	}
+	for _, c := range sampled {
+		allCases = append(allCases, evaluationCase{c, "generalization"})
+	}
+
+	ctx := context.Background()
+	var results []eval.CaseResult
+
+	for _, ec := range allCases {
+		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
+
+		// Step 1: run proofread.
+		raw := runProofread(ctx, t, targetClient, proofreadPrompt, ec.Lines, targetCfg.Model)
+		if raw == nil {
+			// runProofread logged the error; check if inconclusive.
+			t.Skipf("proofread API call failed for case %s (inconclusive)", ec.Name)
+		}
+
+		correctionsJSON := string(raw)
+
+		// Step 2: judge.
+		linesJSON := mustJSONString(t, ec.Lines)
+		judgeInput := eval.JudgeInput{
+			LinesJSON:       linesJSON,
+			CorrectionsJSON: correctionsJSON,
+			Expectation:     ec.Expectation,
+		}
+
+		judgeModel := ""
+		if v := os.Getenv("VOX_EVAL_JUDGE_MODEL"); v != "" {
+			judgeModel = v
+		}
+		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, judgeInput, judgeModel)
+		if err != nil {
+			if eval.IsInconclusive(err) {
+				t.Skipf("judge API call failed (inconclusive): %v", err)
+			}
+			t.Fatalf("judge failed for case %s: %v", ec.Name, err)
+		}
+
+		results = append(results, eval.CaseResult{
+			CaseName: ec.Name,
+			SetType:  ec.setType,
+			Scores:   scores,
+		})
+
+		// Log per-case scores.
+		for _, s := range scores {
+			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
+		}
+	}
+
+	if len(results) == 0 {
+		t.Skip("no results collected (all cases inconclusive)")
+	}
+
+	// Aggregate.
+	agg := eval.AggregateScores(results)
+
+	t.Logf("=== Aggregated scores ===")
+	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, threshold)
+	for _, c := range eval.AllCriteria {
+		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
+	}
+
+	// Check for regression failures with emphasis.
+	for _, r := range results {
+		if r.SetType != "regression" {
+			continue
+		}
+		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
+		if caseAgg.Overall < threshold {
+			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, threshold)
+			for _, s := range r.Scores {
+				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
+			}
+		}
+	}
+
+	// Overall quality check.
+	if agg.Overall < threshold {
+		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, threshold)
+	}
+}

--- a/internal/eval/proofread_eval_test.go
+++ b/internal/eval/proofread_eval_test.go
@@ -5,17 +5,32 @@ package eval_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/eval"
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
+
+// testdataDir is resolved once at init time using runtime.Caller.
+var testdataDir string
+
+func init() {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	testdataDir = filepath.Join(filepath.Dir(thisFile), "testdata")
+}
+
+func testdataPath(filename string) string {
+	return filepath.Join(testdataDir, filename)
+}
 
 // proofreadLine mirrors the input format for proofread.md.
 type proofreadLine struct {
@@ -35,12 +50,7 @@ type proofreadCase struct {
 
 func loadCases(t *testing.T, filename string) []proofreadCase {
 	t.Helper()
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	path := filepath.Join(filepath.Dir(thisFile), "testdata", filename)
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(testdataPath(filename))
 	if err != nil {
 		t.Fatalf("read %s: %v", filename, err)
 	}
@@ -53,73 +63,75 @@ func loadCases(t *testing.T, filename string) []proofreadCase {
 
 func loadJudgePrompt(t *testing.T) string {
 	t.Helper()
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller failed")
-	}
-	path := filepath.Join(filepath.Dir(thisFile), "testdata", "proofread_judge.md")
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(testdataPath("proofread_judge.md"))
 	if err != nil {
 		t.Fatalf("read judge prompt: %v", err)
 	}
 	return string(data)
 }
 
-func mustJSONString(t *testing.T, v any) string {
-	t.Helper()
-	b, err := json.Marshal(v)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	return string(b)
-}
-
-func runProofread(ctx context.Context, t *testing.T, client llm.Client, proofreadPrompt string, lines []proofreadLine, model string) json.RawMessage {
-	t.Helper()
-
-	linesJSON := mustJSONString(t, lines)
-	prompt := strings.NewReplacer("{{lines}}", linesJSON).Replace(proofreadPrompt)
-
-	correctionsSchema := json.RawMessage(`{
-		"type": "object",
-		"required": ["corrections"],
-		"properties": {
-			"corrections": {
-				"type": "array",
-				"items": {
-					"type": "object",
-					"required": ["corner_index", "line_index", "text"],
-					"properties": {
-						"corner_index": {"type": "integer", "minimum": 0},
-						"line_index":   {"type": "integer", "minimum": 0},
-						"text":         {"type": "string"},
-						"reason":       {"type": "string"}
-					},
-					"additionalProperties": false
-				}
+var correctionsSchema = json.RawMessage(`{
+	"type": "object",
+	"required": ["corrections"],
+	"properties": {
+		"corrections": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"required": ["corner_index", "line_index", "text"],
+				"properties": {
+					"corner_index": {"type": "integer", "minimum": 0},
+					"line_index":   {"type": "integer", "minimum": 0},
+					"text":         {"type": "string"},
+					"reason":       {"type": "string"}
+				},
+				"additionalProperties": false
 			}
-		},
-		"additionalProperties": false
-	}`)
+		}
+	},
+	"additionalProperties": false
+}`)
 
-	req := llm.CompletionRequest{
+func runProofread(ctx context.Context, t *testing.T, client llm.Client, proofreadPrompt, linesJSON string) json.RawMessage {
+	t.Helper()
+	prompt := strings.NewReplacer("{{lines}}", linesJSON).Replace(proofreadPrompt)
+	raw, err := client.Complete(ctx, llm.CompletionRequest{
 		Messages:   []llm.Message{{Role: "user", Content: prompt}},
 		JSONSchema: correctionsSchema,
-	}
-	if model != "" {
-		req.Model = model
-	}
-
-	raw, err := client.Complete(ctx, req)
+	})
 	if err != nil {
 		return nil
 	}
 	return raw
 }
 
+func getEnvFloat(key string, defaultVal float64) (float64, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal, nil
+	}
+	return strconv.ParseFloat(v, 64)
+}
+
+func getEnvInt(key string, defaultVal int) (int, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal, nil
+	}
+	n, err := strconv.Atoi(v)
+	return n, err
+}
+
+func getEnvInt64(key string, defaultVal int64) (int64, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal, nil
+	}
+	return strconv.ParseInt(v, 10, 64)
+}
+
 func TestProofreadEval(t *testing.T) {
-	apiKey := os.Getenv("GEMINI_API_KEY")
-	if apiKey == "" {
+	if os.Getenv("GEMINI_API_KEY") == "" {
 		t.Skip("GEMINI_API_KEY not set")
 	}
 
@@ -136,28 +148,19 @@ func TestProofreadEval(t *testing.T) {
 	judgeCfg.MaxRetries = 2
 	judgeClient := llm.NewClient(judgeCfg)
 
-	// Threshold.
-	threshold := 4.0
-	if v := os.Getenv("VOX_EVAL_PROOFREAD_THRESHOLD"); v != "" {
-		if _, err := fmt.Sscanf(v, "%f", &threshold); err != nil {
-			t.Fatalf("parse VOX_EVAL_PROOFREAD_THRESHOLD: %v", err)
-		}
+	threshold, err := getEnvFloat("VOX_EVAL_PROOFREAD_THRESHOLD", 4.0)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_PROOFREAD_THRESHOLD: %v", err)
 	}
 
-	// Sample size.
-	sampleSize := 8
-	if v := os.Getenv("VOX_EVAL_SAMPLE_SIZE"); v != "" {
-		if _, err := fmt.Sscanf(v, "%d", &sampleSize); err != nil {
-			t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
-		}
+	sampleSize, err := getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
 	}
 
-	// Seed.
-	seed := eval.DefaultSeed()
-	if v := os.Getenv("VOX_EVAL_SAMPLE_SEED"); v != "" {
-		if _, err := fmt.Sscanf(v, "%d", &seed); err != nil {
-			t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
-		}
+	seed, err := getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
 	}
 
 	proofreadPrompt, err := eval.LoadPrompt("proofread")
@@ -171,7 +174,7 @@ func TestProofreadEval(t *testing.T) {
 	regressionCases := loadCases(t, "proofread_regression_cases.json")
 	poolCases := loadCases(t, "proofread_pool_cases.json")
 
-	sampled := eval.Sample(poolCases, sampleSize, seed, func(c proofreadCase) string { return c.Name })
+	sampled := eval.Sample(poolCases, sampleSize, seed)
 	sampledNames := make([]string, len(sampled))
 	for i, c := range sampled {
 		sampledNames[i] = c.Name
@@ -197,28 +200,25 @@ func TestProofreadEval(t *testing.T) {
 	for _, ec := range allCases {
 		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
 
+		// Marshal lines once; reuse for proofread prompt and judge input.
+		linesJSONBytes, err := json.Marshal(ec.Lines)
+		if err != nil {
+			t.Fatalf("marshal lines for case %s: %v", ec.Name, err)
+		}
+		linesJSON := string(linesJSONBytes)
+
 		// Step 1: run proofread.
-		raw := runProofread(ctx, t, targetClient, proofreadPrompt, ec.Lines, targetCfg.Model)
+		raw := runProofread(ctx, t, targetClient, proofreadPrompt, linesJSON)
 		if raw == nil {
-			// runProofread logged the error; check if inconclusive.
 			t.Skipf("proofread API call failed for case %s (inconclusive)", ec.Name)
 		}
 
-		correctionsJSON := string(raw)
-
 		// Step 2: judge.
-		linesJSON := mustJSONString(t, ec.Lines)
-		judgeInput := eval.JudgeInput{
+		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, eval.JudgeInput{
 			LinesJSON:       linesJSON,
-			CorrectionsJSON: correctionsJSON,
+			CorrectionsJSON: string(raw),
 			Expectation:     ec.Expectation,
-		}
-
-		judgeModel := ""
-		if v := os.Getenv("VOX_EVAL_JUDGE_MODEL"); v != "" {
-			judgeModel = v
-		}
-		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, judgeInput, judgeModel)
+		})
 		if err != nil {
 			if eval.IsInconclusive(err) {
 				t.Skipf("judge API call failed (inconclusive): %v", err)
@@ -232,7 +232,6 @@ func TestProofreadEval(t *testing.T) {
 			Scores:   scores,
 		})
 
-		// Log per-case scores.
 		for _, s := range scores {
 			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
 		}

--- a/internal/eval/proofread_eval_test.go
+++ b/internal/eval/proofread_eval_test.go
@@ -92,17 +92,13 @@ var correctionsSchema = json.RawMessage(`{
 	"additionalProperties": false
 }`)
 
-func runProofread(ctx context.Context, t *testing.T, client llm.Client, proofreadPrompt, linesJSON string) json.RawMessage {
+func runProofread(ctx context.Context, t *testing.T, client llm.Client, proofreadPrompt, linesJSON string) (json.RawMessage, error) {
 	t.Helper()
 	prompt := strings.NewReplacer("{{lines}}", linesJSON).Replace(proofreadPrompt)
-	raw, err := client.Complete(ctx, llm.CompletionRequest{
+	return client.Complete(ctx, llm.CompletionRequest{
 		Messages:   []llm.Message{{Role: "user", Content: prompt}},
 		JSONSchema: correctionsSchema,
 	})
-	if err != nil {
-		return nil
-	}
-	return raw
 }
 
 func getEnvFloat(key string, defaultVal float64) (float64, error) {
@@ -208,9 +204,12 @@ func TestProofreadEval(t *testing.T) {
 		linesJSON := string(linesJSONBytes)
 
 		// Step 1: run proofread.
-		raw := runProofread(ctx, t, targetClient, proofreadPrompt, linesJSON)
-		if raw == nil {
-			t.Skipf("proofread API call failed for case %s (inconclusive)", ec.Name)
+		raw, err := runProofread(ctx, t, targetClient, proofreadPrompt, linesJSON)
+		if err != nil {
+			if eval.IsInconclusive(err) {
+				t.Skipf("proofread API call failed (inconclusive) for case %s: %v", ec.Name, err)
+			}
+			t.Fatalf("proofread failed for case %s: %v", ec.Name, err)
 		}
 
 		// Step 2: judge.

--- a/internal/eval/sample.go
+++ b/internal/eval/sample.go
@@ -6,9 +6,8 @@ import (
 )
 
 // Sample selects n items from pool using a reproducible shuffle seeded by seed.
-// nameFunc extracts a display name for each item (used for logging by callers).
 // If n >= len(pool), all items are returned in shuffled order.
-func Sample[T any](pool []T, n int, seed int64, _ func(T) string) []T {
+func Sample[T any](pool []T, n int, seed int64) []T {
 	if n >= len(pool) {
 		n = len(pool)
 	}

--- a/internal/eval/sample.go
+++ b/internal/eval/sample.go
@@ -1,0 +1,36 @@
+package eval
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+// Sample selects n items from pool using a reproducible shuffle seeded by seed.
+// nameFunc extracts a display name for each item (used for logging by callers).
+// If n >= len(pool), all items are returned in shuffled order.
+func Sample[T any](pool []T, n int, seed int64, _ func(T) string) []T {
+	if n >= len(pool) {
+		n = len(pool)
+	}
+
+	src := rand.New(rand.NewPCG(uint64(seed), 0)) //nolint:gosec
+	indices := src.Perm(len(pool))
+
+	result := make([]T, n)
+	for i := range n {
+		result[i] = pool[indices[i]]
+	}
+	return result
+}
+
+// isoWeekSeed returns a seed derived from the ISO year and week number of t.
+// All times within the same ISO week return the same seed.
+func isoWeekSeed(t time.Time) int64 {
+	year, week := t.ISOWeek()
+	return int64(year)*100 + int64(week)
+}
+
+// DefaultSeed returns the ISO week-based seed for the current time.
+func DefaultSeed() int64 {
+	return isoWeekSeed(time.Now())
+}

--- a/internal/eval/sample_test.go
+++ b/internal/eval/sample_test.go
@@ -1,0 +1,81 @@
+package eval
+
+import (
+	"testing"
+	"time"
+)
+
+type testCase struct {
+	Name     string
+	Category string
+}
+
+func TestSample_Count(t *testing.T) {
+	pool := []testCase{
+		{Name: "a"}, {Name: "b"}, {Name: "c"}, {Name: "d"}, {Name: "e"},
+	}
+	got := Sample(pool, 3, 42, func(c testCase) string { return c.Name })
+	if len(got) != 3 {
+		t.Errorf("len = %d, want 3", len(got))
+	}
+}
+
+func TestSample_CountExceedsPool(t *testing.T) {
+	pool := []testCase{{Name: "a"}, {Name: "b"}}
+	got := Sample(pool, 5, 42, func(c testCase) string { return c.Name })
+	if len(got) != 2 {
+		t.Errorf("len = %d, want 2 (pool size)", len(got))
+	}
+}
+
+func TestSample_Reproducible(t *testing.T) {
+	pool := make([]testCase, 20)
+	for i := range pool {
+		pool[i] = testCase{Name: string(rune('A' + i))}
+	}
+	got1 := Sample(pool, 8, 100, func(c testCase) string { return c.Name })
+	got2 := Sample(pool, 8, 100, func(c testCase) string { return c.Name })
+
+	for i := range got1 {
+		if got1[i].Name != got2[i].Name {
+			t.Errorf("same seed should produce same order: index %d differs", i)
+		}
+	}
+}
+
+func TestSample_DifferentSeeds(t *testing.T) {
+	pool := make([]testCase, 20)
+	for i := range pool {
+		pool[i] = testCase{Name: string(rune('A' + i))}
+	}
+	got1 := Sample(pool, 8, 1, func(c testCase) string { return c.Name })
+	got2 := Sample(pool, 8, 2, func(c testCase) string { return c.Name })
+
+	same := true
+	for i := range got1 {
+		if got1[i].Name != got2[i].Name {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Error("different seeds should produce different results (probabilistically)")
+	}
+}
+
+func TestISOWeekSeed(t *testing.T) {
+	// Verify that ISOWeekSeed returns a deterministic value for the same week.
+	now := time.Date(2026, 6, 7, 0, 0, 0, 0, time.UTC)
+	seed1 := isoWeekSeed(now)
+	seed2 := isoWeekSeed(now.Add(12 * time.Hour))
+	if seed1 != seed2 {
+		t.Errorf("same week should give same seed: %d vs %d", seed1, seed2)
+	}
+
+	// Different week → different seed (almost certainly)
+	nextWeek := now.Add(7 * 24 * time.Hour)
+	seed3 := isoWeekSeed(nextWeek)
+	if seed1 == seed3 {
+		t.Errorf("different weeks should give different seeds (usually): %d == %d", seed1, seed3)
+	}
+}

--- a/internal/eval/sample_test.go
+++ b/internal/eval/sample_test.go
@@ -14,7 +14,7 @@ func TestSample_Count(t *testing.T) {
 	pool := []testCase{
 		{Name: "a"}, {Name: "b"}, {Name: "c"}, {Name: "d"}, {Name: "e"},
 	}
-	got := Sample(pool, 3, 42, func(c testCase) string { return c.Name })
+	got := Sample(pool, 3, 42)
 	if len(got) != 3 {
 		t.Errorf("len = %d, want 3", len(got))
 	}
@@ -22,7 +22,7 @@ func TestSample_Count(t *testing.T) {
 
 func TestSample_CountExceedsPool(t *testing.T) {
 	pool := []testCase{{Name: "a"}, {Name: "b"}}
-	got := Sample(pool, 5, 42, func(c testCase) string { return c.Name })
+	got := Sample(pool, 5, 42)
 	if len(got) != 2 {
 		t.Errorf("len = %d, want 2 (pool size)", len(got))
 	}
@@ -33,8 +33,8 @@ func TestSample_Reproducible(t *testing.T) {
 	for i := range pool {
 		pool[i] = testCase{Name: string(rune('A' + i))}
 	}
-	got1 := Sample(pool, 8, 100, func(c testCase) string { return c.Name })
-	got2 := Sample(pool, 8, 100, func(c testCase) string { return c.Name })
+	got1 := Sample(pool, 8, 100)
+	got2 := Sample(pool, 8, 100)
 
 	for i := range got1 {
 		if got1[i].Name != got2[i].Name {
@@ -48,8 +48,8 @@ func TestSample_DifferentSeeds(t *testing.T) {
 	for i := range pool {
 		pool[i] = testCase{Name: string(rune('A' + i))}
 	}
-	got1 := Sample(pool, 8, 1, func(c testCase) string { return c.Name })
-	got2 := Sample(pool, 8, 2, func(c testCase) string { return c.Name })
+	got1 := Sample(pool, 8, 1)
+	got2 := Sample(pool, 8, 2)
 
 	same := true
 	for i := range got1 {
@@ -64,7 +64,6 @@ func TestSample_DifferentSeeds(t *testing.T) {
 }
 
 func TestISOWeekSeed(t *testing.T) {
-	// Verify that ISOWeekSeed returns a deterministic value for the same week.
 	now := time.Date(2026, 6, 7, 0, 0, 0, 0, time.UTC)
 	seed1 := isoWeekSeed(now)
 	seed2 := isoWeekSeed(now.Add(12 * time.Hour))
@@ -72,7 +71,6 @@ func TestISOWeekSeed(t *testing.T) {
 		t.Errorf("same week should give same seed: %d vs %d", seed1, seed2)
 	}
 
-	// Different week → different seed (almost certainly)
 	nextWeek := now.Add(7 * 24 * time.Hour)
 	seed3 := isoWeekSeed(nextWeek)
 	if seed1 == seed3 {

--- a/internal/eval/testdata/proofread_judge.md
+++ b/internal/eval/testdata/proofread_judge.md
@@ -1,0 +1,51 @@
+# 発音校正プロンプト評価（LLM-as-judge）
+
+あなたは日本語の発音校正タスクの評価者です。
+以下のケース入力・正解説明・発音校正結果を見て、4つの観点でそれぞれ1〜5点（整数）で採点してください。
+
+## ケース入力（セリフ一覧）
+
+```json
+{{lines}}
+```
+
+## 正解説明（expectation）
+
+{{expectation}}
+
+> `expectation` が「（なし）」の場合は `original_text` の内容から妥当性を自律判断してください。
+
+## 発音校正結果（corrections）
+
+```json
+{{corrections}}
+```
+
+## 観点定義
+
+| 観点キー | 説明 |
+|---|---|
+| `detection_recall` | 検出網羅性: 既知/想定される誤読をすべて検出できたか。正常ケース（誤読なし）では `corrections` が空なら満点とする。 |
+| `false_positive_suppression` | 誤検出抑制: 問題のない行を `corrections` に含めて正常な変換を壊していないか。誤検出が多いほど低点。 |
+| `correction_accuracy` | 修正の正確さ: 修正後 `text` が行全体の正しい完全かな表記になっているか。 |
+| `reason_validity` | 理由の妥当性: `reason` フィールドが誤りの種類（連濁/熟字訓/複合語読み/音訓混在/誤読/意味不明など）を的確に説明しているか。 |
+
+## 採点ガイドライン
+
+- `expectation` がある場合: それを正解基準として各観点を採点する。
+- `expectation` が「（なし）」の場合: `original_text` と `converted_text` から誤読の有無・種類を自律判断して採点する。
+- 正常ケース（誤読なし）で `corrections` が空の場合、`detection_recall` を満点（5点）とする。
+- 採点後は各観点の `reason` に採点理由を簡潔に記載する。
+
+## 出力形式
+
+```json
+{
+  "scores": [
+    {"criterion": "detection_recall", "score": 5, "reason": "採点理由"},
+    {"criterion": "false_positive_suppression", "score": 5, "reason": "採点理由"},
+    {"criterion": "correction_accuracy", "score": 5, "reason": "採点理由"},
+    {"criterion": "reason_validity", "score": 5, "reason": "採点理由"}
+  ]
+}
+```

--- a/internal/eval/testdata/proofread_pool_cases.json
+++ b/internal/eval/testdata/proofread_pool_cases.json
@@ -1,0 +1,278 @@
+[
+  {
+    "name": "rendaku_kaminari",
+    "category": "rendaku",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "雷雨に注意してください",
+        "converted_text": "かみなりあめにちゅういしてください"
+      }
+    ]
+  },
+  {
+    "name": "rendaku_kobitozu",
+    "category": "rendaku",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "山頂の頂上を目指します",
+        "converted_text": "さんちょうのちょうじょうをめざします"
+      }
+    ]
+  },
+  {
+    "name": "jukujikun_otomodachi",
+    "category": "jukujikun",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "今年の目標を発表します",
+        "converted_text": "ことしのもくひょうをはっぴょうします"
+      }
+    ]
+  },
+  {
+    "name": "jukujikun_ashita",
+    "category": "jukujikun",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "明日の予定を確認しましょう",
+        "converted_text": "あすのよていをかくにんしましょう"
+      }
+    ]
+  },
+  {
+    "name": "jukujikun_otona",
+    "category": "jukujikun",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "大人として責任を持ちます",
+        "converted_text": "おとなとしてせきにんをもちます"
+      }
+    ]
+  },
+  {
+    "name": "compound_hatsumode",
+    "category": "compound_special_reading",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "師走に入りました",
+        "converted_text": "しわすにはいりました"
+      }
+    ]
+  },
+  {
+    "name": "compound_kawasemi",
+    "category": "compound_special_reading",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "川辺で翡翠を見かけました",
+        "converted_text": "かわべでかわせみをみかけました"
+      }
+    ]
+  },
+  {
+    "name": "onyomi_mix_nyukyo",
+    "category": "onyomi_kunyomi_mix",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "入居者の皆様へお知らせです",
+        "converted_text": "にゅうきょしゃのみなさまへおしらせです"
+      }
+    ]
+  },
+  {
+    "name": "onyomi_mix_shuppatsubi",
+    "category": "onyomi_kunyomi_mix",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "出発日は来週火曜日です",
+        "converted_text": "しゅっぱつびはらいしゅうかようびです"
+      }
+    ]
+  },
+  {
+    "name": "homophone_kikan",
+    "category": "homophone_misreading",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "期間限定のキャンペーンです",
+        "converted_text": "きかんげんていのきゃんぺーんです"
+      }
+    ]
+  },
+  {
+    "name": "homophone_kikou",
+    "category": "homophone_misreading",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "気候変動に対応します",
+        "converted_text": "きこうへんどうにたいおうします"
+      }
+    ]
+  },
+  {
+    "name": "meaningless_garbled",
+    "category": "meaningless",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "記録を更新しました",
+        "converted_text": "きろくをこうしんました"
+      }
+    ]
+  },
+  {
+    "name": "normal_simple_sentence",
+    "category": "normal",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "本日はお越しいただきありがとうございます",
+        "converted_text": "ほんじつはおこしいただきありがとうございます"
+      }
+    ]
+  },
+  {
+    "name": "normal_weather",
+    "category": "normal",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "明日は晴れの予報です",
+        "converted_text": "あしたははれのよほうです"
+      }
+    ]
+  },
+  {
+    "name": "normal_news_intro",
+    "category": "normal",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "こんにちは、ラジオをお聴きの皆さん",
+        "converted_text": "こんにちは、らじおをおききのみなさん"
+      }
+    ]
+  },
+  {
+    "name": "normal_katakana",
+    "category": "normal",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "インターネットを活用しましょう",
+        "converted_text": "いんたーねっとをかつようしましょう"
+      }
+    ]
+  },
+  {
+    "name": "multi_line_all_normal",
+    "category": "multi_line_mixed",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "今週のニュースをお届けします",
+        "converted_text": "こんしゅうのにゅーすをおとどけします"
+      },
+      {
+        "corner_index": 0,
+        "line_index": 1,
+        "original_text": "まず最初のトピックです",
+        "converted_text": "まずさいしょのとぴっくです"
+      }
+    ]
+  },
+  {
+    "name": "multi_line_partial_error",
+    "category": "multi_line_mixed",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "今日の天気予報をお伝えします",
+        "converted_text": "こんにちのてんきよほうをおつたえします"
+      },
+      {
+        "corner_index": 0,
+        "line_index": 1,
+        "original_text": "気温は二十度です",
+        "converted_text": "きおんはにじゅうどです"
+      }
+    ]
+  },
+  {
+    "name": "rendaku_shimbun",
+    "category": "rendaku",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "新聞を読みましょう",
+        "converted_text": "しんぶんをよみましょう"
+      }
+    ]
+  },
+  {
+    "name": "jukujikun_kinoo",
+    "category": "jukujikun",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "昨日の出来事を振り返ります",
+        "converted_text": "きのうのできごとをふりかえります"
+      }
+    ]
+  },
+  {
+    "name": "normal_formal_closing",
+    "category": "normal",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "以上でニュースをお届けしました",
+        "converted_text": "いじょうでにゅーすをおとどけしました"
+      }
+    ]
+  },
+  {
+    "name": "compound_sakura",
+    "category": "compound_special_reading",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "桜前線が北上しています",
+        "converted_text": "さくらぜんせんがほくじょうしています"
+      }
+    ]
+  }
+]

--- a/internal/eval/testdata/proofread_regression_cases.json
+++ b/internal/eval/testdata/proofread_regression_cases.json
@@ -1,0 +1,130 @@
+[
+  {
+    "name": "rendaku_zutuki",
+    "category": "rendaku",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "頭突きを食らいました",
+        "converted_text": "あたまつきをくらいました"
+      }
+    ],
+    "expectation": "「頭突き」は連濁により「ずつき」と読む。converted_text の「あたまつき」は連濁が取りこぼされた誤読であり、corrections に corner_index=0, line_index=0, text=\"ずつきをくらいました\" の修正を含めるべき。"
+  },
+  {
+    "name": "jukujikun_kyou",
+    "category": "jukujikun",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "今日はいい天気ですね",
+        "converted_text": "こんにちはいいてんきですね"
+      }
+    ],
+    "expectation": "「今日」は熟字訓で「きょう」と読む。「こんにち」は誤りであり、corrections に corner_index=0, line_index=0, text=\"きょうはいいてんきですね\" の修正を含めるべき。"
+  },
+  {
+    "name": "compound_azuki",
+    "category": "compound_special_reading",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "小豆を炊いてずんだ餅を作ります",
+        "converted_text": "しょうずをたいてずんだもちをつくります"
+      }
+    ],
+    "expectation": "「小豆」は複合語特殊読みで「あずき」と読む。「しょうず」は誤りであり、corrections に corner_index=0, line_index=0, text=\"あずきをたいてずんだもちをつくります\" の修正を含めるべき。"
+  },
+  {
+    "name": "onyomi_kunyomi_mix",
+    "category": "onyomi_kunyomi_mix",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "入場口からお入りください",
+        "converted_text": "はいりばぐちからおはいりください"
+      }
+    ],
+    "expectation": "「入場口」は音訓混在で「にゅうじょうぐち」と読む。「はいりばぐち」は誤りであり、corrections に corner_index=0, line_index=0, text=\"にゅうじょうぐちからおはいりください\" の修正を含めるべき。"
+  },
+  {
+    "name": "homophone_error",
+    "category": "homophone_misreading",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "橋を渡ります",
+        "converted_text": "はしをわたります"
+      },
+      {
+        "corner_index": 0,
+        "line_index": 1,
+        "original_text": "箸で食べます",
+        "converted_text": "はしでたべます"
+      }
+    ],
+    "expectation": "「橋」は「はし」で正しい。「箸」も「はし」で正しい。どちらも corrections に含めるべきではない（VOICEVOX のアクセント処理に委ねる）。"
+  },
+  {
+    "name": "meaningless_conversion",
+    "category": "meaningless",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "ニュースを報告します",
+        "converted_text": "にゅーすをほーこくにちます"
+      }
+    ],
+    "expectation": "「報告します」の converted_text が「ほーこくにちます」となっており日本語として意味不明。corrections に corner_index=0, line_index=0, text=\"にゅーすをほうこくします\" の修正を含めるべき。"
+  },
+  {
+    "name": "normal_no_correction",
+    "category": "normal",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "ずんだ餅はおいしいです",
+        "converted_text": "ずんだもちはおいしいです"
+      },
+      {
+        "corner_index": 0,
+        "line_index": 1,
+        "original_text": "今日もよろしくお願いします",
+        "converted_text": "きょうもよろしくおねがいします"
+      }
+    ],
+    "expectation": "どちらの行も converted_text は正しい読みを表している。corrections は空配列であるべき。"
+  },
+  {
+    "name": "multi_line_mixed",
+    "category": "multi_line_mixed",
+    "lines": [
+      {
+        "corner_index": 0,
+        "line_index": 0,
+        "original_text": "頭突きは痛い",
+        "converted_text": "あたまつきはいたい"
+      },
+      {
+        "corner_index": 0,
+        "line_index": 1,
+        "original_text": "でも元気です",
+        "converted_text": "でもげんきです"
+      },
+      {
+        "corner_index": 1,
+        "line_index": 0,
+        "original_text": "今日は晴れです",
+        "converted_text": "こんにちははれです"
+      }
+    ],
+    "expectation": "line_index=0 の「あたまつき」は連濁誤り（→ずつき）。line_index=1 の「でもげんきです」は正しい。corner_index=1, line_index=0 の「こんにちは」は熟字訓誤り（→きょう）。2件の修正を corrections に含めるべき。"
+  }
+]


### PR DESCRIPTION
## Summary

- `internal/eval/` パッケージを新設し、LLM-as-judge 方式の共通評価基盤を実装（`eval.go` / `sample.go` / `prompt.go` / `judge.go`）
- `proofread.md` を対象に `//go:build eval` 付きの評価テスト（`proofread_eval_test.go`）を実装
  - 回帰セット（8件・`expectation` 付き）＋汎化プール（22件・judge 自律判定）の二層データセット
  - 4観点（`detection_recall` / `false_positive_suppression` / `correction_accuracy` / `reason_validity`）を1〜5点採点、全体平均 4.0 以上で合格
  - レートリミット・API・ネットワークエラーは `t.Skip`（inconclusive）、品質不足のみ `t.Errorf`
- `Makefile` に `eval` ターゲット（`go test -tags=eval -count=1 -v ./internal/eval/...`）を追加
- `.github/workflows/prompt-eval.yml` を週次 schedule + workflow_dispatch で追加（既存 `build.yml` は変更なし）
- `README` に評価フレームワークの実行方法・環境変数・二層データセットの仕組みを追記

Closes #337

---
🤖 Generated with [Claude Code](https://claude.ai/code)