### PR TITLE
refactor(eval): LLM-as-judge の共通 eval ループ・クライアント setup を共通ヘルパーに抽出する

### DIFF
--- a/internal/eval/corner_summary_eval_test.go
+++ b/internal/eval/corner_summary_eval_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -64,9 +63,7 @@ func runCornerSummary(ctx context.Context, t *testing.T, client llm.Client, prom
 }
 
 func TestCornerSummaryEval(t *testing.T) {
-	if os.Getenv("GEMINI_API_KEY") == "" {
-		t.Skip("GEMINI_API_KEY not set")
-	}
+	requireGeminiKey(t)
 
 	targetClient, judgeClient := buildEvalClients(t)
 
@@ -75,15 +72,7 @@ func TestCornerSummaryEval(t *testing.T) {
 		t.Fatalf("parse VOX_EVAL_CORNER_SUMMARY_THRESHOLD: %v", err)
 	}
 
-	sampleSize, err := getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
-	}
-
-	seed, err := getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
-	}
+	sampleSize, seed := loadSampleParams(t)
 
 	cornerSummaryPrompt, err := eval.LoadPrompt("corner_summary")
 	if err != nil {
@@ -103,18 +92,13 @@ func TestCornerSummaryEval(t *testing.T) {
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
 	caseByName := make(map[string]cornerSummaryCase, len(regressionCases)+len(sampled))
-	for _, c := range regressionCases {
-		caseByName[c.Name] = c
-	}
-	for _, c := range sampled {
-		caseByName[c.Name] = c
-	}
-
 	var allCases []harnessCase
 	for _, c := range regressionCases {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "regression"})
 	}
 	for _, c := range sampled {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 

--- a/internal/eval/corner_summary_eval_test.go
+++ b/internal/eval/corner_summary_eval_test.go
@@ -5,7 +5,7 @@ package eval_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -68,18 +68,7 @@ func TestCornerSummaryEval(t *testing.T) {
 		t.Skip("GEMINI_API_KEY not set")
 	}
 
-	// Build LLM clients.
-	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	targetCfg.MaxRetries = 2
-	targetClient := llm.NewClient(targetCfg)
-
-	// Judge model can be overridden via VOX_EVAL_JUDGE_MODEL.
-	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
-		judgeCfg.Model = jm
-	}
-	judgeCfg.MaxRetries = 2
-	judgeClient := llm.NewClient(judgeCfg)
+	targetClient, judgeClient := buildEvalClients(t)
 
 	threshold, err := getEnvFloat("VOX_EVAL_CORNER_SUMMARY_THRESHOLD", 4.0)
 	if err != nil {
@@ -103,7 +92,6 @@ func TestCornerSummaryEval(t *testing.T) {
 
 	judgePrompt := loadTestdataString(t, "corner_summary_judge.md")
 
-	// Load test sets.
 	regressionCases := loadCasesJSON[cornerSummaryCase](t, "corner_summary_regression_cases.json")
 	poolCases := loadCasesJSON[cornerSummaryCase](t, "corner_summary_pool_cases.json")
 
@@ -114,96 +102,49 @@ func TestCornerSummaryEval(t *testing.T) {
 	}
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
-	// Bundle all cases: regression (all) + generalization (sampled).
-	type evaluationCase struct {
-		cornerSummaryCase
-		setType string
-	}
-	var allCases []evaluationCase
+	caseByName := make(map[string]cornerSummaryCase, len(regressionCases)+len(sampled))
 	for _, c := range regressionCases {
-		allCases = append(allCases, evaluationCase{c, "regression"})
+		caseByName[c.Name] = c
 	}
 	for _, c := range sampled {
-		allCases = append(allCases, evaluationCase{c, "generalization"})
+		caseByName[c.Name] = c
+	}
+
+	var allCases []harnessCase
+	for _, c := range regressionCases {
+		allCases = append(allCases, harnessCase{c.Name, "regression"})
+	}
+	for _, c := range sampled {
+		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 
 	ctx := context.Background()
-	var results []eval.CaseResult
 
-	for _, ec := range allCases {
-		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
-
-		linesJSONBytes, err := json.Marshal(ec.ScriptLines)
-		if err != nil {
-			t.Fatalf("marshal script_lines for case %s: %v", ec.Name, err)
-		}
-		linesJSON := string(linesJSONBytes)
-
-		// Step 1: run corner_summary.
-		raw, err := runCornerSummary(ctx, t, targetClient, cornerSummaryPrompt, ec.cornerSummaryCase, linesJSON)
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("corner_summary API call failed (inconclusive) for case %s: %v", ec.Name, err)
+	runEvalHarness(ctx, t, allCases, harnessConfig{
+		Criteria:    eval.AllCornerSummaryCriteria,
+		JudgeClient: judgeClient,
+		JudgePrompt: judgePrompt,
+		JudgeSchema: cornerSummaryJudgeSchema,
+		Threshold:   threshold,
+		RunCase: func(ctx context.Context, t *testing.T, c harnessCase) (map[string]string, error) {
+			ec := caseByName[c.Name]
+			linesJSONBytes, err := json.Marshal(ec.ScriptLines)
+			if err != nil {
+				return nil, fmt.Errorf("marshal script_lines for case %s: %w", c.Name, err)
 			}
-			t.Fatalf("corner_summary failed for case %s: %v", ec.Name, err)
-		}
+			linesJSON := string(linesJSONBytes)
 
-		// Step 2: judge.
-		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, cornerSummaryJudgeSchema, eval.JudgeInput{
-			Placeholders: map[string]string{
+			raw, err := runCornerSummary(ctx, t, targetClient, cornerSummaryPrompt, ec, linesJSON)
+			if err != nil {
+				return nil, err
+			}
+
+			return map[string]string{
 				"corner_title":          ec.CornerTitle,
 				"script_lines":          linesJSON,
 				"corner_summary_output": string(raw),
 				"expectation":           eval.ResolveExpectation(ec.Expectation),
-			},
-		})
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("judge API call failed (inconclusive): %v", err)
-			}
-			t.Fatalf("judge failed for case %s: %v", ec.Name, err)
-		}
-
-		results = append(results, eval.CaseResult{
-			CaseName: ec.Name,
-			SetType:  ec.setType,
-			Scores:   scores,
-		})
-
-		for _, s := range scores {
-			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
-		}
-	}
-
-	if len(results) == 0 {
-		t.Skip("no results collected (all cases inconclusive)")
-	}
-
-	// Aggregate.
-	agg := eval.AggregateScores(results)
-
-	t.Logf("=== Aggregated scores ===")
-	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, threshold)
-	for _, c := range eval.AllCornerSummaryCriteria {
-		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
-	}
-
-	// Check for regression failures with emphasis.
-	for _, r := range results {
-		if r.SetType != "regression" {
-			continue
-		}
-		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
-		if caseAgg.Overall < threshold {
-			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, threshold)
-			for _, s := range r.Scores {
-				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
-			}
-		}
-	}
-
-	// Overall quality check.
-	if agg.Overall < threshold {
-		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, threshold)
-	}
+			}, nil
+		},
+	})
 }

