### PR TITLE
refactor: テストヘルパーを internal/testutil パッケージに集約する

### DIFF
--- a/internal/cli/feedgen_check_test.go
+++ b/internal/cli/feedgen_check_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/cli"
+	"github.com/canpok1/vox-radio/internal/testutil"
 )
 
 func TestFeedgenCheck_ValidSpec_Success(t *testing.T) {
@@ -33,7 +34,7 @@ func TestFeedgenCheck_UnknownKey_Error(t *testing.T) {
 
 func TestFeedgenCheck_MissingRequiredField_Error(t *testing.T) {
 	// feed.language が欠落した feed-spec.yaml
-	specPath := writeFeedSpecForTest(t, []byte(`feed:
+	specPath := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(`feed:
   author: Test Author
   email: test@example.com
   site_url: https://example.com/
@@ -52,7 +53,7 @@ func TestFeedgenCheck_MissingRequiredField_Error(t *testing.T) {
 
 // program_id は FeedSpec から削除されたため、feedgen check で unknown key エラーになること
 func TestFeedgenCheck_ProgramID_RaisesUnknownKey(t *testing.T) {
-	specPath := writeFeedSpecForTest(t, []byte(`program_id: my-radio
+	specPath := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(`program_id: my-radio
 feed:
   language: ja
   author: Test Author

--- a/internal/cli/slackpost_test.go
+++ b/internal/cli/slackpost_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/cli"
+	"github.com/canpok1/vox-radio/internal/testutil"
 )
 
 func writeSlackSpecForTest(t *testing.T, dir, channel string) string {
@@ -88,7 +89,7 @@ func TestSlackpostCheck_ValidSpec_Success(t *testing.T) {
 }
 
 func TestSlackpostCheck_EmptyChannel_Error(t *testing.T) {
-	specPath := writeSlackSpecRawForTest(t, []byte(`slack:
+	specPath := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(`slack:
   channel: ""
 `))
 
@@ -100,7 +101,7 @@ func TestSlackpostCheck_EmptyChannel_Error(t *testing.T) {
 }
 
 func TestSlackpostCheck_UnknownKey_Error(t *testing.T) {
-	specPath := writeSlackSpecRawForTest(t, []byte(`slack:
+	specPath := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(`slack:
   channel: "C0123456789"
 unknown_key: value
 `))
@@ -114,7 +115,7 @@ unknown_key: value
 
 // program_id は SlackSpec から削除されたため、slackpost check で unknown key エラーになること
 func TestSlackpostCheck_ProgramID_RaisesUnknownKey(t *testing.T) {
-	specPath := writeSlackSpecRawForTest(t, []byte(`program_id: my-radio
+	specPath := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(`program_id: my-radio
 slack:
   channel: "C0123456789"
 `))

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -3,9 +3,6 @@ package cli_test
 import (
 	"path/filepath"
 	"runtime"
-	"testing"
-
-	"github.com/canpok1/vox-radio/internal/testutil"
 )
 
 // cliTestSrcDir is the absolute path of this test file's directory, resolved at init time.
@@ -18,14 +15,4 @@ func init() {
 
 func configTestdataPath(rel string) string {
 	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
-}
-
-func writeFeedSpecForTest(t *testing.T, content []byte) string {
-	t.Helper()
-	return testutil.WriteTempFile(t, "feed-spec.yaml", content)
-}
-
-func writeSlackSpecRawForTest(t *testing.T, content []byte) string {
-	t.Helper()
-	return testutil.WriteTempFile(t, "slack-spec.yaml", content)
 }

--- a/internal/cli/testhelper_test.go
+++ b/internal/cli/testhelper_test.go
@@ -1,10 +1,11 @@
 package cli_test
 
 import (
-	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/canpok1/vox-radio/internal/testutil"
 )
 
 // cliTestSrcDir is the absolute path of this test file's directory, resolved at init time.
@@ -19,22 +20,12 @@ func configTestdataPath(rel string) string {
 	return filepath.Join(cliTestSrcDir, "..", "config", "testdata", rel)
 }
 
-func writeTempFileForTest(t *testing.T, name string, content []byte) string {
-	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, content, 0o644); err != nil {
-		t.Fatalf("write %s: %v", name, err)
-	}
-	return path
-}
-
 func writeFeedSpecForTest(t *testing.T, content []byte) string {
 	t.Helper()
-	return writeTempFileForTest(t, "feed-spec.yaml", content)
+	return testutil.WriteTempFile(t, "feed-spec.yaml", content)
 }
 
 func writeSlackSpecRawForTest(t *testing.T, content []byte) string {
 	t.Helper()
-	return writeTempFileForTest(t, "slack-spec.yaml", content)
+	return testutil.WriteTempFile(t, "slack-spec.yaml", content)
 }

--- a/internal/model/feed_spec_test.go
+++ b/internal/model/feed_spec_test.go
@@ -1,12 +1,11 @@
 package model_test
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/testutil"
 )
 
 const validFeedSpecYAML = `
@@ -20,19 +19,7 @@ output:
   public: public
 `
 
-func writeTempFeedSpec(t *testing.T, content string) string {
-	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "feed-spec.yaml")
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write yaml: %v", err)
-	}
-	return path
-}
-
 func TestLoadFeedSpec_ValidYAML(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "feed-spec.yaml")
 	content := `
 feed:
   language: ja
@@ -47,9 +34,7 @@ feed:
 output:
   public: public
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write yaml: %v", err)
-	}
+	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(content))
 
 	cfg, err := model.LoadFeedSpec(path)
 	if err != nil {
@@ -115,7 +100,7 @@ func TestFeedSpec_EffectivePublicDir_Custom(t *testing.T) {
 }
 
 func TestLoadFeedSpecStrict_Valid(t *testing.T) {
-	path := writeTempFeedSpec(t, validFeedSpecYAML)
+	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(validFeedSpecYAML))
 	_, err := model.LoadFeedSpecStrict(path)
 	if err != nil {
 		t.Fatalf("LoadFeedSpecStrict: unexpected error: %v", err)
@@ -123,7 +108,7 @@ func TestLoadFeedSpecStrict_Valid(t *testing.T) {
 }
 
 func TestLoadFeedSpecStrict_UnknownKey(t *testing.T) {
-	path := writeTempFeedSpec(t, validFeedSpecYAML+"\nunknown_field: value\n")
+	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(validFeedSpecYAML+"\nunknown_field: value\n"))
 	_, err := model.LoadFeedSpecStrict(path)
 	if err == nil {
 		t.Error("LoadFeedSpecStrict: expected error for unknown key, got nil")
@@ -133,7 +118,7 @@ func TestLoadFeedSpecStrict_UnknownKey(t *testing.T) {
 // program_id は FeedSpec から削除されたため、strict モードで unknown key エラーになること
 func TestLoadFeedSpecStrict_ProgramIDField_RaisesUnknownKey(t *testing.T) {
 	content := "program_id: my-radio\n" + validFeedSpecYAML
-	path := writeTempFeedSpec(t, content)
+	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(content))
 	_, err := model.LoadFeedSpecStrict(path)
 	if err == nil {
 		t.Error("LoadFeedSpecStrict: expected error for program_id (unknown key), got nil")

--- a/internal/model/slack_spec_test.go
+++ b/internal/model/slack_spec_test.go
@@ -1,11 +1,10 @@
 package model_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/testutil"
 )
 
 const validSlackSpecYAML = `
@@ -19,18 +18,8 @@ slack:
     article: " • <{url}|{title}>"
 `
 
-func writeTempSlackSpec(t *testing.T, content string) string {
-	t.Helper()
-	dir := t.TempDir()
-	path := filepath.Join(dir, "slack-spec.yaml")
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write yaml: %v", err)
-	}
-	return path
-}
-
 func TestLoadSlackSpec_ValidYAML(t *testing.T) {
-	path := writeTempSlackSpec(t, validSlackSpecYAML)
+	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(validSlackSpecYAML))
 
 	spec, err := model.LoadSlackSpec(path)
 	if err != nil {
@@ -57,7 +46,7 @@ func TestLoadSlackSpec_MissingFile(t *testing.T) {
 
 func TestLoadSlackSpecStrict_UnknownKeyErrors(t *testing.T) {
 	content := validSlackSpecYAML + "\nunknown_key: value\n"
-	path := writeTempSlackSpec(t, content)
+	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(content))
 
 	_, err := model.LoadSlackSpecStrict(path)
 	if err == nil {
@@ -66,7 +55,7 @@ func TestLoadSlackSpecStrict_UnknownKeyErrors(t *testing.T) {
 }
 
 func TestLoadSlackSpecStrict_ValidYAML_Success(t *testing.T) {
-	path := writeTempSlackSpec(t, validSlackSpecYAML)
+	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(validSlackSpecYAML))
 
 	_, err := model.LoadSlackSpecStrict(path)
 	if err != nil {
@@ -77,7 +66,7 @@ func TestLoadSlackSpecStrict_ValidYAML_Success(t *testing.T) {
 // program_id は SlackSpec から削除されたため、strict モードで unknown key エラーになること
 func TestLoadSlackSpecStrict_ProgramIDField_RaisesUnknownKey(t *testing.T) {
 	content := "program_id: my-radio\n" + validSlackSpecYAML
-	path := writeTempSlackSpec(t, content)
+	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(content))
 
 	_, err := model.LoadSlackSpecStrict(path)
 	if err == nil {
@@ -90,7 +79,7 @@ func TestLoadSlackSpec_MessageOmitted_DefaultsToEmpty(t *testing.T) {
 slack:
   channel: "C0123456789"
 `
-	path := writeTempSlackSpec(t, content)
+	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(content))
 
 	spec, err := model.LoadSlackSpec(path)
 	if err != nil {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,0 +1,17 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// WriteTempFile writes content to a temp file named name inside t.TempDir() and returns its path.
+func WriteTempFile(t *testing.T, name string, content []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -1,0 +1,35 @@
+package testutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/testutil"
+)
+
+func TestWriteTempFile_ReturnsPathToWrittenFile(t *testing.T) {
+	content := []byte("hello: world\n")
+	path := testutil.WriteTempFile(t, "test.yaml", content)
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("content = %q, want %q", got, content)
+	}
+	if filepath.Base(path) != "test.yaml" {
+		t.Errorf("filename = %q, want %q", filepath.Base(path), "test.yaml")
+	}
+}
+
+func TestWriteTempFile_FileIsCleanedUpAfterTest(t *testing.T) {
+	var savedPath string
+	t.Run("inner", func(t *testing.T) {
+		savedPath = testutil.WriteTempFile(t, "cleanup.yaml", []byte("data"))
+	})
+	if _, err := os.Stat(savedPath); !os.IsNotExist(err) {
+		t.Errorf("expected file to be cleaned up, but it still exists: %s", savedPath)
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/testutil` パッケージを新設し、パッケージ横断で共有可能な `WriteTempFile` テストヘルパーを実装
- `internal/cli` と `internal/model` で重複していた temp ファイル書き込みロジックを削除し、`testutil.WriteTempFile` に統一
- 薄いラッパー関数（`writeFeedSpecForTest` / `writeSlackSpecRawForTest`）を除去し、呼び出し元を直接 `testutil.WriteTempFile` に変更

Closes #335

---
🤖 Generated with [Claude Code](https://claude.ai/code)