### PR TITLE
feat(eval): summary.md の LLM-as-judge 評価を導入する

### DIFF
--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -29,6 +29,12 @@ const (
 
 	// CornerSummary-only evaluation criteria.
 	CriterionSpecificity Criterion = "specificity"
+
+	// Summary-only evaluation criteria.
+	CriterionSummaryQuality      Criterion = "summary_quality"
+	CriterionEpisodeTitleQuality Criterion = "episode_title_quality"
+	CriterionNotesFaithfulness   Criterion = "notes_faithfulness"
+	CriterionNotesCoverage       Criterion = "notes_coverage"
 )
 
 // AllCriteria lists all proofread scoring dimensions in canonical order.
@@ -53,6 +59,14 @@ var AllCornerSummaryCriteria = []Criterion{
 	CriterionCoverage,
 	CriterionSpecificity,
 	CriterionFormatCompliance,
+}
+
+// AllSummaryCriteria lists all summary scoring dimensions in canonical order.
+var AllSummaryCriteria = []Criterion{
+	CriterionSummaryQuality,
+	CriterionEpisodeTitleQuality,
+	CriterionNotesFaithfulness,
+	CriterionNotesCoverage,
 }
 
 // ScoreEntry holds the score and reason for one criterion.

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -2,6 +2,7 @@ package eval
 
 import (
 	"errors"
+	"slices"
 	"testing"
 )
 
@@ -43,20 +44,51 @@ func TestCriterionValues(t *testing.T) {
 	}
 }
 