--- a/internal/eval/eval_harness_test.go
+++ b/internal/eval/eval_harness_test.go
@@ -77,6 +77,29 @@ func getEnvInt64(key string, defaultVal int64) (int64, error) {
 	return strconv.ParseInt(v, 10, 64)
 }
 
+// requireGeminiKey skips the test if GEMINI_API_KEY is not set.
+func requireGeminiKey(t *testing.T) {
+	t.Helper()
+	if os.Getenv("GEMINI_API_KEY") == "" {
+		t.Skip("GEMINI_API_KEY not set")
+	}
+}
+
+// loadSampleParams reads VOX_EVAL_SAMPLE_SIZE and VOX_EVAL_SAMPLE_SEED from env.
+func loadSampleParams(t *testing.T) (sampleSize int, seed int64) {
+	t.Helper()
+	var err error
+	sampleSize, err = getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
+	}
+	seed, err = getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
+	}
+	return
+}
+
 // buildEvalClients creates target and judge LLM clients from env vars.
 func buildEvalClients(t *testing.T) (llm.Client, llm.Client) {
 	t.Helper()

--- a/internal/eval/eval_harness_test.go
+++ b/internal/eval/eval_harness_test.go
@@ -1,0 +1,182 @@
+//go:build eval
+
+package eval_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/eval"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+var testdataDir string
+
+func init() {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed")
+	}
+	testdataDir = filepath.Join(filepath.Dir(thisFile), "testdata")
+}
+
+func testdataPath(filename string) string {
+	return filepath.Join(testdataDir, filename)
+}
+
+func loadTestdataString(t *testing.T, filename string) string {
+	t.Helper()
+	data, err := os.ReadFile(testdataPath(filename))
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+	return string(data)
+}
+
+func loadCasesJSON[T any](t *testing.T, filename string) []T {
+	t.Helper()
+	data, err := os.ReadFile(testdataPath(filename))
+	if err != nil {
+		t.Fatalf("read %s: %v", filename, err)
+	}
+	var cases []T
+	if err := json.Unmarshal(data, &cases); err != nil {
+		t.Fatalf("parse %s: %v", filename, err)
+	}
+	return cases
+}
+
+func getEnvFloat(key string, defaultVal float64) (float64, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal, nil
+	}
+	return strconv.ParseFloat(v, 64)
+}
+
+func getEnvInt(key string, defaultVal int) (int, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal, nil
+	}
+	n, err := strconv.Atoi(v)
+	return n, err
+}
+
+func getEnvInt64(key string, defaultVal int64) (int64, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultVal, nil
+	}
+	return strconv.ParseInt(v, 10, 64)
+}
+
+// buildEvalClients creates target and judge LLM clients from env vars.
+func buildEvalClients(t *testing.T) (llm.Client, llm.Client) {
+	t.Helper()
+
+	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	targetCfg.MaxRetries = 2
+	targetClient := llm.NewClient(targetCfg)
+
+	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
+		judgeCfg.Model = jm
+	}
+	judgeCfg.MaxRetries = 2
+	judgeClient := llm.NewClient(judgeCfg)
+
+	return targetClient, judgeClient
+}
+
+// harnessCase holds the per-case info needed by the eval harness.
+type harnessCase struct {
+	Name    string
+	SetType string
+}
+
+// harnessConfig configures a call to runEvalHarness.
+type harnessConfig struct {
+	Criteria    []eval.Criterion
+	JudgeClient llm.Client
+	JudgePrompt string
+	JudgeSchema json.RawMessage
+	Threshold   float64
+	// RunCase runs the target prompt and returns judge placeholders.
+	// It may call t.Errorf for non-fatal constraint violations.
+	RunCase func(ctx context.Context, t *testing.T, c harnessCase) (map[string]string, error)
+}
+
+// runEvalHarness runs the common eval loop: invoke target → judge → aggregate → check.
+func runEvalHarness(ctx context.Context, t *testing.T, cases []harnessCase, cfg harnessConfig) {
+	t.Helper()
+
+	var results []eval.CaseResult
+
+	for _, c := range cases {
+		t.Logf("evaluating [%s] %s ...", c.SetType, c.Name)
+
+		placeholders, err := cfg.RunCase(ctx, t, c)
+		if err != nil {
+			if eval.IsInconclusive(err) {
+				t.Skipf("API call failed (inconclusive) for case %s: %v", c.Name, err)
+			}
+			t.Fatalf("case %s failed: %v", c.Name, err)
+		}
+
+		scores, err := eval.Judge(ctx, cfg.JudgeClient, cfg.JudgePrompt, cfg.JudgeSchema, eval.JudgeInput{
+			Placeholders: placeholders,
+		})
+		if err != nil {
+			if eval.IsInconclusive(err) {
+				t.Skipf("judge API call failed (inconclusive): %v", err)
+			}
+			t.Fatalf("judge failed for case %s: %v", c.Name, err)
+		}
+
+		results = append(results, eval.CaseResult{
+			CaseName: c.Name,
+			SetType:  c.SetType,
+			Scores:   scores,
+		})
+
+		for _, s := range scores {
+			t.Logf("  [%s] %s: %s=%d (%s)", c.SetType, c.Name, s.Criterion, s.Score, s.Reason)
+		}
+	}
+
+	if len(results) == 0 {
+		t.Skip("no results collected (all cases inconclusive)")
+	}
+
+	agg := eval.AggregateScores(results)
+
+	t.Logf("=== Aggregated scores ===")
+	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, cfg.Threshold)
+	for _, c := range cfg.Criteria {
+		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
+	}
+
+	for _, r := range results {
+		if r.SetType != "regression" {
+			continue
+		}
+		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
+		if caseAgg.Overall < cfg.Threshold {
+			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, cfg.Threshold)
+			for _, s := range r.Scores {
+				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
+			}
+		}
+	}
+
+	if agg.Overall < cfg.Threshold {
+		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, cfg.Threshold)
+	}
+}

