### PR TITLE
feat(eval): select.md の LLM-as-judge 評価を導入する

### DIFF
--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -13,13 +13,13 @@ import (
 type Criterion string
 
 const (
-	// Proofread evaluation criteria.
+	// Proofread-only evaluation criteria.
 	CriterionDetectionRecall          Criterion = "detection_recall"
 	CriterionFalsePositiveSuppression Criterion = "false_positive_suppression"
 	CriterionCorrectionAccuracy       Criterion = "correction_accuracy"
-	CriterionReasonValidity           Criterion = "reason_validity"
 
 	// Shared evaluation criteria (used by multiple prompts).
+	CriterionReasonValidity   Criterion = "reason_validity"
 	CriterionFaithfulness     Criterion = "faithfulness"
 	CriterionCoverage         Criterion = "coverage"
 	CriterionFormatCompliance Criterion = "format_compliance"
@@ -35,6 +35,11 @@ const (
 	CriterionEpisodeTitleQuality Criterion = "episode_title_quality"
 	CriterionNotesFaithfulness   Criterion = "notes_faithfulness"
 	CriterionNotesCoverage       Criterion = "notes_coverage"
+
+	// Select-only evaluation criteria.
+	CriterionRelevance            Criterion = "relevance"
+	CriterionConstraintCompliance Criterion = "constraint_compliance"
+	CriterionOrderingQuality      Criterion = "ordering_quality"
 )
 
 // AllCriteria lists all proofread scoring dimensions in canonical order.
@@ -67,6 +72,14 @@ var AllSummaryCriteria = []Criterion{
 	CriterionEpisodeTitleQuality,
 	CriterionNotesFaithfulness,
 	CriterionNotesCoverage,
+}
+
+// AllSelectCriteria lists all select scoring dimensions in canonical order.
+var AllSelectCriteria = []Criterion{
+	CriterionRelevance,
+	CriterionConstraintCompliance,
+	CriterionOrderingQuality,
+	CriterionReasonValidity,
 }
 
 // ScoreEntry holds the score and reason for one criterion.

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -22,73 +22,75 @@ func TestResolveExpectation(t *testing.T) {
 }
 
 func TestCriterionValues(t *testing.T) {
-	criteria := []Criterion{
-		CriterionDetectionRecall,
-		CriterionFalsePositiveSuppression,
-		CriterionCorrectionAccuracy,
-		CriterionReasonValidity,
-		CriterionFaithfulness,
-		CriterionCoverage,
-		CriterionConciseness,
-		CriterionSpecificity,
-		CriterionFormatCompliance,
-		CriterionSummaryQuality,
-		CriterionEpisodeTitleQuality,
-		CriterionNotesFaithfulness,
-		CriterionNotesCoverage,
-	}
-	for _, c := range criteria {
+	all := slices.Concat(AllCriteria, AllSummarizeCriteria, AllCornerSummaryCriteria, AllSummaryCriteria, AllSelectCriteria)
+	for _, c := range all {
 		if c == "" {
 			t.Errorf("criterion should not be empty string")
 		}
 	}
 }
 
-func TestAllCriteria(t *testing.T) {
-	want := []Criterion{
-		CriterionDetectionRecall,
-		CriterionFalsePositiveSuppression,
-		CriterionCorrectionAccuracy,
-		CriterionReasonValidity,
+func TestAllXxxCriteria(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []Criterion
+		want []Criterion
+	}{
+		{
+			name: "AllCriteria",
+			got:  AllCriteria,
+			want: []Criterion{
+				CriterionDetectionRecall,
+				CriterionFalsePositiveSuppression,
+				CriterionCorrectionAccuracy,
+				CriterionReasonValidity,
+			},
+		},
+		{
+			name: "AllSummarizeCriteria",
+			got:  AllSummarizeCriteria,
+			want: []Criterion{
+				CriterionFaithfulness,
+				CriterionCoverage,
+				CriterionConciseness,
+				CriterionFormatCompliance,
+			},
+		},
+		{
+			name: "AllCornerSummaryCriteria",
+			got:  AllCornerSummaryCriteria,
+			want: []Criterion{
+				CriterionFaithfulness,
+				CriterionCoverage,
+				CriterionSpecificity,
+				CriterionFormatCompliance,
+			},
+		},
+		{
+			name: "AllSummaryCriteria",
+			got:  AllSummaryCriteria,
+			want: []Criterion{
+				CriterionSummaryQuality,
+				CriterionEpisodeTitleQuality,
+				CriterionNotesFaithfulness,
+				CriterionNotesCoverage,
+			},
+		},
+		{
+			name: "AllSelectCriteria",
+			got:  AllSelectCriteria,
+			want: []Criterion{
+				CriterionRelevance,
+				CriterionConstraintCompliance,
+				CriterionOrderingQuality,
+				CriterionReasonValidity,
+			},
+		},
 	}
-	if !slices.Equal(AllCriteria, want) {
-		t.Errorf("AllCriteria = %v, want %v", AllCriteria, want)
-	}
-}
-
-func TestAllSummarizeCriteria(t *testing.T) {
-	want := []Criterion{
-		CriterionFaithfulness,
-		CriterionCoverage,
-		CriterionConciseness,
-		CriterionFormatCompliance,
-	}
-	if !slices.Equal(AllSummarizeCriteria, want) {
-		t.Errorf("AllSummarizeCriteria = %v, want %v", AllSummarizeCriteria, want)
-	}
-}
-
-func TestAllCornerSummaryCriteria(t *testing.T) {
-	want := []Criterion{
-		CriterionFaithfulness,
-		CriterionCoverage,
-		CriterionSpecificity,
-		CriterionFormatCompliance,
-	}
-	if !slices.Equal(AllCornerSummaryCriteria, want) {
-		t.Errorf("AllCornerSummaryCriteria = %v, want %v", AllCornerSummaryCriteria, want)
-	}
-}
-
-func TestAllSummaryCriteria(t *testing.T) {
-	want := []Criterion{
-		CriterionSummaryQuality,
-		CriterionEpisodeTitleQuality,
-		CriterionNotesFaithfulness,
-		CriterionNotesCoverage,
-	}
-	if !slices.Equal(AllSummaryCriteria, want) {
-		t.Errorf("AllSummaryCriteria = %v, want %v", AllSummaryCriteria, want)
+	for _, tt := range tests {
+		if !slices.Equal(tt.got, tt.want) {
+			t.Errorf("%s = %v, want %v", tt.name, tt.got, tt.want)
+		}
 	}
 }
 

--- a/internal/eval/select_eval_test.go
+++ b/internal/eval/select_eval_test.go
@@ -1,0 +1,280 @@
+//go:build eval
+
+package eval_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/eval"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// selectCast mirrors the cast element passed to select.md.
+type selectCast struct {
+	CharacterID     string `json:"character_id"`
+	Role            string `json:"role"`
+	Type            string `json:"type"`
+	AppearanceCount int    `json:"appearance_count"`
+}
+
+// selectCorner mirrors the CornerForPrompt passed to select.md.
+type selectCorner struct {
+	Title                 string `json:"title"`
+	Content               string `json:"content"`
+	TargetDurationSeconds int    `json:"target_duration_seconds"`
+}
+
+// selectArticle mirrors the articleForPrompt passed to select.md.
+type selectArticle struct {
+	URL   string `json:"url"`
+	Title string `json:"title"`
+}
+
+// selectCase is one entry in the select testdata files.
+type selectCase struct {
+	Name        string          `json:"name"`
+	Category    string          `json:"category"`
+	Casts       []selectCast    `json:"casts"`
+	Corner      selectCorner    `json:"corner"`
+	Articles    []selectArticle `json:"articles"`
+	Expectation string          `json:"expectation,omitempty"`
+}
+
+// selectOutputSchema is the JSON schema for the select.md output.
+var selectOutputSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["selected_urls", "selection_reason"],
+  "properties": {
+    "selected_urls": {
+      "type": "array",
+      "items": {"type": "string"},
+      "minItems": 1
+    },
+    "selection_reason": {"type": "string"}
+  },
+  "additionalProperties": false
+}`)
+
+// selectJudgeSchema is the JSON schema for the select judge LLM output.
+var selectJudgeSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["scores"],
+  "properties": {
+    "scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["criterion", "score", "reason"],
+        "properties": {
+          "criterion": {
+            "type": "string",
+            "enum": ["relevance", "constraint_compliance", "ordering_quality", "reason_validity"]
+          },
+          "score": {"type": "integer", "minimum": 1, "maximum": 5},
+          "reason": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
+
+// selectOutput mirrors the select.md output for mechanical verification.
+type selectOutput struct {
+	SelectedURLs    []string `json:"selected_urls"`
+	SelectionReason string   `json:"selection_reason"`
+}
+
+func runSelect(ctx context.Context, t *testing.T, client llm.Client, promptTemplate string, castsJSON, cornerJSON, articlesJSON string) (json.RawMessage, error) {
+	t.Helper()
+	prompt := strings.NewReplacer(
+		"{{casts}}", castsJSON,
+		"{{corner}}", cornerJSON,
+		"{{articles}}", articlesJSON,
+	).Replace(promptTemplate)
+	return client.Complete(ctx, llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: selectOutputSchema,
+	})
+}
+
+func TestSelectEval(t *testing.T) {
+	if os.Getenv("GEMINI_API_KEY") == "" {
+		t.Skip("GEMINI_API_KEY not set")
+	}
+
+	// Build LLM clients.
+	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	targetCfg.MaxRetries = 2
+	targetClient := llm.NewClient(targetCfg)
+
+	// Judge model can be overridden via VOX_EVAL_JUDGE_MODEL.
+	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
+		judgeCfg.Model = jm
+	}
+	judgeCfg.MaxRetries = 2
+	judgeClient := llm.NewClient(judgeCfg)
+
+	threshold, err := getEnvFloat("VOX_EVAL_SELECT_THRESHOLD", 4.0)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SELECT_THRESHOLD: %v", err)
+	}
+
+	sampleSize, err := getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
+	}
+
+	seed, err := getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
+	}
+
+	selectPrompt, err := eval.LoadPrompt("select")
+	if err != nil {
+		t.Fatalf("load select prompt: %v", err)
+	}
+
+	judgePrompt := loadTestdataString(t, "select_judge.md")
+
+	// Load test sets.
+	regressionCases := loadCasesJSON[selectCase](t, "select_regression_cases.json")
+	poolCases := loadCasesJSON[selectCase](t, "select_pool_cases.json")
+
+	sampled := eval.Sample(poolCases, sampleSize, seed)
+	sampledNames := make([]string, len(sampled))
+	for i, c := range sampled {
+		sampledNames[i] = c.Name
+	}
+	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
+
+	// Bundle all cases: regression (all) + generalization (sampled).
+	type evaluationCase struct {
+		selectCase
+		setType string
+	}
+	var allCases []evaluationCase
+	for _, c := range regressionCases {
+		allCases = append(allCases, evaluationCase{c, "regression"})
+	}
+	for _, c := range sampled {
+		allCases = append(allCases, evaluationCase{c, "generalization"})
+	}
+
+	ctx := context.Background()
+	var results []eval.CaseResult
+
+	for _, ec := range allCases {
+		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
+
+		// Marshal inputs for use in prompt and judge.
+		castsJSONBytes, err := json.Marshal(ec.Casts)
+		if err != nil {
+			t.Fatalf("marshal casts for case %s: %v", ec.Name, err)
+		}
+		cornerJSONBytes, err := json.Marshal(ec.Corner)
+		if err != nil {
+			t.Fatalf("marshal corner for case %s: %v", ec.Name, err)
+		}
+		articlesJSONBytes, err := json.Marshal(ec.Articles)
+		if err != nil {
+			t.Fatalf("marshal articles for case %s: %v", ec.Name, err)
+		}
+		castsJSON := string(castsJSONBytes)
+		cornerJSON := string(cornerJSONBytes)
+		articlesJSON := string(articlesJSONBytes)
+
+		// Step 1: run select.
+		raw, err := runSelect(ctx, t, targetClient, selectPrompt, castsJSON, cornerJSON, articlesJSON)
+		if err != nil {
+			if eval.IsInconclusive(err) {
+				t.Skipf("select API call failed (inconclusive) for case %s: %v", ec.Name, err)
+			}
+			t.Fatalf("select failed for case %s: %v", ec.Name, err)
+		}
+
+		// Step 2: mechanical verification of constraint_compliance.
+		var output selectOutput
+		if err := json.Unmarshal(raw, &output); err != nil {
+			t.Fatalf("unmarshal select output for case %s: %v", ec.Name, err)
+		}
+		candidateURLs := make(map[string]bool, len(ec.Articles))
+		for _, a := range ec.Articles {
+			candidateURLs[a.URL] = true
+		}
+		if len(output.SelectedURLs) == 0 {
+			t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected_urls is empty (min 1 required)", ec.Name)
+		}
+		for _, u := range output.SelectedURLs {
+			if !candidateURLs[u] {
+				t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected URL %q is not in candidate set", ec.Name, u)
+			}
+		}
+
+		// Step 3: judge.
+		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, selectJudgeSchema, eval.JudgeInput{
+			Placeholders: map[string]string{
+				"casts":         castsJSON,
+				"corner":        cornerJSON,
+				"articles":      articlesJSON,
+				"select_output": string(raw),
+				"expectation":   eval.ResolveExpectation(ec.Expectation),
+			},
+		})
+		if err != nil {
+			if eval.IsInconclusive(err) {
+				t.Skipf("judge API call failed (inconclusive): %v", err)
+			}
+			t.Fatalf("judge failed for case %s: %v", ec.Name, err)
+		}
+
+		results = append(results, eval.CaseResult{
+			CaseName: ec.Name,
+			SetType:  ec.setType,
+			Scores:   scores,
+		})
+
+		for _, s := range scores {
+			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
+		}
+	}
+
+	if len(results) == 0 {
+		t.Skip("no results collected (all cases inconclusive)")
+	}
+
+	// Aggregate.
+	agg := eval.AggregateScores(results)
+
+	t.Logf("=== Aggregated scores ===")
+	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, threshold)
+	for _, c := range eval.AllSelectCriteria {
+		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
+	}
+
+	// Check for regression failures with emphasis.
+	for _, r := range results {
+		if r.SetType != "regression" {
+			continue
+		}
+		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
+		if caseAgg.Overall < threshold {
+			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, threshold)
+			for _, s := range r.Scores {
+				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
+			}
+		}
+	}
+
+	// Overall quality check.
+	if agg.Overall < threshold {
+		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, threshold)
+	}
+}

--- a/internal/eval/testdata/select_judge.md
+++ b/internal/eval/testdata/select_judge.md
@@ -1,0 +1,66 @@
+# 記事選別プロンプト評価（LLM-as-judge）
+
+あなたはラジオ番組の記事選別タスクの評価者です。
+以下のキャスト情報・コーナー情報・候補記事・正解説明・選別結果を見て、4つの観点でそれぞれ1〜5点（整数）で採点してください。
+
+## キャスト情報
+
+```json
+{{casts}}
+```
+
+## コーナー情報
+
+```json
+{{corner}}
+```
+
+## 候補記事（タイトルと URL）
+
+```json
+{{articles}}
+```
+
+## 正解説明（expectation）
+
+{{expectation}}
+
+> `expectation` が「（なし）」の場合はコーナー情報・候補記事から妥当性を自律判断してください。
+
+## 選別結果
+
+```json
+{{select_output}}
+```
+
+## 観点定義
+
+| 観点キー | 説明 |
+|---|---|
+| `relevance` | 適合性: コーナーの趣旨（`content`）・目標放送時間（`target_duration_seconds`）に合った記事を選べているか。コーナーの趣旨と無関係な記事を選んでいないか。 |
+| `constraint_compliance` | 制約遵守: `selected_urls` が候補記事内の URL のみを使用しているか・最低1件以上選ばれているか・URL 形式が正しいか。 |
+| `ordering_quality` | 紹介順の質: 選ばれた記事の紹介順が番組の流れとして自然・妥当か。関連性の高い記事が適切な順序で並んでいるか。 |
+| `reason_validity` | 選別理由の妥当性: `selection_reason` が選択意図・紹介順の根拠を的確に説明しているか。なぜその記事をその順で選んだか理由が明確か。 |
+
+## 採点ガイドライン
+
+- `expectation` がある場合: それを正解基準として各観点を採点する。
+- `expectation` が「（なし）」の場合: コーナー情報・候補記事から妥当性を自律判断して採点する。
+- 候補に存在しない URL が `selected_urls` に含まれる場合、`constraint_compliance` は大幅に減点する。
+- `selected_urls` が空の場合（最低1件制約違反）、`constraint_compliance` は大幅に減点する。
+- コーナー趣旨と明らかに無関係な記事が多く選ばれている場合、`relevance` は減点する。
+- `selection_reason` が空文字や「理由なし」のみの場合、`reason_validity` は大幅に減点する。
+- 採点後は各観点の `reason` に採点理由を簡潔に記載する。
+
+## 出力形式
+
+```json
+{
+  "scores": [
+    {"criterion": "relevance", "score": 5, "reason": "採点理由"},
+    {"criterion": "constraint_compliance", "score": 5, "reason": "採点理由"},
+    {"criterion": "ordering_quality", "score": 5, "reason": "採点理由"},
+    {"criterion": "reason_validity", "score": 5, "reason": "採点理由"}
+  ]
+}
+```

--- a/internal/eval/testdata/select_pool_cases.json
+++ b/internal/eval/testdata/select_pool_cases.json
@@ -1,0 +1,122 @@
+[
+  {
+    "name": "infra_corner_mixed_articles",
+    "category": "article_selection",
+    "casts": [
+      {"character_id": "metan", "role": "MC", "type": "regular", "appearance_count": 7},
+      {"character_id": "zundamon", "role": "アシスタント", "type": "regular", "appearance_count": 7}
+    ],
+    "corner": {
+      "title": "インフラ・クラウドニュース",
+      "content": "クラウドインフラ・DevOps・コンテナ技術に関するニュースを2〜3本紹介するコーナー。",
+      "target_duration_seconds": 240
+    },
+    "articles": [
+      {"url": "https://example.com/docker-security", "title": "Dockerコンテナのセキュリティ強化：最新ベストプラクティス"},
+      {"url": "https://example.com/aws-lambda-update", "title": "AWS Lambdaが新機能追加：実行時間制限が最大15分に延長"},
+      {"url": "https://example.com/frontend-css", "title": "CSSコンテナクエリの使い方：レスポンシブデザインの新手法"},
+      {"url": "https://example.com/terraform-module", "title": "Terraformモジュールの設計パターン：再利用性を高める方法"},
+      {"url": "https://example.com/nodejs-update", "title": "Node.js 22リリース：パフォーマンス改善と新API"},
+      {"url": "https://example.com/gcp-bigquery", "title": "BigQueryの新料金体系発表：コスト最適化のポイント"}
+    ]
+  },
+  {
+    "name": "security_corner_diverse",
+    "category": "article_selection",
+    "casts": [
+      {"character_id": "kiritan", "role": "MC", "type": "guest", "appearance_count": 1},
+      {"character_id": "metan", "role": "ホスト", "type": "regular", "appearance_count": 15}
+    ],
+    "corner": {
+      "title": "サイバーセキュリティ最前線",
+      "content": "サイバーセキュリティに関する最新ニュースを2〜3本紹介する。脆弱性・攻撃手法・防御対策を扱う。",
+      "target_duration_seconds": 270
+    },
+    "articles": [
+      {"url": "https://example.com/ransomware-trend", "title": "2024年ランサムウェア攻撃の動向：被害額が過去最高を更新"},
+      {"url": "https://example.com/zero-trust", "title": "ゼロトラストアーキテクチャ導入事例：中小企業での実装"},
+      {"url": "https://example.com/python-update", "title": "Python 3.13リリース：型ヒントの改善とパフォーマンス向上"},
+      {"url": "https://example.com/oauth-vuln", "title": "OAuth 2.0実装の脆弱性：フィッシング攻撃への悪用リスク"},
+      {"url": "https://example.com/game-dev", "title": "インディーゲーム開発のビジネスモデル：Steam成功事例分析"}
+    ]
+  },
+  {
+    "name": "beginner_friendly_corner",
+    "category": "article_selection",
+    "casts": [
+      {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 20},
+      {"character_id": "ankomon", "role": "アシスタント", "type": "guest", "appearance_count": 0}
+    ],
+    "corner": {
+      "title": "はじめてのプログラミング",
+      "content": "プログラミング初心者向けの情報を紹介するコーナー。入門記事・学習方法・ツール紹介などを2本程度紹介する。",
+      "target_duration_seconds": 200
+    },
+    "articles": [
+      {"url": "https://example.com/python-beginner", "title": "Python完全入門：ゼロから始めるプログラミング学習"},
+      {"url": "https://example.com/microservices-adv", "title": "マイクロサービス設計の落とし穴：大規模システムの失敗事例"},
+      {"url": "https://example.com/scratch-kids", "title": "Scratchで学ぶプログラミング的思考：小学生でも楽しめる"},
+      {"url": "https://example.com/kubernetes-adv", "title": "本番Kubernetesクラスターの運用：SREが教えるベストプラクティス"},
+      {"url": "https://example.com/vscode-tips", "title": "VSCode初心者向けおすすめ拡張機能10選"}
+    ]
+  },
+  {
+    "name": "oss_community_corner",
+    "category": "article_selection",
+    "casts": [
+      {"character_id": "metan", "role": "MC", "type": "regular", "appearance_count": 6}
+    ],
+    "corner": {
+      "title": "OSSコミュニティニュース",
+      "content": "オープンソースソフトウェアのリリース・コミュニティ動向・ライセンス問題などを3〜4本紹介するコーナー。",
+      "target_duration_seconds": 360
+    },
+    "articles": [
+      {"url": "https://example.com/linux-kernel-update", "title": "Linux Kernel 6.9リリース：主要変更点まとめ"},
+      {"url": "https://example.com/redis-license", "title": "RedisのライセンスをBSDからSSPLへ変更：コミュニティの反応"},
+      {"url": "https://example.com/valkey-fork", "title": "Redis代替のValkey：Linux Foundation主導でフォーク開始"},
+      {"url": "https://example.com/stock-market", "title": "日本株式市場の動向：テック株に注目集まる"},
+      {"url": "https://example.com/apache-arrow", "title": "Apache Arrowの採用が加速：データエンジニアリングでの活用事例"},
+      {"url": "https://example.com/sports-news", "title": "プロ野球開幕戦：各球団の戦力分析"}
+    ]
+  },
+  {
+    "name": "short_duration_corner",
+    "category": "edge_case",
+    "casts": [
+      {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 4},
+      {"character_id": "zunko", "role": "アシスタント", "type": "regular", "appearance_count": 4}
+    ],
+    "corner": {
+      "title": "速報ニュース",
+      "content": "本日の速報技術ニュースを1本だけ紹介するコーナー。最も注目度の高い1件に絞る。",
+      "target_duration_seconds": 90
+    },
+    "articles": [
+      {"url": "https://example.com/chatgpt-outage", "title": "ChatGPTが大規模障害：世界中で数時間アクセス不能に"},
+      {"url": "https://example.com/github-actions", "title": "GitHub Actionsに新機能：ジョブの一時停止と再開が可能に"},
+      {"url": "https://example.com/openai-new-model", "title": "OpenAIが次世代モデル発表：GPT-5の性能と価格を公開"},
+      {"url": "https://example.com/fashion-trends", "title": "2024年春夏ファッショントレンド：シンプルが鍵"}
+    ]
+  },
+  {
+    "name": "first_appearance_guest_corner",
+    "category": "article_selection",
+    "casts": [
+      {"character_id": "metan", "role": "MC", "type": "regular", "appearance_count": 9},
+      {"character_id": "itako", "role": "ゲスト", "type": "guest", "appearance_count": 0}
+    ],
+    "corner": {
+      "title": "週刊Webフロントエンド",
+      "content": "Webフロントエンド開発に関するニュース・ライブラリ更新・ブラウザ新機能などを2〜3本紹介するコーナー。",
+      "target_duration_seconds": 270
+    },
+    "articles": [
+      {"url": "https://example.com/react-19", "title": "React 19リリース：Server ComponentsとActionsが正式対応"},
+      {"url": "https://example.com/chrome-update", "title": "Chrome 124：Web標準の新機能とパフォーマンス改善"},
+      {"url": "https://example.com/backend-go", "title": "GoでのAPIサーバー実装：gRPC vs REST比較"},
+      {"url": "https://example.com/css-houdini", "title": "CSS Houdini APIの実用化：カスタムペイントの活用例"},
+      {"url": "https://example.com/database-orm", "title": "TypeScript向けORMの比較：Prisma vs Drizzle"}
+    ]
+  }
+]

--- a/internal/eval/testdata/select_regression_cases.json
+++ b/internal/eval/testdata/select_regression_cases.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "tech_news_corner_basic",
+    "category": "article_selection",
+    "casts": [
+      {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 5},
+      {"character_id": "metan", "role": "アシスタント", "type": "regular", "appearance_count": 3}
+    ],
+    "corner": {
+      "title": "今週のテックニュース",
+      "content": "最新の技術ニュースを3〜4本紹介するコーナー。AI・クラウド・プログラミング言語などITエンジニア向けの話題を扱う。",
+      "target_duration_seconds": 300
+    },
+    "articles": [
+      {"url": "https://example.com/ai-chip-perf", "title": "最新AIチップの性能が従来比3倍に向上"},
+      {"url": "https://example.com/cloud-cost", "title": "クラウドコスト削減の新戦略：スポットインスタンス活用ガイド"},
+      {"url": "https://example.com/cooking-recipe", "title": "時短料理レシピ特集：忙しいエンジニアのための夕食10選"},
+      {"url": "https://example.com/rust-async", "title": "Rustの非同期処理入門：async/awaitの使い方"},
+      {"url": "https://example.com/travel-guide", "title": "ゴールデンウィーク国内旅行おすすめスポット"}
+    ],
+    "expectation": "selected_urls にはテック系記事（AIチップ・クラウドコスト・Rust非同期）の URL が含まれ、料理・旅行の記事は含まれないこと。コーナー趣旨に合った3本程度を選ぶのが妥当。selection_reason にはコーナー趣旨（ITエンジニア向け技術ニュース）に基づく選別理由が述べられていること。"
+  },
+  {
+    "name": "single_candidate_must_select",
+    "category": "edge_case",
+    "casts": [
+      {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 10}
+    ],
+    "corner": {
+      "title": "セキュリティニュース",
+      "content": "セキュリティに関するニュースを紹介するコーナー。脆弱性情報・対策方法・業界動向などを扱う。",
+      "target_duration_seconds": 180
+    },
+    "articles": [
+      {"url": "https://example.com/vuln-patch", "title": "主要Linuxディストリビューションに影響するゼロデイ脆弱性にパッチ公開"}
+    ],
+    "expectation": "候補が1件のみのため、selected_urls には必ずその URL が含まれること。最低1件選ぶ制約を守ること。selection_reason には1件しか候補がなかった旨が記されているか、その記事の内容に基づく選択理由が述べられていること。"
+  },
+  {
+    "name": "narrow_corner_many_articles",
+    "category": "article_selection",
+    "casts": [
+      {"character_id": "zunko", "role": "解説", "type": "regular", "appearance_count": 8},
+      {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 12}
+    ],
+    "corner": {
+      "title": "AI最前線",
+      "content": "人工知能・機械学習・大規模言語モデルに特化したニュースを2本程度紹介するコーナー。深掘り解説を重視する。",
+      "target_duration_seconds": 240
+    },
+    "articles": [
+      {"url": "https://example.com/llm-new-model", "title": "新しい大規模言語モデルが公開、ベンチマークで最高性能"},
+      {"url": "https://example.com/ml-framework", "title": "機械学習フレームワークの最新バージョンリリース"},
+      {"url": "https://example.com/k8s-update", "title": "Kubernetes 1.30リリース：新機能まとめ"},
+      {"url": "https://example.com/go-generics", "title": "Go言語のジェネリクス活用パターン集"},
+      {"url": "https://example.com/ai-regulation", "title": "EU AI法が施行：企業が知っておくべき規制の概要"},
+      {"url": "https://example.com/database-perf", "title": "PostgreSQLのパフォーマンスチューニング実践"},
+      {"url": "https://example.com/llm-rag", "title": "RAGアーキテクチャによるLLMの精度改善手法"}
+    ],
+    "expectation": "selected_urls にはAI・LLM・機械学習に直接関連する記事（llm-new-model・ml-framework・ai-regulation・llm-rag）の中から2本程度が選ばれること。KubernetesやGo・PostgreSQLはAI専門コーナーの趣旨から外れるため含まれないことが望ましい。target_duration_seconds=240（4分）に対して2本が適切。selection_reason にはAI専門コーナーとしての絞り込み理由が述べられていること。"
+  }
+]


### PR DESCRIPTION
## Summary

- `internal/eval/eval.go` に select 専用評価観点定数（`relevance` / `constraint_compliance` / `ordering_quality`）と `AllSelectCriteria` を追加
- `CriterionReasonValidity` を「Proofread-only」から「Shared」セクションへ移動（proofread・select 共用のため）
- `internal/eval/select_eval_test.go` を `//go:build eval` で新規作成:
  - `GEMINI_API_KEY` 未設定時は `t.Skip`
  - 候補 URL の機械検証（件数 ≥1・候補集合内チェック）
  - LLM-as-judge による 4 観点（relevance / constraint_compliance / ordering_quality / reason_validity）採点
  - 全体平均が閾値（デフォルト 4.0、`VOX_EVAL_SELECT_THRESHOLD`）未満で `t.Errorf`
  - 回帰ケース個別失敗を強調表示
  - レートリミット/API エラーは inconclusive（`t.Skip`）扱い
- `testdata/select_judge.md` — judge プロンプト
- `testdata/select_regression_cases.json` — expectation 付き 3 件（基本選別・候補1件エッジケース・狭コーナー多候補）
- `testdata/select_pool_cases.json` — expectation なし 6 件（週次 seed サンプリング汎化セット）
- `eval_test.go` リファクタリング（/simplify 適用）:
  - `TestCriterionValues` を `AllXxx` スライスから自動導出し手動メンテ不要に
  - `TestAll*Criteria` 5 関数を `TestAllXxxCriteria` テーブル駆動テストに統合

Closes #346

---
🤖 Generated with [Claude Code](https://claude.ai/code)