-func TestAllSummaryCriteria(t *testing.T) {
-	if len(AllSummaryCriteria) != 4 {
-		t.Errorf("AllSummaryCriteria length = %d, want 4", len(AllSummaryCriteria))
+func TestAllCriteria(t *testing.T) {
+	want := []Criterion{
+		CriterionDetectionRecall,
+		CriterionFalsePositiveSuppression,
+		CriterionCorrectionAccuracy,
+		CriterionReasonValidity,
 	}
+	if !slices.Equal(AllCriteria, want) {
+		t.Errorf("AllCriteria = %v, want %v", AllCriteria, want)
+	}
+}
+
+func TestAllSummarizeCriteria(t *testing.T) {
+	want := []Criterion{
+		CriterionFaithfulness,
+		CriterionCoverage,
+		CriterionConciseness,
+		CriterionFormatCompliance,
+	}
+	if !slices.Equal(AllSummarizeCriteria, want) {
+		t.Errorf("AllSummarizeCriteria = %v, want %v", AllSummarizeCriteria, want)
+	}
+}
+
+func TestAllCornerSummaryCriteria(t *testing.T) {
+	want := []Criterion{
+		CriterionFaithfulness,
+		CriterionCoverage,
+		CriterionSpecificity,
+		CriterionFormatCompliance,
+	}
+	if !slices.Equal(AllCornerSummaryCriteria, want) {
+		t.Errorf("AllCornerSummaryCriteria = %v, want %v", AllCornerSummaryCriteria, want)
+	}
+}
+
+func TestAllSummaryCriteria(t *testing.T) {
 	want := []Criterion{
 		CriterionSummaryQuality,
 		CriterionEpisodeTitleQuality,
 		CriterionNotesFaithfulness,
 		CriterionNotesCoverage,
 	}
-	for i, c := range want {
-		if AllSummaryCriteria[i] != c {
-			t.Errorf("AllSummaryCriteria[%d] = %q, want %q", i, AllSummaryCriteria[i], c)
-		}
+	if !slices.Equal(AllSummaryCriteria, want) {
+		t.Errorf("AllSummaryCriteria = %v, want %v", AllSummaryCriteria, want)
 	}
 }
 

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -31,10 +31,31 @@ func TestCriterionValues(t *testing.T) {
 		CriterionConciseness,
 		CriterionSpecificity,
 		CriterionFormatCompliance,
+		CriterionSummaryQuality,
+		CriterionEpisodeTitleQuality,
+		CriterionNotesFaithfulness,
+		CriterionNotesCoverage,
 	}
 	for _, c := range criteria {
 		if c == "" {
 			t.Errorf("criterion should not be empty string")
+		}
+	}
+}
+
+func TestAllSummaryCriteria(t *testing.T) {
+	if len(AllSummaryCriteria) != 4 {
+		t.Errorf("AllSummaryCriteria length = %d, want 4", len(AllSummaryCriteria))
+	}
+	want := []Criterion{
+		CriterionSummaryQuality,
+		CriterionEpisodeTitleQuality,
+		CriterionNotesFaithfulness,
+		CriterionNotesCoverage,
+	}
+	for i, c := range want {
+		if AllSummaryCriteria[i] != c {
+			t.Errorf("AllSummaryCriteria[%d] = %q, want %q", i, AllSummaryCriteria[i], c)
 		}
 	}
 }

--- a/internal/eval/summary_eval_test.go
+++ b/internal/eval/summary_eval_test.go
@@ -1,0 +1,236 @@
+//go:build eval
+
+package eval_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/eval"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// summaryScriptLine mirrors one element of the {{script_lines}} input for summary.md.
+type summaryScriptLine struct {
+	Speaker string `json:"speaker"`
+	Text    string `json:"text"`
+}
+
+// summaryCase is one entry in the summary testdata files.
+type summaryCase struct {
+	Name          string              `json:"name"`
+	Category      string              `json:"category"`
+	ScriptLines   []summaryScriptLine `json:"script_lines"`
+	SummaryLength int                 `json:"summary_length"`
+	Expectation   string              `json:"expectation,omitempty"`
+}
+
+// summaryOutputSchema is the JSON schema for the summary.md output.
+var summaryOutputSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["summary", "episode_title", "conversation_notes"],
+  "properties": {
+    "summary": {"type": "string"},
+    "episode_title": {"type": "string"},
+    "conversation_notes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["category", "character_ids", "note"],
+        "properties": {
+          "category": {"type": "string"},
+          "character_ids": {"type": "array", "items": {"type": "string"}},
+          "note": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
+
+// summaryJudgeSchema is the JSON schema for the summary judge LLM output.
+var summaryJudgeSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["scores"],
+  "properties": {
+    "scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["criterion", "score", "reason"],
+        "properties": {
+          "criterion": {
+            "type": "string",
+            "enum": ["summary_quality", "episode_title_quality", "notes_faithfulness", "notes_coverage"]
+          },
+          "score": {"type": "integer", "minimum": 1, "maximum": 5},
+          "reason": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
+
+func runSummary(ctx context.Context, t *testing.T, client llm.Client, promptTemplate string, ec summaryCase, linesJSON string) (json.RawMessage, error) {
+	t.Helper()
+	prompt := strings.NewReplacer(
+		"{{script_lines}}", linesJSON,
+		"{{summary_length}}", strconv.Itoa(ec.SummaryLength),
+	).Replace(promptTemplate)
+	return client.Complete(ctx, llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: summaryOutputSchema,
+	})
+}
+
+func TestSummaryEval(t *testing.T) {
+	if os.Getenv("GEMINI_API_KEY") == "" {
+		t.Skip("GEMINI_API_KEY not set")
+	}
+
+	// Build LLM clients.
+	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	targetCfg.MaxRetries = 2
+	targetClient := llm.NewClient(targetCfg)
+
+	// Judge model can be overridden via VOX_EVAL_JUDGE_MODEL.
+	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
+		judgeCfg.Model = jm
+	}
+	judgeCfg.MaxRetries = 2
+	judgeClient := llm.NewClient(judgeCfg)
+
+	threshold, err := getEnvFloat("VOX_EVAL_SUMMARY_THRESHOLD", 4.0)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SUMMARY_THRESHOLD: %v", err)
+	}
+
+	sampleSize, err := getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
+	}
+
+	seed, err := getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
+	}
+
+	summaryPrompt, err := eval.LoadPrompt("summary")
+	if err != nil {
+		t.Fatalf("load summary prompt: %v", err)
+	}
+
+	judgePrompt := loadTestdataString(t, "summary_judge.md")
+
+	// Load test sets.
+	regressionCases := loadCasesJSON[summaryCase](t, "summary_regression_cases.json")
+	poolCases := loadCasesJSON[summaryCase](t, "summary_pool_cases.json")
+
+	sampled := eval.Sample(poolCases, sampleSize, seed)
+	sampledNames := make([]string, len(sampled))
+	for i, c := range sampled {
+		sampledNames[i] = c.Name
+	}
+	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
+
+	// Bundle all cases: regression (all) + generalization (sampled).
+	type evaluationCase struct {
+		summaryCase
+		setType string
+	}
+	var allCases []evaluationCase
+	for _, c := range regressionCases {
+		allCases = append(allCases, evaluationCase{c, "regression"})
+	}
+	for _, c := range sampled {
+		allCases = append(allCases, evaluationCase{c, "generalization"})
+	}
+
+	ctx := context.Background()
+	var results []eval.CaseResult
+
+	for _, ec := range allCases {
+		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
+
+		linesJSONBytes, err := json.Marshal(ec.ScriptLines)
+		if err != nil {
+			t.Fatalf("marshal script_lines for case %s: %v", ec.Name, err)
+		}
+		linesJSON := string(linesJSONBytes)
+
+		// Step 1: run summary.
+		raw, err := runSummary(ctx, t, targetClient, summaryPrompt, ec.summaryCase, linesJSON)
+		if err != nil {
+			if eval.IsInconclusive(err) {
+				t.Skipf("summary API call failed (inconclusive) for case %s: %v", ec.Name, err)
+			}
+			t.Fatalf("summary failed for case %s: %v", ec.Name, err)
+		}
+
+		// Step 2: judge.
+		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, summaryJudgeSchema, eval.JudgeInput{
+			Placeholders: map[string]string{
+				"script_lines":   linesJSON,
+				"summary_output": string(raw),
+				"expectation":    eval.ResolveExpectation(ec.Expectation),
+			},
+		})
+		if err != nil {
+			if eval.IsInconclusive(err) {
+				t.Skipf("judge API call failed (inconclusive): %v", err)
+			}
+			t.Fatalf("judge failed for case %s: %v", ec.Name, err)
+		}
+
+		results = append(results, eval.CaseResult{
+			CaseName: ec.Name,
+			SetType:  ec.setType,
+			Scores:   scores,
+		})
+
+		for _, s := range scores {
+			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
+		}
+	}
+
+	if len(results) == 0 {
+		t.Skip("no results collected (all cases inconclusive)")
+	}
+
+	// Aggregate.
+	agg := eval.AggregateScores(results)
+
+	t.Logf("=== Aggregated scores ===")
+	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, threshold)
+	for _, c := range eval.AllSummaryCriteria {
+		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
+	}
+
+	// Check for regression failures with emphasis.
+	for _, r := range results {
+		if r.SetType != "regression" {
+			continue
+		}
+		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
+		if caseAgg.Overall < threshold {
+			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, threshold)
+			for _, s := range r.Scores {
+				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
+			}
+		}
+	}
+
+	// Overall quality check.
+	if agg.Overall < threshold {
+		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, threshold)
+	}
+}