--- a/internal/eval/proofread_eval_test.go
+++ b/internal/eval/proofread_eval_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -28,14 +27,6 @@ type proofreadCase struct {
 	Category    string          `json:"category"`
 	Lines       []proofreadLine `json:"lines"`
 	Expectation string          `json:"expectation,omitempty"`
-}
-
-func loadJudgePrompt(t *testing.T) string {
-	return loadTestdataString(t, "proofread_judge.md")
-}
-
-func loadCases(t *testing.T, filename string) []proofreadCase {
-	return loadCasesJSON[proofreadCase](t, filename)
 }
 
 var correctionsSchema = json.RawMessage(`{
@@ -94,9 +85,7 @@ func runProofread(ctx context.Context, t *testing.T, client llm.Client, proofrea
 }
 
 func TestProofreadEval(t *testing.T) {
-	if os.Getenv("GEMINI_API_KEY") == "" {
-		t.Skip("GEMINI_API_KEY not set")
-	}
+	requireGeminiKey(t)
 
 	targetClient, judgeClient := buildEvalClients(t)
 
@@ -105,25 +94,17 @@ func TestProofreadEval(t *testing.T) {
 		t.Fatalf("parse VOX_EVAL_PROOFREAD_THRESHOLD: %v", err)
 	}
 
-	sampleSize, err := getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
-	}
-
-	seed, err := getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
-	}
+	sampleSize, seed := loadSampleParams(t)
 
 	proofreadPrompt, err := eval.LoadPrompt("proofread")
 	if err != nil {
 		t.Fatalf("load proofread prompt: %v", err)
 	}
 
-	judgePrompt := loadJudgePrompt(t)
+	judgePrompt := loadTestdataString(t, "proofread_judge.md")
 
-	regressionCases := loadCases(t, "proofread_regression_cases.json")
-	poolCases := loadCases(t, "proofread_pool_cases.json")
+	regressionCases := loadCasesJSON[proofreadCase](t, "proofread_regression_cases.json")
+	poolCases := loadCasesJSON[proofreadCase](t, "proofread_pool_cases.json")
 
 	sampled := eval.Sample(poolCases, sampleSize, seed)
 	sampledNames := make([]string, len(sampled))
@@ -133,18 +114,13 @@ func TestProofreadEval(t *testing.T) {
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
 	caseByName := make(map[string]proofreadCase, len(regressionCases)+len(sampled))
-	for _, c := range regressionCases {
-		caseByName[c.Name] = c
-	}
-	for _, c := range sampled {
-		caseByName[c.Name] = c
-	}
-
 	var allCases []harnessCase
 	for _, c := range regressionCases {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "regression"})
 	}
 	for _, c := range sampled {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 

--- a/internal/eval/proofread_eval_test.go
+++ b/internal/eval/proofread_eval_test.go
@@ -5,32 +5,14 @@ package eval_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
+	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/eval"
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
-
-// testdataDir is resolved once at init time using runtime.Caller.
-var testdataDir string
-
-func init() {
-	_, thisFile, _, ok := runtime.Caller(0)
-	if !ok {
-		panic("runtime.Caller failed")
-	}
-	testdataDir = filepath.Join(filepath.Dir(thisFile), "testdata")
-}
-
-func testdataPath(filename string) string {
-	return filepath.Join(testdataDir, filename)
-}
 
 // proofreadLine mirrors the input format for proofread.md.
 type proofreadLine struct {
@@ -46,30 +28,6 @@ type proofreadCase struct {
 	Category    string          `json:"category"`
 	Lines       []proofreadLine `json:"lines"`
 	Expectation string          `json:"expectation,omitempty"`
-}
-
-// loadTestdataString reads a testdata file and returns its content as a string.
-func loadTestdataString(t *testing.T, filename string) string {
-	t.Helper()
-	data, err := os.ReadFile(testdataPath(filename))
-	if err != nil {
-		t.Fatalf("read %s: %v", filename, err)
-	}
-	return string(data)
-}
-
-// loadCasesJSON reads a testdata JSON file and unmarshals it into a slice of T.
-func loadCasesJSON[T any](t *testing.T, filename string) []T {
-	t.Helper()
-	data, err := os.ReadFile(testdataPath(filename))
-	if err != nil {
-		t.Fatalf("read %s: %v", filename, err)
-	}
-	var cases []T
-	if err := json.Unmarshal(data, &cases); err != nil {
-		t.Fatalf("parse %s: %v", filename, err)
-	}
-	return cases
 }
 
 func loadJudgePrompt(t *testing.T) string {
@@ -102,7 +60,6 @@ var correctionsSchema = json.RawMessage(`{
 	"additionalProperties": false
 }`)
 
-// proofreadJudgeSchema is the JSON schema for the proofread judge LLM output.
 var proofreadJudgeSchema = json.RawMessage(`{
   "type": "object",
   "required": ["scores"],
@@ -136,48 +93,12 @@ func runProofread(ctx context.Context, t *testing.T, client llm.Client, proofrea
 	})
 }
 
