### PR TITLE
refactor: install_test.go のインライン MkdirAll+WriteFile を writeTestFile に統一

### DIFF
--- a/internal/cli/install_test.go
+++ b/internal/cli/install_test.go
@@ -42,20 +42,13 @@ func TestInstallCmd_SkillsGenerated(t *testing.T) {
 
 func TestInstallCmd_SkillsExistingSkipped(t *testing.T) {
 	dir := chdirTemp(t)
-	skillDir := filepath.Join(dir, ".claude/skills/vox-radio")
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	existing := filepath.Join(skillDir, "SKILL.md")
 	existingContent := []byte("# existing")
-	if err := os.WriteFile(existing, existingContent, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dir, ".claude/skills/vox-radio/SKILL.md", existingContent)
 	out, err := runInstallCmd(t, "--skills")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	data, _ := os.ReadFile(existing)
+	data, _ := os.ReadFile(filepath.Join(dir, ".claude/skills/vox-radio/SKILL.md"))
 	if string(data) != string(existingContent) {
 		t.Error("SKILL.md should not be overwritten without --force")
 	}
@@ -66,20 +59,13 @@ func TestInstallCmd_SkillsExistingSkipped(t *testing.T) {
 
 func TestInstallCmd_SkillsForceOverwrites(t *testing.T) {
 	dir := chdirTemp(t)
-	skillDir := filepath.Join(dir, ".claude/skills/vox-radio")
-	if err := os.MkdirAll(skillDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	existing := filepath.Join(skillDir, "SKILL.md")
 	existingContent := []byte("# old content")
-	if err := os.WriteFile(existing, existingContent, 0644); err != nil {
-		t.Fatal(err)
-	}
+	writeTestFile(t, dir, ".claude/skills/vox-radio/SKILL.md", existingContent)
 	_, err := runInstallCmd(t, "--skills", "--force")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	data, _ := os.ReadFile(existing)
+	data, _ := os.ReadFile(filepath.Join(dir, ".claude/skills/vox-radio/SKILL.md"))
 	if string(data) == string(existingContent) {
 		t.Error("SKILL.md should be overwritten with --force")
 	}


### PR DESCRIPTION
## Summary

- `internal/cli/install_test.go` の `TestInstallCmd_SkillsExistingSkipped` と `TestInstallCmd_SkillsForceOverwrites` で重複していたインライン `MkdirAll + WriteFile` を、同パッケージの `init_test.go` で定義済みの `writeTestFile` ヘルパーに統一した
- 各テスト関数で 7 行あった初期化コードが 2 行に削減され、可読性が向上した

Closes #298

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)