--- a/internal/eval/testdata/summary_judge.md
+++ b/internal/eval/testdata/summary_judge.md
@@ -1,0 +1,56 @@
+# 番組要約プロンプト評価（LLM-as-judge）
+
+あなたはラジオ番組の要約タスクの評価者です。
+以下のセリフ一覧・正解説明・要約結果を見て、4つの観点でそれぞれ1〜5点（整数）で採点してください。
+
+## セリフ一覧
+
+```json
+{{script_lines}}
+```
+
+## 正解説明（expectation）
+
+{{expectation}}
+
+> `expectation` が「（なし）」の場合はセリフ一覧から妥当性を自律判断してください。
+
+## 要約結果
+
+```json
+{{summary_output}}
+```
+
+## 観点定義
+
+| 観点キー | 説明 |
+|---|---|
+| `summary_quality` | 要約品質: `summary` がこの回固有の内容を具体的に記述しており、固定説明文でなく `summary_length` 程度の分量か。リスナーがエピソードを選ぶ参考になるか。 |
+| `episode_title_quality` | サブタイトル品質: `episode_title` が15〜30文字程度・番組名や「第○回」等の固定フレーズを含まない・この回の内容を端的に表しているか。 |
+| `notes_faithfulness` | 会話メモ忠実性: `conversation_notes` の各メモが実際に語られた・起きたことのみを記述しており、創作・推測を含まないか。`character_ids` がセリフ一覧の `speaker` に実在するIDのみを使用しているか。 |
+| `notes_coverage` | 会話メモ網羅性: 事実の紹介・解説以外の会話要素（近況・掛け合い・感想・ハプニング・継続ネタ等）を幅広く拾えているか。セリフに個人的な会話が無い場合は空配列が正解。 |
+
+## 採点ガイドライン
+
+- `expectation` がある場合: それを正解基準として各観点を採点する。
+- `expectation` が「（なし）」の場合: セリフ一覧から重要な要点と要約の質を自律判断して採点する。
+- `summary` が汎用的な番組説明文（「この回ではさまざまな話題を取り上げました」等）のみで具体性がない場合、`summary_quality` は減点する。
+- `episode_title` が「第○回」「番組名」等の固定フレーズを含む場合や、30文字を大きく超える・15文字を大きく下回る場合は `episode_title_quality` を減点する。
+- セリフに書かれていない事実や創作を `conversation_notes` に含む場合、`notes_faithfulness` は大幅に減点する。
+- セリフ一覧に存在しない `speaker` のIDを `character_ids` に使った場合、`notes_faithfulness` は大幅に減点する。
+- セリフに個人的な会話・近況・掛け合いが存在するのに `conversation_notes` が空配列の場合、`notes_coverage` は減点する。
+- セリフが純粋な事実紹介・解説のみで個人的な会話要素がない場合、`conversation_notes` が空配列なら `notes_coverage` は満点（5点）とする。
+- 採点後は各観点の `reason` に採点理由を簡潔に記載する。
+
+## 出力形式
+
+```json
+{
+  "scores": [
+    {"criterion": "summary_quality", "score": 5, "reason": "採点理由"},
+    {"criterion": "episode_title_quality", "score": 5, "reason": "採点理由"},
+    {"criterion": "notes_faithfulness", "score": 5, "reason": "採点理由"},
+    {"criterion": "notes_coverage", "score": 5, "reason": "採点理由"}
+  ]
+}
+```