-func getEnvFloat(key string, defaultVal float64) (float64, error) {
-	v := os.Getenv(key)
-	if v == "" {
-		return defaultVal, nil
-	}
-	return strconv.ParseFloat(v, 64)
-}
-
-func getEnvInt(key string, defaultVal int) (int, error) {
-	v := os.Getenv(key)
-	if v == "" {
-		return defaultVal, nil
-	}
-	n, err := strconv.Atoi(v)
-	return n, err
-}
-
-func getEnvInt64(key string, defaultVal int64) (int64, error) {
-	v := os.Getenv(key)
-	if v == "" {
-		return defaultVal, nil
-	}
-	return strconv.ParseInt(v, 10, 64)
-}
-
 func TestProofreadEval(t *testing.T) {
 	if os.Getenv("GEMINI_API_KEY") == "" {
 		t.Skip("GEMINI_API_KEY not set")
 	}
 
-	// Build LLM clients.
-	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	targetCfg.MaxRetries = 2
-	targetClient := llm.NewClient(targetCfg)
-
-	// Judge model can be overridden via VOX_EVAL_JUDGE_MODEL.
-	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
-		judgeCfg.Model = jm
-	}
-	judgeCfg.MaxRetries = 2
-	judgeClient := llm.NewClient(judgeCfg)
+	targetClient, judgeClient := buildEvalClients(t)
 
 	threshold, err := getEnvFloat("VOX_EVAL_PROOFREAD_THRESHOLD", 4.0)
 	if err != nil {
@@ -201,7 +122,6 @@ func TestProofreadEval(t *testing.T) {
 
 	judgePrompt := loadJudgePrompt(t)
 
-	// Load test sets.
 	regressionCases := loadCases(t, "proofread_regression_cases.json")
 	poolCases := loadCases(t, "proofread_pool_cases.json")
 
@@ -212,96 +132,48 @@ func TestProofreadEval(t *testing.T) {
 	}
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
-	// Bundle all cases: regression (all) + generalization (sampled).
-	type evaluationCase struct {
-		proofreadCase
-		setType string
-	}
-	var allCases []evaluationCase
+	caseByName := make(map[string]proofreadCase, len(regressionCases)+len(sampled))
 	for _, c := range regressionCases {
-		allCases = append(allCases, evaluationCase{c, "regression"})
+		caseByName[c.Name] = c
 	}
 	for _, c := range sampled {
-		allCases = append(allCases, evaluationCase{c, "generalization"})
+		caseByName[c.Name] = c
+	}
+
+	var allCases []harnessCase
+	for _, c := range regressionCases {
+		allCases = append(allCases, harnessCase{c.Name, "regression"})
+	}
+	for _, c := range sampled {
+		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 
 	ctx := context.Background()
-	var results []eval.CaseResult
 
-	for _, ec := range allCases {
-		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
-
-		// Marshal lines once; reuse for proofread prompt and judge input.
-		linesJSONBytes, err := json.Marshal(ec.Lines)
-		if err != nil {
-			t.Fatalf("marshal lines for case %s: %v", ec.Name, err)
-		}
-		linesJSON := string(linesJSONBytes)
-
-		// Step 1: run proofread.
-		raw, err := runProofread(ctx, t, targetClient, proofreadPrompt, linesJSON)
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("proofread API call failed (inconclusive) for case %s: %v", ec.Name, err)
+	runEvalHarness(ctx, t, allCases, harnessConfig{
+		Criteria:    eval.AllCriteria,
+		JudgeClient: judgeClient,
+		JudgePrompt: judgePrompt,
+		JudgeSchema: proofreadJudgeSchema,
+		Threshold:   threshold,
+		RunCase: func(ctx context.Context, t *testing.T, c harnessCase) (map[string]string, error) {
+			ec := caseByName[c.Name]
+			linesJSONBytes, err := json.Marshal(ec.Lines)
+			if err != nil {
+				return nil, fmt.Errorf("marshal lines for case %s: %w", c.Name, err)
 			}
-			t.Fatalf("proofread failed for case %s: %v", ec.Name, err)
-		}
+			linesJSON := string(linesJSONBytes)
 
-		// Step 2: judge.
-		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, proofreadJudgeSchema, eval.JudgeInput{
-			Placeholders: map[string]string{
+			raw, err := runProofread(ctx, t, targetClient, proofreadPrompt, linesJSON)
+			if err != nil {
+				return nil, err
+			}
+
+			return map[string]string{
 				"lines":       linesJSON,
 				"corrections": string(raw),
 				"expectation": eval.ResolveExpectation(ec.Expectation),
-			},
-		})
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("judge API call failed (inconclusive): %v", err)
-			}
-			t.Fatalf("judge failed for case %s: %v", ec.Name, err)
-		}
-
-		results = append(results, eval.CaseResult{
-			CaseName: ec.Name,
-			SetType:  ec.setType,
-			Scores:   scores,
-		})
-
-		for _, s := range scores {
-			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
-		}
-	}
-
-	if len(results) == 0 {
-		t.Skip("no results collected (all cases inconclusive)")
-	}
-
-	// Aggregate.
-	agg := eval.AggregateScores(results)
-
-	t.Logf("=== Aggregated scores ===")
-	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, threshold)
-	for _, c := range eval.AllCriteria {
-		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
-	}
-
-	// Check for regression failures with emphasis.
-	for _, r := range results {
-		if r.SetType != "regression" {
-			continue
-		}
-		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
-		if caseAgg.Overall < threshold {
-			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, threshold)
-			for _, s := range r.Scores {
-				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
-			}
-		}
-	}
-
-	// Overall quality check.
-	if agg.Overall < threshold {
-		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, threshold)
-	}
+			}, nil
+		},
+	})
 }

