### PR TITLE
refactor: slackpost_test.go の inline os.WriteFile パターンをヘルパーに抽出する

### DIFF
--- a/internal/cli/slackpost_test.go
+++ b/internal/cli/slackpost_test.go
@@ -88,14 +88,9 @@ func TestSlackpostCheck_ValidSpec_Success(t *testing.T) {
 }
 
 func TestSlackpostCheck_EmptyChannel_Error(t *testing.T) {
-	dir := t.TempDir()
-	content := `slack:
+	specPath := writeSlackSpecRawForTest(t, []byte(`slack:
   channel: ""
-`
-	specPath := filepath.Join(dir, "slack-spec.yaml")
-	if err := os.WriteFile(specPath, []byte(content), 0o644); err != nil {
-		t.Fatalf("write spec: %v", err)
-	}
+`))
 
 	cmd := cli.NewRootCmd()
 	cmd.SetArgs([]string{"slackpost", "check", specPath})
@@ -105,15 +100,10 @@ func TestSlackpostCheck_EmptyChannel_Error(t *testing.T) {
 }
 
 func TestSlackpostCheck_UnknownKey_Error(t *testing.T) {
-	dir := t.TempDir()
-	content := `slack:
+	specPath := writeSlackSpecRawForTest(t, []byte(`slack:
   channel: "C0123456789"
 unknown_key: value
-`
-	specPath := filepath.Join(dir, "slack-spec.yaml")
-	if err := os.WriteFile(specPath, []byte(content), 0o644); err != nil {
-		t.Fatalf("write spec: %v", err)
-	}
+`))
 
 	cmd := cli.NewRootCmd()
 	cmd.SetArgs([]string{"slackpost", "check", specPath})
@@ -124,15 +114,10 @@ unknown_key: value
 
 // program_id は SlackSpec から削除されたため、slackpost check で unknown key エラーになること
 func TestSlackpostCheck_ProgramID_RaisesUnknownKey(t *testing.T) {
-	dir := t.TempDir()
-	content := `program_id: my-radio
+	specPath := writeSlackSpecRawForTest(t, []byte(`program_id: my-radio
 slack:
   channel: "C0123456789"
-`
-	specPath := filepath.Join(dir, "slack-spec.yaml")
-	if err := os.WriteFile(specPath, []byte(content), 0o644); err != nil {
-		t.Fatalf("write spec: %v", err)
-	}
+`))
 
 	cmd := cli.NewRootCmd()
 	cmd.SetArgs([]string{"slackpost", "check", specPath})

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -19,22 +19,22 @@ func configTestdataPath(rel string) string {
 	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
 }
 
-func writeFeedSpecForTest(t *testing.T, content []byte) string {
+func writeTempFileForTest(t *testing.T, name string, content []byte) string {
 	t.Helper()
 	dir := t.TempDir()
-	path := filepath.Join(dir, "feed-spec.yaml")
+	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, content, 0o644); err != nil {
-		t.Fatalf("write feed spec: %v", err)
+		t.Fatalf("write %s: %v", name, err)
 	}
 	return path
 }
 
+func writeFeedSpecForTest(t *testing.T, content []byte) string {
+	t.Helper()
+	return writeTempFileForTest(t, "feed-spec.yaml", content)
+}
+
 func writeSlackSpecRawForTest(t *testing.T, content []byte) string {
 	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "slack-spec.yaml")
-	if err := os.WriteFile(path, content, 0o644); err != nil {
-		t.Fatalf("write slack spec: %v", err)
-	}
-	return path
+	return writeTempFileForTest(t, "slack-spec.yaml", content)
 }

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -28,3 +28,13 @@ func writeFeedSpecForTest(t *testing.T, content []byte) string {
 	}
 	return path
 }
+
+func writeSlackSpecRawForTest(t *testing.T, content []byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "slack-spec.yaml")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write slack spec: %v", err)
+	}
+	return path
+}


### PR DESCRIPTION
## Summary

- `internal/cli/slackpost_test.go` の 3 テスト（`TestSlackpostCheck_EmptyChannel_Error` / `TestSlackpostCheck_UnknownKey_Error` / `TestSlackpostCheck_ProgramID_RaisesUnknownKey`）でインライン繰り返されていた `t.TempDir + filepath.Join + os.WriteFile` パターンを `writeSlackSpecRawForTest` ヘルパーに抽出
- `testhelper_test.go` に `writeTempFileForTest(t, name, content)` 共通プリミティブを追加し、`writeFeedSpecForTest` と `writeSlackSpecRawForTest` の構造的重複を解消

Closes #334

---
🤖 Generated with [Claude Code](https://claude.ai/code)