--- a/internal/eval/testdata/summary_pool_cases.json
+++ b/internal/eval/testdata/summary_pool_cases.json
@@ -1,0 +1,170 @@
+[
+  {
+    "name": "weekend_hobby_chat",
+    "category": "banter_rich",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今週はTypeScriptの型システムについて勉強したのだ。"},
+      {"speaker": "metan", "text": "あたくしも最近触り始めましたわ。ジェネリクスが便利ですよね。"},
+      {"speaker": "zundamon", "text": "そうなのだ！型推論が賢くて助かるのだ。"},
+      {"speaker": "metan", "text": "ところで、週末にハイキングに行ってきましたの。山頂から富士山が見えて感動しましたわ。"},
+      {"speaker": "zundamon", "text": "それはいいのだ！ボクも行きたいのだ。"},
+      {"speaker": "metan", "text": "ぜひ一緒に行きましょう。では TypeScript の話に戻りますが、interfaceとtypeの使い分けも重要で…"},
+      {"speaker": "zundamon", "text": "そうなのだ。場面によって使い分けるのが大事なのだ。"}
+    ],
+    "summary_length": 200
+  },
+  {
+    "name": "deep_dive_kubernetes",
+    "category": "technical",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今日はKubernetesのPod設計について詳しく解説するのだ。"},
+      {"speaker": "metan", "text": "PodはKubernetesの最小デプロイ単位ですね。"},
+      {"speaker": "zundamon", "text": "1つのPodには複数のコンテナを含められますが、基本は1コンテナが推奨なのだ。"},
+      {"speaker": "metan", "text": "リソースリクエストとリミットの設定も重要ですよね。"},
+      {"speaker": "zundamon", "text": "そうなのだ。設定しないとノードのリソースを使い果たすリスクがあるのだ。"},
+      {"speaker": "metan", "text": "ヘルスチェックのlivenessProbeとreadinessProbsも忘れずに設定すべきです。"},
+      {"speaker": "zundamon", "text": "以上、KubernetesのPod設計のポイントでした。"}
+    ],
+    "summary_length": 200
+  },
+  {
+    "name": "mistake_and_laughter",
+    "category": "banter_rich",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今回はSQLのインデックス最適化について話すのだ。"},
+      {"speaker": "metan", "text": "インデックスはWHERE句で使われるカラムに設定すると効果的ですね。"},
+      {"speaker": "zundamon", "text": "そうなのだ。ただしインデックスを増やしすぎると…えっと、なんだっけ。"},
+      {"speaker": "metan", "text": "書き込みパフォーマンスが落ちますわよ。"},
+      {"speaker": "zundamon", "text": "そうなのだ！言い間違えそうになったのだ。ありがとうのだ。"},
+      {"speaker": "metan", "text": "ふふ、大丈夫ですわ。複合インデックスの列順序も重要ですね。"},
+      {"speaker": "zundamon", "text": "そうなのだ。選択性の高いカラムを先頭に置くのがコツなのだ。"}
+    ],
+    "summary_length": 180
+  },
+  {
+    "name": "news_discussion_episode",
+    "category": "mixed",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今週は注目のAI関連ニュースをピックアップしたのだ。"},
+      {"speaker": "metan", "text": "まず大手クラウド各社が相次いでAI推論サービスを強化していますね。"},
+      {"speaker": "zundamon", "text": "コストが下がってきているのが嬉しいのだ。個人開発者でも使いやすくなってきたのだ。"},
+      {"speaker": "metan", "text": "そうですわね。あたくしも最近個人プロジェクトでAPIを使い始めましたわ。"},
+      {"speaker": "zundamon", "text": "おお、どんなプロジェクトなのだ？"},
+      {"speaker": "metan", "text": "読書記録をまとめてくれるツールを作っていますの。"},
+      {"speaker": "zundamon", "text": "それは面白そうなのだ！完成したら教えてほしいのだ。"},
+      {"speaker": "metan", "text": "もちろんですわ。次のニュースはオープンソースのLLMについてです。"}
+    ],
+    "summary_length": 220
+  },
+  {
+    "name": "short_announcement_episode",
+    "category": "no_banter",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今日はLinuxのプロセス管理コマンドを紹介するのだ。"},
+      {"speaker": "metan", "text": "psコマンドで実行中のプロセスを一覧できます。"},
+      {"speaker": "zundamon", "text": "killコマンドでプロセスを終了できるのだ。シグナル番号を指定して細かく制御もできるのだ。"},
+      {"speaker": "metan", "text": "topコマンドはCPU・メモリ使用率をリアルタイムで確認できて便利ですね。"},
+      {"speaker": "zundamon", "text": "以上でした。"}
+    ],
+    "summary_length": 130
+  },
+  {
+    "name": "listener_question_episode",
+    "category": "banter_rich",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今回はリスナーからの質問コーナーなのだ。"},
+      {"speaker": "metan", "text": "最初の質問は「Goの並行処理とPythonの非同期処理の違いを教えてください」ですね。"},
+      {"speaker": "zundamon", "text": "GoはgoroutineとチャネルでCSPスタイルの並行処理なのだ。"},
+      {"speaker": "metan", "text": "Pythonはイベントループベースの協調的マルチタスクですわね。"},
+      {"speaker": "zundamon", "text": "この質問、ボクも最初に悩んだのだ。懐かしいのだ。"},
+      {"speaker": "metan", "text": "あたくしはGoから入ったので最初はPythonのasyncioが不思議に感じましたわ。"},
+      {"speaker": "zundamon", "text": "次の質問はTypeScriptの型推論について、なのだ。"},
+      {"speaker": "metan", "text": "型推論はコードを読みながら変数の型を自動で決めてくれる機能ですね。"}
+    ],
+    "summary_length": 200
+  },
+  {
+    "name": "book_recommendation_episode",
+    "category": "mixed",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今回はおすすめの技術書を紹介するのだ。"},
+      {"speaker": "metan", "text": "最初の一冊は「Clean Code」ですね。コードの書き方の基本が学べます。"},
+      {"speaker": "zundamon", "text": "ボクはこの本を読んで変数名の付け方が変わったのだ。"},
+      {"speaker": "metan", "text": "わかりますわ。次は「Designing Data-Intensive Applications」です。"},
+      {"speaker": "zundamon", "text": "分散システムの設計を幅広く学べる名著なのだ！"},
+      {"speaker": "metan", "text": "少し難しいですが読み応えがありますね。あたくしは電子書籍で読みましたわ。"},
+      {"speaker": "zundamon", "text": "どちらもエンジニアなら手元に置いておきたい本なのだ。"}
+    ],
+    "summary_length": 200
+  },
+  {
+    "name": "failure_story_episode",
+    "category": "banter_rich",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今日はやらかし話コーナーなのだ。"},
+      {"speaker": "metan", "text": "あたくしの話から始めましょう。本番環境で誤ってDROP TABLEを実行しそうになったことがありますわ。"},
+      {"speaker": "zundamon", "text": "それはヒヤッとしたのだ！"},
+      {"speaker": "metan", "text": "直前でロールバックできましたが、それ以来必ずトランザクション内で確認するようにしていますの。"},
+      {"speaker": "zundamon", "text": "ボクはデプロイしたつもりが間違えてステージング環境に本番データを書き込んだことがあるのだ。"},
+      {"speaker": "metan", "text": "それも大変でしたわね。環境変数の管理は本当に大切ですね。"},
+      {"speaker": "zundamon", "text": "そうなのだ。みんな同じような失敗をするのだ。笑えるのだ。"}
+    ],
+    "summary_length": 220
+  },
+  {
+    "name": "tool_introduction_episode",
+    "category": "technical",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今回は開発効率を上げるCLIツールを紹介するのだ。"},
+      {"speaker": "metan", "text": "まずはfzfですね。ファジー検索でファイルやコマンド履歴を素早く探せます。"},
+      {"speaker": "zundamon", "text": "ripgrepも速くて便利なのだ。grepより大幅に速いのだ。"},
+      {"speaker": "metan", "text": "jqはJSONのパースと整形に欠かせませんね。"},
+      {"speaker": "zundamon", "text": "これらを組み合わせるとシェル作業がかなり快適になるのだ。"},
+      {"speaker": "metan", "text": "以上、おすすめCLIツールの紹介でした。"}
+    ],
+    "summary_length": 160
+  },
+  {
+    "name": "project_progress_episode",
+    "category": "banter_rich",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今週の作業報告をするのだ。"},
+      {"speaker": "metan", "text": "あたくしはAPIのレート制限実装を完成させましたわ。"},
+      {"speaker": "zundamon", "text": "おお、すごいのだ！どんな実装にしたのだ？"},
+      {"speaker": "metan", "text": "token bucketアルゴリズムを使いましたの。設定から柔軟に調整できるようにしましたわ。"},
+      {"speaker": "zundamon", "text": "ボクはテストカバレッジを80%以上に上げたのだ。"},
+      {"speaker": "metan", "text": "それは良い進捗ですわね。来週はデプロイですか？"},
+      {"speaker": "zundamon", "text": "そうなのだ。いよいよ本番リリースなのだ。少しドキドキするのだ。"},
+      {"speaker": "metan", "text": "一緒に頑張りましょう。"}
+    ],
+    "summary_length": 220
+  },
+  {
+    "name": "trivia_challenge_episode",
+    "category": "banter_rich",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今日はプログラミングトリビアクイズをするのだ！"},
+      {"speaker": "metan", "text": "第一問、C言語が開発された年は何年でしょうか？"},
+      {"speaker": "zundamon", "text": "1972年なのだ！"},
+      {"speaker": "metan", "text": "正解ですわ。では第二問、最初のウェブブラウザの名前は？"},
+      {"speaker": "zundamon", "text": "WorldWideWebなのだ！後にNexusに改名されたのだ。"},
+      {"speaker": "metan", "text": "完璧ですわ。ずんだもんさん、意外と物知りですね。"},
+      {"speaker": "zundamon", "text": "ボクはこういう豆知識が大好きなのだ！"},
+      {"speaker": "metan", "text": "次回もクイズコーナーやりたいですわね。"}
+    ],
+    "summary_length": 200
+  },
+  {
+    "name": "architecture_discussion_episode",
+    "category": "technical",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今回はマイクロサービスとモノリスの比較をするのだ。"},
+      {"speaker": "metan", "text": "モノリスはシンプルで開発初期には適していますね。"},
+      {"speaker": "zundamon", "text": "でもスケールが必要になってきたときにマイクロサービスへの移行を考えるのだ。"},
+      {"speaker": "metan", "text": "マイクロサービスはサービス間通信のオーバーヘッドや運用の複雑さがデメリットですね。"},
+      {"speaker": "zundamon", "text": "最近はモジュラーモノリスという中間的なアーキテクチャも注目されているのだ。"},
+      {"speaker": "metan", "text": "チームの規模やシステムの要件に合わせて選択するのが大切ですね。"}
+    ],
+    "summary_length": 180
+  }
+]