--- a/internal/eval/select_eval_test.go
+++ b/internal/eval/select_eval_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -105,9 +104,7 @@ func runSelect(ctx context.Context, t *testing.T, client llm.Client, promptTempl
 }
 
 func TestSelectEval(t *testing.T) {
-	if os.Getenv("GEMINI_API_KEY") == "" {
-		t.Skip("GEMINI_API_KEY not set")
-	}
+	requireGeminiKey(t)
 
 	targetClient, judgeClient := buildEvalClients(t)
 
@@ -116,15 +113,7 @@ func TestSelectEval(t *testing.T) {
 		t.Fatalf("parse VOX_EVAL_SELECT_THRESHOLD: %v", err)
 	}
 
-	sampleSize, err := getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
-	}
-
-	seed, err := getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
-	}
+	sampleSize, seed := loadSampleParams(t)
 
 	selectPrompt, err := eval.LoadPrompt("select")
 	if err != nil {
@@ -144,18 +133,13 @@ func TestSelectEval(t *testing.T) {
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
 	caseByName := make(map[string]selectCase, len(regressionCases)+len(sampled))
-	for _, c := range regressionCases {
-		caseByName[c.Name] = c
-	}
-	for _, c := range sampled {
-		caseByName[c.Name] = c
-	}
-
 	var allCases []harnessCase
 	for _, c := range regressionCases {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "regression"})
 	}
 	for _, c := range sampled {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 

--- a/internal/eval/select_eval_test.go
+++ b/internal/eval/select_eval_test.go
@@ -5,7 +5,7 @@ package eval_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -109,18 +109,7 @@ func TestSelectEval(t *testing.T) {
 		t.Skip("GEMINI_API_KEY not set")
 	}
 
-	// Build LLM clients.
-	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	targetCfg.MaxRetries = 2
-	targetClient := llm.NewClient(targetCfg)
-
-	// Judge model can be overridden via VOX_EVAL_JUDGE_MODEL.
-	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
-		judgeCfg.Model = jm
-	}
-	judgeCfg.MaxRetries = 2
-	judgeClient := llm.NewClient(judgeCfg)
+	targetClient, judgeClient := buildEvalClients(t)
 
 	threshold, err := getEnvFloat("VOX_EVAL_SELECT_THRESHOLD", 4.0)
 	if err != nil {
@@ -144,7 +133,6 @@ func TestSelectEval(t *testing.T) {
 
 	judgePrompt := loadTestdataString(t, "select_judge.md")
 
-	// Load test sets.
 	regressionCases := loadCasesJSON[selectCase](t, "select_regression_cases.json")
 	poolCases := loadCasesJSON[selectCase](t, "select_pool_cases.json")
 
@@ -155,126 +143,79 @@ func TestSelectEval(t *testing.T) {
 	}
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
-	// Bundle all cases: regression (all) + generalization (sampled).
-	type evaluationCase struct {
-		selectCase
-		setType string
-	}
-	var allCases []evaluationCase
+	caseByName := make(map[string]selectCase, len(regressionCases)+len(sampled))
 	for _, c := range regressionCases {
-		allCases = append(allCases, evaluationCase{c, "regression"})
+		caseByName[c.Name] = c
 	}
 	for _, c := range sampled {
-		allCases = append(allCases, evaluationCase{c, "generalization"})
+		caseByName[c.Name] = c
+	}
+
+	var allCases []harnessCase
+	for _, c := range regressionCases {
+		allCases = append(allCases, harnessCase{c.Name, "regression"})
+	}
+	for _, c := range sampled {
+		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 
 	ctx := context.Background()
-	var results []eval.CaseResult
 
-	for _, ec := range allCases {
-		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
+	runEvalHarness(ctx, t, allCases, harnessConfig{
+		Criteria:    eval.AllSelectCriteria,
+		JudgeClient: judgeClient,
+		JudgePrompt: judgePrompt,
+		JudgeSchema: selectJudgeSchema,
+		Threshold:   threshold,
+		RunCase: func(ctx context.Context, t *testing.T, c harnessCase) (map[string]string, error) {
+			ec := caseByName[c.Name]
 
-		// Marshal inputs for use in prompt and judge.
-		castsJSONBytes, err := json.Marshal(ec.Casts)
-		if err != nil {
-			t.Fatalf("marshal casts for case %s: %v", ec.Name, err)
-		}
-		cornerJSONBytes, err := json.Marshal(ec.Corner)
-		if err != nil {
-			t.Fatalf("marshal corner for case %s: %v", ec.Name, err)
-		}
-		articlesJSONBytes, err := json.Marshal(ec.Articles)
-		if err != nil {
-			t.Fatalf("marshal articles for case %s: %v", ec.Name, err)
-		}
-		castsJSON := string(castsJSONBytes)
-		cornerJSON := string(cornerJSONBytes)
-		articlesJSON := string(articlesJSONBytes)
-
-		// Step 1: run select.
-		raw, err := runSelect(ctx, t, targetClient, selectPrompt, castsJSON, cornerJSON, articlesJSON)
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("select API call failed (inconclusive) for case %s: %v", ec.Name, err)
+			castsJSONBytes, err := json.Marshal(ec.Casts)
+			if err != nil {
+				return nil, fmt.Errorf("marshal casts for case %s: %w", c.Name, err)
 			}
-			t.Fatalf("select failed for case %s: %v", ec.Name, err)
-		}
-
-		// Step 2: mechanical verification of constraint_compliance.
-		var output selectOutput
-		if err := json.Unmarshal(raw, &output); err != nil {
-			t.Fatalf("unmarshal select output for case %s: %v", ec.Name, err)
-		}
-		candidateURLs := make(map[string]bool, len(ec.Articles))
-		for _, a := range ec.Articles {
-			candidateURLs[a.URL] = true
-		}
-		if len(output.SelectedURLs) == 0 {
-			t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected_urls is empty (min 1 required)", ec.Name)
-		}
-		for _, u := range output.SelectedURLs {
-			if !candidateURLs[u] {
-				t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected URL %q is not in candidate set", ec.Name, u)
+			cornerJSONBytes, err := json.Marshal(ec.Corner)
+			if err != nil {
+				return nil, fmt.Errorf("marshal corner for case %s: %w", c.Name, err)
 			}
-		}
+			articlesJSONBytes, err := json.Marshal(ec.Articles)
+			if err != nil {
+				return nil, fmt.Errorf("marshal articles for case %s: %w", c.Name, err)
+			}
+			castsJSON := string(castsJSONBytes)
+			cornerJSON := string(cornerJSONBytes)
+			articlesJSON := string(articlesJSONBytes)
 
-		// Step 3: judge.
-		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, selectJudgeSchema, eval.JudgeInput{
-			Placeholders: map[string]string{
+			raw, err := runSelect(ctx, t, targetClient, selectPrompt, castsJSON, cornerJSON, articlesJSON)
+			if err != nil {
+				return nil, err
+			}
+
+			// Mechanical verification of constraint_compliance.
+			var output selectOutput
+			if err := json.Unmarshal(raw, &output); err != nil {
+				return nil, fmt.Errorf("unmarshal select output for case %s: %w", c.Name, err)
+			}
+			candidateURLs := make(map[string]bool, len(ec.Articles))
+			for _, a := range ec.Articles {
+				candidateURLs[a.URL] = true
+			}
+			if len(output.SelectedURLs) == 0 {
+				t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected_urls is empty (min 1 required)", c.Name)
+			}
+			for _, u := range output.SelectedURLs {
+				if !candidateURLs[u] {
+					t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected URL %q is not in candidate set", c.Name, u)
+				}
+			}
+
+			return map[string]string{
 				"casts":         castsJSON,
 				"corner":        cornerJSON,
 				"articles":      articlesJSON,
 				"select_output": string(raw),
 				"expectation":   eval.ResolveExpectation(ec.Expectation),
-			},
-		})
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("judge API call failed (inconclusive): %v", err)
-			}
-			t.Fatalf("judge failed for case %s: %v", ec.Name, err)
-		}
-
-		results = append(results, eval.CaseResult{
-			CaseName: ec.Name,
-			SetType:  ec.setType,
-			Scores:   scores,
-		})
-
-		for _, s := range scores {
-			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
-		}
-	}
-
-	if len(results) == 0 {
-		t.Skip("no results collected (all cases inconclusive)")
-	}
-
-	// Aggregate.
-	agg := eval.AggregateScores(results)
-
-	t.Logf("=== Aggregated scores ===")
-	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, threshold)
-	for _, c := range eval.AllSelectCriteria {
-		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
-	}
-
-	// Check for regression failures with emphasis.
-	for _, r := range results {
-		if r.SetType != "regression" {
-			continue
-		}
-		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
-		if caseAgg.Overall < threshold {
-			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, threshold)
-			for _, s := range r.Scores {
-				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
-			}
-		}
-	}
-
-	// Overall quality check.
-	if agg.Overall < threshold {
-		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, threshold)
-	}
+			}, nil
+		},
+	})
 }