--- a/internal/eval/testdata/summary_regression_cases.json
+++ b/internal/eval/testdata/summary_regression_cases.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "rich_banter_episode",
+    "category": "banter_rich",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今日はPythonの非同期処理について話すのだ。"},
+      {"speaker": "metan", "text": "asyncioですね。最近あたくしもよく使います。"},
+      {"speaker": "zundamon", "text": "async/awaitで書くとコードがすっきりするよね。"},
+      {"speaker": "metan", "text": "ところで、昨日カフェで作業してたんですが、隣の人のPCの壁紙がうちの番組のキャラクターで驚きましたわ。"},
+      {"speaker": "zundamon", "text": "え、それはびっくりなのだ！リスナーさんかな？"},
+      {"speaker": "metan", "text": "声をかけようか迷って結局かけられなかったんです。"},
+      {"speaker": "zundamon", "text": "それは惜しかったのだ〜。次は勇気出して声かけてほしいのだ。"},
+      {"speaker": "metan", "text": "そうですわね！では本題に戻りますが、asyncioのイベントループの仕組みも重要で…"},
+      {"speaker": "zundamon", "text": "そうなのだ。タスクを並列で走らせるとパフォーマンスが上がるのだ。"}
+    ],
+    "summary_length": 200,
+    "expectation": "summaryはPythonのasyncio・async/await・イベントループによる非同期処理について200文字程度で具体的に述べること。episode_titleは「Pythonの非同期処理」等この回固有の内容を15〜30文字で表すこと（番組名や「第○回」は含まない）。conversation_notesには「めたんがカフェでリスナーと思われる人を見かけたが声をかけられなかった」というエピソードが含まれていること。character_idsはzundamonおよびmetanのみで存在しないIDを創作しないこと。"
+  },
+  {
+    "name": "factual_only_episode",
+    "category": "no_banter",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今回はDockerの基礎について解説します。"},
+      {"speaker": "metan", "text": "DockerはコンテナによってアプリをOSから分離して動かす技術です。"},
+      {"speaker": "zundamon", "text": "Dockerfileにイメージの構成を記述し、docker buildでイメージを作成します。"},
+      {"speaker": "metan", "text": "docker runでコンテナを起動します。-pオプションでポートをマッピングできます。"},
+      {"speaker": "zundamon", "text": "docker-composeを使えば複数のコンテナを一括管理できます。"},
+      {"speaker": "metan", "text": "以上、Dockerの基礎でした。"}
+    ],
+    "summary_length": 150,
+    "expectation": "summaryはDockerのコンテナ技術・Dockerfile・docker run・docker-composeについて150文字程度で具体的に述べること。episode_titleはDockerに関する15〜30文字のこの回固有のサブタイトル。conversation_notesは空配列（[]）が正解。セリフが事実の解説のみで個人的な会話要素がないため。"
+  },
+  {
+    "name": "known_speakers_episode",
+    "category": "speaker_check",
+    "script_lines": [
+      {"speaker": "host_a", "text": "今日はRustのメモリ安全性について話しましょう。"},
+      {"speaker": "host_b", "text": "Rustは所有権システムでメモリ管理をコンパイル時に保証するのが大きな特徴ですね。"},
+      {"speaker": "host_a", "text": "借用チェッカーがあることでnullポインタやデータ競合を防げます。"},
+      {"speaker": "host_b", "text": "先週Rustでコマンドラインツールを書いてみたんですが、最初はエラーだらけで大変でした。"},
+      {"speaker": "host_a", "text": "慣れるまでが大変ですよね。でも一度慣れると安心感が全然違います。"},
+      {"speaker": "host_b", "text": "確かに。パフォーマンスもCに近い速度が出るのが魅力です。"}
+    ],
+    "summary_length": 180,
+    "expectation": "summaryはRustの所有権システム・借用チェッカー・メモリ安全性について180文字程度で述べること。character_idsはhost_aおよびhost_bのみ使用し、それ以外のIDを創作しないこと。conversation_notesにはhost_bが先週Rustで開発した体験談が含まれていること。"
+  },
+  {
+    "name": "empty_notes_minimal_chat",
+    "category": "no_banter",
+    "script_lines": [
+      {"speaker": "zundamon", "text": "今回はGitのブランチ戦略を解説するのだ。"},
+      {"speaker": "metan", "text": "Git FlowとGitHub Flowの二つが代表的です。"},
+      {"speaker": "zundamon", "text": "Git Flowはmain・develop・feature・release・hotfixの5種類のブランチを使います。"},
+      {"speaker": "metan", "text": "GitHub Flowはシンプルで、mainブランチとfeatureブランチだけで運用できます。"},
+      {"speaker": "zundamon", "text": "小規模チームにはGitHub Flowが合っていることが多いのだ。"},
+      {"speaker": "metan", "text": "大規模リリース管理が必要な場合はGit Flowが向いていますね。"},
+      {"speaker": "zundamon", "text": "ありがとうございました、以上でした。"}
+    ],
+    "summary_length": 150,
+    "expectation": "summaryはGitのブランチ戦略（Git Flow・GitHub Flow）について150文字程度で具体的に述べること。episode_titleは15〜30文字のこの回固有のサブタイトル。conversation_notesは空配列が正解。セリフが純粋な技術解説のみで個人的な会話要素がない。"
+  }
+]


### PR DESCRIPTION
## Summary

- `internal/eval/eval.go` に summary 用 Criterion 定数 4 種（`summary_quality` / `episode_title_quality` / `notes_faithfulness` / `notes_coverage`）と `AllSummaryCriteria` スライスを追加
- `internal/eval/summary_eval_test.go` を `//go:build eval` 付きで実装
  - `VOX_EVAL_SUMMARY_THRESHOLD`（デフォルト 4.0）で合否判定
  - `VOX_EVAL_JUDGE_MODEL` / `VOX_EVAL_MIN_INTERVAL_MS` 対応
  - レートリミット等は inconclusive（`t.Skip`）扱い
  - 回帰ケース個別失敗を強調表示
- `testdata/` に judge プロンプト・回帰セット（4 件）・汎化プール（12 件）を追加
  - 回帰セットに 空 `conversation_notes` ケース・`character_ids` 創作検出ケースを含む
- `/simplify` 対応: 既存の criteria スライステストを `slices.Equal` で簡略化し、全 4 スライス（`AllCriteria` / `AllSummarizeCriteria` / `AllCornerSummaryCriteria` / `AllSummaryCriteria`）を対称テストでカバー
- スコープ外の /simplify 指摘（eval ループ共通化）は Issue #352 として追跡

## 関連

Closes #345

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)