--- a/internal/eval/summarize_eval_test.go
+++ b/internal/eval/summarize_eval_test.go
@@ -5,7 +5,7 @@ package eval_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -81,18 +81,7 @@ func TestSummarizeEval(t *testing.T) {
 		t.Skip("GEMINI_API_KEY not set")
 	}
 
-	// Build LLM clients.
-	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	targetCfg.MaxRetries = 2
-	targetClient := llm.NewClient(targetCfg)
-
-	// Judge model can be overridden via VOX_EVAL_JUDGE_MODEL.
-	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
-		judgeCfg.Model = jm
-	}
-	judgeCfg.MaxRetries = 2
-	judgeClient := llm.NewClient(judgeCfg)
+	targetClient, judgeClient := buildEvalClients(t)
 
 	threshold, err := getEnvFloat("VOX_EVAL_SUMMARIZE_THRESHOLD", 4.0)
 	if err != nil {
@@ -116,7 +105,6 @@ func TestSummarizeEval(t *testing.T) {
 
 	judgePrompt := loadTestdataString(t, "summarize_judge.md")
 
-	// Load test sets.
 	regressionCases := loadCasesJSON[summarizeCase](t, "summarize_regression_cases.json")
 	poolCases := loadCasesJSON[summarizeCase](t, "summarize_pool_cases.json")
 
@@ -127,96 +115,48 @@ func TestSummarizeEval(t *testing.T) {
 	}
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
-	// Bundle all cases: regression (all) + generalization (sampled).
-	type evaluationCase struct {
-		summarizeCase
-		setType string
-	}
-	var allCases []evaluationCase
+	caseByName := make(map[string]summarizeCase, len(regressionCases)+len(sampled))
 	for _, c := range regressionCases {
-		allCases = append(allCases, evaluationCase{c, "regression"})
+		caseByName[c.Name] = c
 	}
 	for _, c := range sampled {
-		allCases = append(allCases, evaluationCase{c, "generalization"})
+		caseByName[c.Name] = c
+	}
+
+	var allCases []harnessCase
+	for _, c := range regressionCases {
+		allCases = append(allCases, harnessCase{c.Name, "regression"})
+	}
+	for _, c := range sampled {
+		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 
 	ctx := context.Background()
-	var results []eval.CaseResult
 
-	for _, ec := range allCases {
-		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
-
-		// Marshal article for use in summarize prompt and judge input.
-		articleJSONBytes, err := json.Marshal(ec.Article)
-		if err != nil {
-			t.Fatalf("marshal article for case %s: %v", ec.Name, err)
-		}
-		articleJSON := string(articleJSONBytes)
-
-		// Step 1: run summarize.
-		raw, err := runSummarize(ctx, t, targetClient, summarizePrompt, articleJSON)
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("summarize API call failed (inconclusive) for case %s: %v", ec.Name, err)
+	runEvalHarness(ctx, t, allCases, harnessConfig{
+		Criteria:    eval.AllSummarizeCriteria,
+		JudgeClient: judgeClient,
+		JudgePrompt: judgePrompt,
+		JudgeSchema: summarizeJudgeSchema,
+		Threshold:   threshold,
+		RunCase: func(ctx context.Context, t *testing.T, c harnessCase) (map[string]string, error) {
+			ec := caseByName[c.Name]
+			articleJSONBytes, err := json.Marshal(ec.Article)
+			if err != nil {
+				return nil, fmt.Errorf("marshal article for case %s: %w", c.Name, err)
 			}
-			t.Fatalf("summarize failed for case %s: %v", ec.Name, err)
-		}
+			articleJSON := string(articleJSONBytes)
 
-		// Step 2: judge.
-		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, summarizeJudgeSchema, eval.JudgeInput{
-			Placeholders: map[string]string{
+			raw, err := runSummarize(ctx, t, targetClient, summarizePrompt, articleJSON)
+			if err != nil {
+				return nil, err
+			}
+
+			return map[string]string{
 				"article":        articleJSON,
 				"summary_output": string(raw),
 				"expectation":    eval.ResolveExpectation(ec.Expectation),
-			},
-		})
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("judge API call failed (inconclusive): %v", err)
-			}
-			t.Fatalf("judge failed for case %s: %v", ec.Name, err)
-		}
-
-		results = append(results, eval.CaseResult{
-			CaseName: ec.Name,
-			SetType:  ec.setType,
-			Scores:   scores,
-		})
-
-		for _, s := range scores {
-			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
-		}
-	}
-
-	if len(results) == 0 {
-		t.Skip("no results collected (all cases inconclusive)")
-	}
-
-	// Aggregate.
-	agg := eval.AggregateScores(results)
-
-	t.Logf("=== Aggregated scores ===")
-	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, threshold)
-	for _, c := range eval.AllSummarizeCriteria {
-		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
-	}
-
-	// Check for regression failures with emphasis.
-	for _, r := range results {
-		if r.SetType != "regression" {
-			continue
-		}
-		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
-		if caseAgg.Overall < threshold {
-			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, threshold)
-			for _, s := range r.Scores {
-				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
-			}
-		}
-	}
-
-	// Overall quality check.
-	if agg.Overall < threshold {
-		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, threshold)
-	}
+			}, nil
+		},
+	})
 }

--- a/internal/eval/summarize_eval_test.go
+++ b/internal/eval/summarize_eval_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -77,9 +76,7 @@ func runSummarize(ctx context.Context, t *testing.T, client llm.Client, summariz
 }
 
 func TestSummarizeEval(t *testing.T) {
-	if os.Getenv("GEMINI_API_KEY") == "" {
-		t.Skip("GEMINI_API_KEY not set")
-	}
+	requireGeminiKey(t)
 
 	targetClient, judgeClient := buildEvalClients(t)
 
@@ -88,15 +85,7 @@ func TestSummarizeEval(t *testing.T) {
 		t.Fatalf("parse VOX_EVAL_SUMMARIZE_THRESHOLD: %v", err)
 	}
 
-	sampleSize, err := getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
-	}
-
-	seed, err := getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
-	}
+	sampleSize, seed := loadSampleParams(t)
 
 	summarizePrompt, err := eval.LoadPrompt("summarize")
 	if err != nil {
@@ -116,18 +105,13 @@ func TestSummarizeEval(t *testing.T) {
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
 	caseByName := make(map[string]summarizeCase, len(regressionCases)+len(sampled))
-	for _, c := range regressionCases {
-		caseByName[c.Name] = c
-	}
-	for _, c := range sampled {
-		caseByName[c.Name] = c
-	}
-
 	var allCases []harnessCase
 	for _, c := range regressionCases {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "regression"})
 	}
 	for _, c := range sampled {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 

--- a/internal/eval/summary_eval_test.go
+++ b/internal/eval/summary_eval_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -92,9 +91,7 @@ func runSummary(ctx context.Context, t *testing.T, client llm.Client, promptTemp
 }
 
 func TestSummaryEval(t *testing.T) {
-	if os.Getenv("GEMINI_API_KEY") == "" {
-		t.Skip("GEMINI_API_KEY not set")
-	}
+	requireGeminiKey(t)
 
 	targetClient, judgeClient := buildEvalClients(t)
 
@@ -103,15 +100,7 @@ func TestSummaryEval(t *testing.T) {
 		t.Fatalf("parse VOX_EVAL_SUMMARY_THRESHOLD: %v", err)
 	}
 
-	sampleSize, err := getEnvInt("VOX_EVAL_SAMPLE_SIZE", 8)
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SIZE: %v", err)
-	}
-
-	seed, err := getEnvInt64("VOX_EVAL_SAMPLE_SEED", eval.DefaultSeed())
-	if err != nil {
-		t.Fatalf("parse VOX_EVAL_SAMPLE_SEED: %v", err)
-	}
+	sampleSize, seed := loadSampleParams(t)
 
 	summaryPrompt, err := eval.LoadPrompt("summary")
 	if err != nil {
@@ -131,18 +120,13 @@ func TestSummaryEval(t *testing.T) {
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
 	caseByName := make(map[string]summaryCase, len(regressionCases)+len(sampled))
-	for _, c := range regressionCases {
-		caseByName[c.Name] = c
-	}
-	for _, c := range sampled {
-		caseByName[c.Name] = c
-	}
-
 	var allCases []harnessCase
 	for _, c := range regressionCases {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "regression"})
 	}
 	for _, c := range sampled {
+		caseByName[c.Name] = c
 		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 

--- a/internal/eval/summary_eval_test.go
+++ b/internal/eval/summary_eval_test.go
@@ -5,7 +5,7 @@ package eval_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -96,18 +96,7 @@ func TestSummaryEval(t *testing.T) {
 		t.Skip("GEMINI_API_KEY not set")
 	}
 
-	// Build LLM clients.
-	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	targetCfg.MaxRetries = 2
-	targetClient := llm.NewClient(targetCfg)
-
-	// Judge model can be overridden via VOX_EVAL_JUDGE_MODEL.
-	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
-	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
-		judgeCfg.Model = jm
-	}
-	judgeCfg.MaxRetries = 2
-	judgeClient := llm.NewClient(judgeCfg)
+	targetClient, judgeClient := buildEvalClients(t)
 
 	threshold, err := getEnvFloat("VOX_EVAL_SUMMARY_THRESHOLD", 4.0)
 	if err != nil {
@@ -131,7 +120,6 @@ func TestSummaryEval(t *testing.T) {
 
 	judgePrompt := loadTestdataString(t, "summary_judge.md")
 
-	// Load test sets.
 	regressionCases := loadCasesJSON[summaryCase](t, "summary_regression_cases.json")
 	poolCases := loadCasesJSON[summaryCase](t, "summary_pool_cases.json")
 
@@ -142,95 +130,48 @@ func TestSummaryEval(t *testing.T) {
 	}
 	t.Logf("seed=%d, sampled generalization cases: %v", seed, sampledNames)
 
-	// Bundle all cases: regression (all) + generalization (sampled).
-	type evaluationCase struct {
-		summaryCase
-		setType string
-	}
-	var allCases []evaluationCase
+	caseByName := make(map[string]summaryCase, len(regressionCases)+len(sampled))
 	for _, c := range regressionCases {
-		allCases = append(allCases, evaluationCase{c, "regression"})
+		caseByName[c.Name] = c
 	}
 	for _, c := range sampled {
-		allCases = append(allCases, evaluationCase{c, "generalization"})
+		caseByName[c.Name] = c
+	}
+
+	var allCases []harnessCase
+	for _, c := range regressionCases {
+		allCases = append(allCases, harnessCase{c.Name, "regression"})
+	}
+	for _, c := range sampled {
+		allCases = append(allCases, harnessCase{c.Name, "generalization"})
 	}
 
 	ctx := context.Background()
-	var results []eval.CaseResult
 
-	for _, ec := range allCases {
-		t.Logf("evaluating [%s] %s ...", ec.setType, ec.Name)
-
-		linesJSONBytes, err := json.Marshal(ec.ScriptLines)
-		if err != nil {
-			t.Fatalf("marshal script_lines for case %s: %v", ec.Name, err)
-		}
-		linesJSON := string(linesJSONBytes)
-
-		// Step 1: run summary.
-		raw, err := runSummary(ctx, t, targetClient, summaryPrompt, ec.summaryCase, linesJSON)
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("summary API call failed (inconclusive) for case %s: %v", ec.Name, err)
+	runEvalHarness(ctx, t, allCases, harnessConfig{
+		Criteria:    eval.AllSummaryCriteria,
+		JudgeClient: judgeClient,
+		JudgePrompt: judgePrompt,
+		JudgeSchema: summaryJudgeSchema,
+		Threshold:   threshold,
+		RunCase: func(ctx context.Context, t *testing.T, c harnessCase) (map[string]string, error) {
+			ec := caseByName[c.Name]
+			linesJSONBytes, err := json.Marshal(ec.ScriptLines)
+			if err != nil {
+				return nil, fmt.Errorf("marshal script_lines for case %s: %w", c.Name, err)
 			}
-			t.Fatalf("summary failed for case %s: %v", ec.Name, err)
-		}
+			linesJSON := string(linesJSONBytes)
 
-		// Step 2: judge.
-		scores, err := eval.Judge(ctx, judgeClient, judgePrompt, summaryJudgeSchema, eval.JudgeInput{
-			Placeholders: map[string]string{
+			raw, err := runSummary(ctx, t, targetClient, summaryPrompt, ec, linesJSON)
+			if err != nil {
+				return nil, err
+			}
+
+			return map[string]string{
 				"script_lines":   linesJSON,
 				"summary_output": string(raw),
 				"expectation":    eval.ResolveExpectation(ec.Expectation),
-			},
-		})
-		if err != nil {
-			if eval.IsInconclusive(err) {
-				t.Skipf("judge API call failed (inconclusive): %v", err)
-			}
-			t.Fatalf("judge failed for case %s: %v", ec.Name, err)
-		}
-
-		results = append(results, eval.CaseResult{
-			CaseName: ec.Name,
-			SetType:  ec.setType,
-			Scores:   scores,
-		})
-
-		for _, s := range scores {
-			t.Logf("  [%s] %s: %s=%d (%s)", ec.setType, ec.Name, s.Criterion, s.Score, s.Reason)
-		}
-	}
-
-	if len(results) == 0 {
-		t.Skip("no results collected (all cases inconclusive)")
-	}
-
-	// Aggregate.
-	agg := eval.AggregateScores(results)
-
-	t.Logf("=== Aggregated scores ===")
-	t.Logf("overall average: %.2f (threshold: %.2f)", agg.Overall, threshold)
-	for _, c := range eval.AllSummaryCriteria {
-		t.Logf("  %s: %.2f", c, agg.ByCriterion[c])
-	}
-
-	// Check for regression failures with emphasis.
-	for _, r := range results {
-		if r.SetType != "regression" {
-			continue
-		}
-		caseAgg := eval.AggregateScores([]eval.CaseResult{r})
-		if caseAgg.Overall < threshold {
-			t.Errorf("*** REGRESSION CASE FAILED *** [%s] overall=%.2f < threshold=%.2f", r.CaseName, caseAgg.Overall, threshold)
-			for _, s := range r.Scores {
-				slog.Warn("regression failure detail", "case", r.CaseName, "criterion", s.Criterion, "score", s.Score, "reason", s.Reason)
-			}
-		}
-	}
-
-	// Overall quality check.
-	if agg.Overall < threshold {
-		t.Errorf("overall average %.2f is below threshold %.2f", agg.Overall, threshold)
-	}
+			}, nil
+		},
+	})
 }


### PR DESCRIPTION
## Summary

- `eval_harness_test.go` を新規作成し、5つの eval テストファイルに散らばっていた共通コードを集約
- LLM クライアント setup ブロック（11行）× 5ファイルの重複を `buildEvalClients(t)` ヘルパーに抽出
- eval ループ本体（約90行）× 5ファイルの重複を `runEvalHarness(ctx, t, cases, cfg)` ハーネス関数に抽出
- プロンプト固有部分は `RunCase func(ctx, t, c harnessCase) (map[string]string, error)` コールバックで差し込む設計
- `requireGeminiKey(t)` / `loadSampleParams(t)` の追加、4ループ→2ループ統合など `/simplify` 指摘も対応済み

## 変更ファイル

- `internal/eval/eval_harness_test.go` (新規): 共通ヘルパー群・ハーネス関数
- `internal/eval/proofread_eval_test.go` (修正): ハーネス利用へ移行
- `internal/eval/summarize_eval_test.go` (修正): ハーネス利用へ移行
- `internal/eval/corner_summary_eval_test.go` (修正): ハーネス利用へ移行
- `internal/eval/summary_eval_test.go` (修正): ハーネス利用へ移行
- `internal/eval/select_eval_test.go` (修正): ハーネス利用へ移行

Closes #352

---
🤖 Generated with [Claude Code](https://claude.ai/code)