### PR TITLE
feat(eval): flow.md の LLM-as-judge 評価を導入する

### DIFF
--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -40,6 +40,12 @@ const (
 	CriterionRelevance            Criterion = "relevance"
 	CriterionConstraintCompliance Criterion = "constraint_compliance"
 	CriterionOrderingQuality      Criterion = "ordering_quality"
+
+	// Flow-only evaluation criteria.
+	CriterionPositionRoleFit  Criterion = "position_role_fit"
+	CriterionConsistency      Criterion = "consistency"
+	CriterionArticleAlignment Criterion = "article_alignment"
+	CriterionActionability    Criterion = "actionability"
 )
 
 // AllCriteria lists all proofread scoring dimensions in canonical order.
@@ -80,6 +86,14 @@ var AllSelectCriteria = []Criterion{
 	CriterionConstraintCompliance,
 	CriterionOrderingQuality,
 	CriterionReasonValidity,
+}
+
+// AllFlowCriteria lists all flow scoring dimensions in canonical order.
+var AllFlowCriteria = []Criterion{
+	CriterionPositionRoleFit,
+	CriterionConsistency,
+	CriterionArticleAlignment,
+	CriterionActionability,
 }
 
 // ScoreEntry holds the score and reason for one criterion.

--- a/internal/eval/eval_harness_test.go
+++ b/internal/eval/eval_harness_test.go
@@ -18,6 +18,21 @@ import (
 
 var testdataDir string
 
+// evalCorner mirrors the CornerForPrompt shared across prompt eval tests.
+type evalCorner struct {
+	Title                 string `json:"title"`
+	Content               string `json:"content"`
+	TargetDurationSeconds int    `json:"target_duration_seconds"`
+}
+
+// evalCast mirrors the RundownCast (LLM-facing) shared across prompt eval tests.
+type evalCast struct {
+	CharacterID     string `json:"character_id"`
+	Role            string `json:"role"`
+	Type            string `json:"type"`
+	AppearanceCount int    `json:"appearance_count"`
+}
+
 func init() {
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -22,7 +22,7 @@ func TestResolveExpectation(t *testing.T) {
 }
 
 func TestCriterionValues(t *testing.T) {
-	all := slices.Concat(AllCriteria, AllSummarizeCriteria, AllCornerSummaryCriteria, AllSummaryCriteria, AllSelectCriteria)
+	all := slices.Concat(AllCriteria, AllSummarizeCriteria, AllCornerSummaryCriteria, AllSummaryCriteria, AllSelectCriteria, AllFlowCriteria)
 	for _, c := range all {
 		if c == "" {
 			t.Errorf("criterion should not be empty string")
@@ -84,6 +84,16 @@ func TestAllXxxCriteria(t *testing.T) {
 				CriterionConstraintCompliance,
 				CriterionOrderingQuality,
 				CriterionReasonValidity,
+			},
+		},
+		{
+			name: "AllFlowCriteria",
+			got:  AllFlowCriteria,
+			want: []Criterion{
+				CriterionPositionRoleFit,
+				CriterionConsistency,
+				CriterionArticleAlignment,
+				CriterionActionability,
 			},
 		},
 	}

--- a/internal/eval/flow_eval_test.go
+++ b/internal/eval/flow_eval_test.go
@@ -13,13 +13,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
 
-// flowCorner mirrors the CornerForPrompt passed to flow.md.
-type flowCorner struct {
-	Title                 string `json:"title"`
-	Content               string `json:"content"`
-	TargetDurationSeconds int    `json:"target_duration_seconds"`
-}
-
 // flowArticle mirrors the RundownArticle passed to flow.md.
 type flowArticle struct {
 	URL     string   `json:"url"`
@@ -35,18 +28,10 @@ type flowCornerForProgram struct {
 	Articles        []flowArticle `json:"articles"`
 }
 
-// flowCast mirrors the RundownCast (LLM-facing) passed as part of {{program}}.
-type flowCast struct {
-	CharacterID     string `json:"character_id"`
-	Role            string `json:"role"`
-	Type            string `json:"type"`
-	AppearanceCount int    `json:"appearance_count"`
-}
-
 // flowProgram mirrors the programForPrompt passed to flow.md.
 type flowProgram struct {
 	Corners []flowCornerForProgram `json:"corners"`
-	Casts   []flowCast             `json:"casts"`
+	Casts   []evalCast             `json:"casts"`
 }
 
 // flowCase is one entry in the flow testdata files.
@@ -54,7 +39,7 @@ type flowCase struct {
 	Name            string        `json:"name"`
 	Category        string        `json:"category"`
 	Position        string        `json:"position"`
-	Corner          flowCorner    `json:"corner"`
+	Corner          evalCorner    `json:"corner"`
 	Articles        []flowArticle `json:"articles"`
 	SelectionReason string        `json:"selection_reason"`
 	Program         flowProgram   `json:"program"`

--- a/internal/eval/flow_eval_test.go
+++ b/internal/eval/flow_eval_test.go
@@ -1,0 +1,195 @@
+//go:build eval
+
+package eval_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/eval"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// flowCorner mirrors the CornerForPrompt passed to flow.md.
+type flowCorner struct {
+	Title                 string `json:"title"`
+	Content               string `json:"content"`
+	TargetDurationSeconds int    `json:"target_duration_seconds"`
+}
+
+// flowArticle mirrors the RundownArticle passed to flow.md.
+type flowArticle struct {
+	URL     string   `json:"url"`
+	Title   string   `json:"title"`
+	Summary string   `json:"summary"`
+	Points  []string `json:"points"`
+}
+
+// flowCornerForProgram mirrors the cornerForProgram passed as part of {{program}}.
+type flowCornerForProgram struct {
+	Title           string        `json:"title"`
+	SelectionReason string        `json:"selection_reason"`
+	Articles        []flowArticle `json:"articles"`
+}
+
+// flowCast mirrors the RundownCast (LLM-facing) passed as part of {{program}}.
+type flowCast struct {
+	CharacterID     string `json:"character_id"`
+	Role            string `json:"role"`
+	Type            string `json:"type"`
+	AppearanceCount int    `json:"appearance_count"`
+}
+
+// flowProgram mirrors the programForPrompt passed to flow.md.
+type flowProgram struct {
+	Corners []flowCornerForProgram `json:"corners"`
+	Casts   []flowCast             `json:"casts"`
+}
+
+// flowCase is one entry in the flow testdata files.
+type flowCase struct {
+	Name            string        `json:"name"`
+	Category        string        `json:"category"`
+	Position        string        `json:"position"`
+	Corner          flowCorner    `json:"corner"`
+	Articles        []flowArticle `json:"articles"`
+	SelectionReason string        `json:"selection_reason"`
+	Program         flowProgram   `json:"program"`
+	Expectation     string        `json:"expectation,omitempty"`
+}
+
+// flowOutputSchema is the JSON schema for the flow.md output.
+var flowOutputSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["flow"],
+  "properties": {
+    "flow": {"type": "string"}
+  },
+  "additionalProperties": false
+}`)
+
+// flowJudgeSchema is the JSON schema for the flow judge LLM output.
+var flowJudgeSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["scores"],
+  "properties": {
+    "scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["criterion", "score", "reason"],
+        "properties": {
+          "criterion": {
+            "type": "string",
+            "enum": ["position_role_fit", "consistency", "article_alignment", "actionability"]
+          },
+          "score": {"type": "integer", "minimum": 1, "maximum": 5},
+          "reason": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
+
+// flowOutput mirrors the flow.md output.
+type flowOutput struct {
+	Flow string `json:"flow"`
+}
+
+func runFlow(ctx context.Context, t *testing.T, client llm.Client, promptTemplate string, cornerJSON, articlesJSON, programJSON, position, selectionReason string) (json.RawMessage, error) {
+	t.Helper()
+	prompt := strings.NewReplacer(
+		"{{corner}}", cornerJSON,
+		"{{position}}", position,
+		"{{articles}}", articlesJSON,
+		"{{selection_reason}}", selectionReason,
+		"{{program}}", programJSON,
+	).Replace(promptTemplate)
+	return client.Complete(ctx, llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: flowOutputSchema,
+	})
+}
+
+func TestFlowEval(t *testing.T) {
+	requireGeminiKey(t)
+
+	targetClient, judgeClient := buildEvalClients(t)
+
+	threshold, err := getEnvFloat("VOX_EVAL_FLOW_THRESHOLD", 4.0)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_FLOW_THRESHOLD: %v", err)
+	}
+
+	sampleSize, seed := loadSampleParams(t)
+
+	flowPrompt, err := eval.LoadPrompt("flow")
+	if err != nil {
+		t.Fatalf("load flow prompt: %v", err)
+	}
+
+	judgePrompt := loadTestdataString(t, "flow_judge.md")
+
+	regressionCases := loadCasesJSON[flowCase](t, "flow_regression_cases.json")
+	poolCases := loadCasesJSON[flowCase](t, "flow_pool_cases.json")
+
+	allCases, caseByName := buildHarnessCases(t, regressionCases, poolCases, sampleSize, seed, func(c flowCase) string { return c.Name })
+
+	ctx := context.Background()
+
+	runEvalHarness(ctx, t, allCases, harnessConfig{
+		Criteria:    eval.AllFlowCriteria,
+		JudgeClient: judgeClient,
+		JudgePrompt: judgePrompt,
+		JudgeSchema: flowJudgeSchema,
+		Threshold:   threshold,
+		RunCase: func(ctx context.Context, t *testing.T, c harnessCase) (map[string]string, error) {
+			ec := caseByName[c.Name]
+
+			cornerJSONBytes, err := json.Marshal(ec.Corner)
+			if err != nil {
+				return nil, fmt.Errorf("marshal corner for case %s: %w", c.Name, err)
+			}
+			articlesJSONBytes, err := json.Marshal(ec.Articles)
+			if err != nil {
+				return nil, fmt.Errorf("marshal articles for case %s: %w", c.Name, err)
+			}
+			programJSONBytes, err := json.Marshal(ec.Program)
+			if err != nil {
+				return nil, fmt.Errorf("marshal program for case %s: %w", c.Name, err)
+			}
+			cornerJSON := string(cornerJSONBytes)
+			articlesJSON := string(articlesJSONBytes)
+			programJSON := string(programJSONBytes)
+
+			raw, err := runFlow(ctx, t, targetClient, flowPrompt, cornerJSON, articlesJSON, programJSON, ec.Position, ec.SelectionReason)
+			if err != nil {
+				return nil, err
+			}
+
+			// Mechanical verification: flow must be non-empty.
+			var output flowOutput
+			if err := json.Unmarshal(raw, &output); err != nil {
+				return nil, fmt.Errorf("unmarshal flow output for case %s: %w", c.Name, err)
+			}
+			if strings.TrimSpace(output.Flow) == "" {
+				t.Errorf("*** CONSTRAINT VIOLATION *** [%s] flow is empty", c.Name)
+			}
+
+			return map[string]string{
+				"corner":           cornerJSON,
+				"position":         ec.Position,
+				"articles":         articlesJSON,
+				"selection_reason": ec.SelectionReason,
+				"program":          programJSON,
+				"flow_output":      output.Flow,
+				"expectation":      eval.ResolveExpectation(ec.Expectation),
+			}, nil
+		},
+	})
+}

--- a/internal/eval/select_eval_test.go
+++ b/internal/eval/select_eval_test.go
@@ -13,21 +13,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
 
-// selectCast mirrors the cast element passed to select.md.
-type selectCast struct {
-	CharacterID     string `json:"character_id"`
-	Role            string `json:"role"`
-	Type            string `json:"type"`
-	AppearanceCount int    `json:"appearance_count"`
-}
-
-// selectCorner mirrors the CornerForPrompt passed to select.md.
-type selectCorner struct {
-	Title                 string `json:"title"`
-	Content               string `json:"content"`
-	TargetDurationSeconds int    `json:"target_duration_seconds"`
-}
-
 // selectArticle mirrors the articleForPrompt passed to select.md.
 type selectArticle struct {
 	URL   string `json:"url"`
@@ -38,8 +23,8 @@ type selectArticle struct {
 type selectCase struct {
 	Name        string          `json:"name"`
 	Category    string          `json:"category"`
-	Casts       []selectCast    `json:"casts"`
-	Corner      selectCorner    `json:"corner"`
+	Casts       []evalCast      `json:"casts"`
+	Corner      evalCorner      `json:"corner"`
 	Articles    []selectArticle `json:"articles"`
 	Expectation string          `json:"expectation,omitempty"`
 }

--- a/internal/eval/testdata/flow_judge.md
+++ b/internal/eval/testdata/flow_judge.md
@@ -1,0 +1,72 @@
+# flow設計プロンプト評価（LLM-as-judge）
+
+あなたはラジオ番組の flow 設計タスクの評価者です。
+以下のコーナー情報・番組内位置・選別済み記事・選別理由・番組構成全体・正解説明・flow設計結果を見て、4つの観点でそれぞれ1〜5点（整数）で採点してください。
+
+## コーナー情報
+
+```json
+{{corner}}
+```
+
+## 番組内位置
+
+{{position}}
+
+## 選別済み記事
+
+```json
+{{articles}}
+```
+
+## 選別理由
+
+{{selection_reason}}
+
+## 番組構成全体
+
+```json
+{{program}}
+```
+
+## 正解説明（expectation）
+
+{{expectation}}
+
+> `expectation` が「（なし）」の場合はコーナー情報・番組内位置・記事情報から妥当性を自律判断してください。
+
+## flow設計結果
+
+{{flow_output}}
+
+## 観点定義
+
+| 観点キー | 説明 |
+|---|---|
+| `position_role_fit` | 位置別役割適合: `position` の役割（opening=導入・締めない / ending=締め / middle=つなぎ）を満たしているか。opening なのに番組を締める内容になっていないか。ending なのに次の話題を引き出す流れになっていないか。 |
+| `consistency` | 整合性: 番組構成全体・他コーナーと矛盾・重複しない flow か。特定コーナー名をハードコードせず番組構成から読み取った内容に基づいているか。 |
+| `article_alignment` | 記事整合: 記事ありコーナーでは選別済み記事・選別理由に沿った紹介順・繋ぎになっているか。記事なしコーナーでも番組構成に沿った矛盾のない flow になっているか。 |
+| `actionability` | 指針性: 台本作成の指針として具体的な構成・繋ぎ方が記述できているか。抽象的な方針にとどまらず、何をどの順で話すかが読み取れるか。 |
+
+## 採点ガイドライン
+
+- `expectation` がある場合: それを正解基準として各観点を採点する。
+- `expectation` が「（なし）」の場合: コーナー情報・番組内位置・記事情報・番組構成から妥当性を自律判断して採点する。
+- opening なのに番組を締める内容（「本日はここまで」等）がある場合、`position_role_fit` は大幅に減点する。
+- 他コーナーの内容と重複した紹介をしている場合、`consistency` は減点する。
+- 記事ありコーナーで記事の内容と無関係な flow の場合、`article_alignment` は大幅に減点する。
+- 「自然につなぐ」のみで具体的な構成が書かれていない場合、`actionability` は減点する。
+- 採点後は各観点の `reason` に採点理由を簡潔に記載する。
+
+## 出力形式
+
+```json
+{
+  "scores": [
+    {"criterion": "position_role_fit", "score": 5, "reason": "採点理由"},
+    {"criterion": "consistency", "score": 5, "reason": "採点理由"},
+    {"criterion": "article_alignment", "score": 5, "reason": "採点理由"},
+    {"criterion": "actionability", "score": 5, "reason": "採点理由"}
+  ]
+}
+```

--- a/internal/eval/testdata/flow_pool_cases.json
+++ b/internal/eval/testdata/flow_pool_cases.json
@@ -1,0 +1,266 @@
+[
+  {
+    "name": "ending_with_articles",
+    "category": "position_role",
+    "position": "ending",
+    "corner": {
+      "title": "今週の注目OSS",
+      "content": "今週注目のオープンソースプロジェクトを1〜2本紹介して締めるコーナー。",
+      "target_duration_seconds": 180
+    },
+    "articles": [
+      {
+        "url": "https://example.com/valkey-fork",
+        "title": "Redis代替のValkey：Linux Foundation主導でフォーク開始",
+        "summary": "Redisのライセンス変更を受けてLinux Foundationが主導するValkeyプロジェクトが始動。",
+        "points": ["Linux Foundation主導でフォーク", "BSDライセンスを維持", "主要クラウドが既に支持表明"]
+      }
+    ],
+    "selection_reason": "Redisのライセンス問題は業界全体に影響し、Valkeyの登場は注目のOSSニュース。番組の締めにふさわしいトレンド記事。",
+    "program": {
+      "corners": [
+        {
+          "title": "今週のテックニュース",
+          "selection_reason": "クラウドとセキュリティの話題。",
+          "articles": [
+            {"url": "https://example.com/aws-lambda", "title": "AWS Lambdaが新機能追加", "summary": "AWS Lambdaの実行時間制限が延長された。", "points": ["実行時間制限が最大15分に延長"]}
+          ]
+        },
+        {
+          "title": "今週の注目OSS",
+          "selection_reason": "Redisのライセンス問題を受けてValkeyを紹介。",
+          "articles": [
+            {"url": "https://example.com/valkey-fork", "title": "Redis代替のValkey：Linux Foundation主導でフォーク開始", "summary": "ValkeyプロジェクトがLinux Foundationの下で開始。", "points": ["Linux Foundation主導でフォーク", "BSDライセンスを維持"]}
+          ]
+        }
+      ],
+      "casts": [
+        {"character_id": "metan", "role": "MC", "type": "regular", "appearance_count": 6}
+      ]
+    }
+  },
+  {
+    "name": "middle_single_article",
+    "category": "edge_case",
+    "position": "middle",
+    "corner": {
+      "title": "速報コーナー",
+      "content": "本日の最も注目すべき速報ニュースを1本だけ深掘りするコーナー。",
+      "target_duration_seconds": 120
+    },
+    "articles": [
+      {
+        "url": "https://example.com/major-vuln",
+        "title": "主要ブラウザに深刻な脆弱性、即時アップデートを推奨",
+        "summary": "主要ブラウザに任意コード実行を可能にする深刻な脆弱性が発見され、緊急パッチが公開された。",
+        "points": ["任意コード実行が可能な脆弱性", "全主要ブラウザが影響", "緊急パッチを即時適用を推奨"]
+      }
+    ],
+    "selection_reason": "影響範囲が広く緊急性が高い脆弱性情報のため最優先で取り上げる。",
+    "program": {
+      "corners": [
+        {
+          "title": "オープニング",
+          "selection_reason": "",
+          "articles": []
+        },
+        {
+          "title": "速報コーナー",
+          "selection_reason": "影響範囲が広く緊急性が高い脆弱性情報のため最優先で取り上げる。",
+          "articles": [
+            {"url": "https://example.com/major-vuln", "title": "主要ブラウザに深刻な脆弱性、即時アップデートを推奨", "summary": "深刻な脆弱性が発見され緊急パッチが公開。", "points": ["任意コード実行が可能な脆弱性", "緊急パッチを即時適用を推奨"]}
+          ]
+        },
+        {
+          "title": "今週の深掘り",
+          "selection_reason": "セキュリティの深掘り解説。",
+          "articles": [
+            {"url": "https://example.com/zero-trust-impl", "title": "ゼロトラスト実装の実践", "summary": "ゼロトラストアーキテクチャの実装方法を解説。", "points": ["導入ステップを解説"]}
+          ]
+        }
+      ],
+      "casts": [
+        {"character_id": "zunko", "role": "解説", "type": "regular", "appearance_count": 8},
+        {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 12}
+      ]
+    }
+  },
+  {
+    "name": "opening_guest_first_appearance",
+    "category": "edge_case",
+    "position": "opening",
+    "corner": {
+      "title": "オープニング",
+      "content": "ゲストを迎えて番組の冒頭でリスナーに自己紹介と今回の見どころを伝えるコーナー。記事は使用しない。",
+      "target_duration_seconds": 120
+    },
+    "articles": [],
+    "selection_reason": "",
+    "program": {
+      "corners": [
+        {
+          "title": "オープニング",
+          "selection_reason": "",
+          "articles": []
+        },
+        {
+          "title": "フロントエンド最新動向",
+          "selection_reason": "React 19とChrome更新という2本でフロントエンドの最新トレンドを網羅。",
+          "articles": [
+            {"url": "https://example.com/react-19", "title": "React 19リリース", "summary": "React 19が正式リリース。", "points": ["Server Componentsが正式対応"]},
+            {"url": "https://example.com/chrome-update", "title": "Chrome 124アップデート", "summary": "Chrome 124の新機能。", "points": ["Web標準の新機能を追加"]}
+          ]
+        },
+        {
+          "title": "エンディング",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "metan", "role": "ホスト", "type": "regular", "appearance_count": 15},
+        {"character_id": "kiritan", "role": "ゲスト", "type": "guest", "appearance_count": 0}
+      ]
+    }
+  },
+  {
+    "name": "ending_all_no_articles",
+    "category": "no_articles",
+    "position": "ending",
+    "corner": {
+      "title": "クロージングトーク",
+      "content": "番組の締めとして今回の振り返りと次回予告を行うコーナー。記事は使用しない。",
+      "target_duration_seconds": 90
+    },
+    "articles": [],
+    "selection_reason": "",
+    "program": {
+      "corners": [
+        {
+          "title": "オープニングトーク",
+          "selection_reason": "",
+          "articles": []
+        },
+        {
+          "title": "フリートーク",
+          "selection_reason": "",
+          "articles": []
+        },
+        {
+          "title": "クロージングトーク",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 3},
+        {"character_id": "metan", "role": "アシスタント", "type": "regular", "appearance_count": 3}
+      ]
+    }
+  },
+  {
+    "name": "middle_many_articles",
+    "category": "article_selection",
+    "position": "middle",
+    "corner": {
+      "title": "OSSコミュニティニュース",
+      "content": "オープンソースソフトウェアのリリース・コミュニティ動向・ライセンス問題などを3〜4本紹介するコーナー。",
+      "target_duration_seconds": 360
+    },
+    "articles": [
+      {
+        "url": "https://example.com/linux-kernel",
+        "title": "Linux Kernel 6.9リリース：主要変更点まとめ",
+        "summary": "Linux Kernel 6.9がリリースされ、新機能と性能改善が含まれる。",
+        "points": ["ファイルシステムの改善", "セキュリティ強化", "新ハードウェアサポート"]
+      },
+      {
+        "url": "https://example.com/redis-license",
+        "title": "RedisのライセンスをBSDからSSPLへ変更",
+        "summary": "Redisがオープンソースライセンスからビジネスソースライセンスへ変更し、コミュニティが反発。",
+        "points": ["SSPLライセンスに変更", "コミュニティが反発", "フォーク計画が浮上"]
+      },
+      {
+        "url": "https://example.com/apache-arrow",
+        "title": "Apache Arrowの採用が加速：データエンジニアリングでの活用事例",
+        "summary": "Apache Arrowがデータエンジニアリング分野での採用を拡大している。",
+        "points": ["データ交換フォーマットとして標準化が進む", "主要ツールが対応", "パフォーマンス向上が評価される"]
+      }
+    ],
+    "selection_reason": "OSSの主要ニュース3本：カーネルリリース・ライセンス問題・データ基盤ツール。Redisライセンス問題はコミュニティへの影響が大きく中心的に取り上げる。",
+    "program": {
+      "corners": [
+        {
+          "title": "今週のテックニュース",
+          "selection_reason": "クラウドの話題を紹介。",
+          "articles": [
+            {"url": "https://example.com/aws-update", "title": "AWS新機能発表", "summary": "AWSの新機能が発表された。", "points": ["新機能の概要"]}
+          ]
+        },
+        {
+          "title": "OSSコミュニティニュース",
+          "selection_reason": "OSSの主要ニュース3本を紹介。",
+          "articles": [
+            {"url": "https://example.com/linux-kernel", "title": "Linux Kernel 6.9リリース", "summary": "Linuxカーネルの新バージョンがリリース。", "points": ["ファイルシステムの改善"]},
+            {"url": "https://example.com/redis-license", "title": "RedisのライセンスをBSDからSSPLへ変更", "summary": "Redisがライセンスを変更。", "points": ["SSPLライセンスに変更"]},
+            {"url": "https://example.com/apache-arrow", "title": "Apache Arrowの採用が加速", "summary": "Apache Arrowの採用が拡大。", "points": ["データ交換フォーマットとして標準化が進む"]}
+          ]
+        },
+        {
+          "title": "エンディング",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "metan", "role": "MC", "type": "regular", "appearance_count": 6}
+      ]
+    }
+  },
+  {
+    "name": "opening_with_two_corners_after",
+    "category": "article_selection",
+    "position": "opening",
+    "corner": {
+      "title": "今週のハイライト",
+      "content": "今週のテクノロジーニュースの中から最も重要なトピックを1本取り上げて番組の冒頭を飾るコーナー。",
+      "target_duration_seconds": 150
+    },
+    "articles": [
+      {
+        "url": "https://example.com/openai-gpt-new",
+        "title": "OpenAIが次世代モデルを発表：性能と価格を公開",
+        "summary": "OpenAIが次世代の大規模言語モデルを発表し、前世代比で大幅な性能向上と価格引き下げを実現。",
+        "points": ["前世代比で性能2倍向上", "API料金が40%削減", "マルチモーダル機能を強化"]
+      }
+    ],
+    "selection_reason": "業界全体に影響するOpenAIの新モデル発表は今週最大のニュース。番組冒頭として視聴者の注目を集めやすい。",
+    "program": {
+      "corners": [
+        {
+          "title": "今週のハイライト",
+          "selection_reason": "業界全体に影響するOpenAIの新モデル発表を紹介。",
+          "articles": [
+            {"url": "https://example.com/openai-gpt-new", "title": "OpenAIが次世代モデルを発表：性能と価格を公開", "summary": "OpenAIが次世代LLMを発表。", "points": ["前世代比で性能2倍向上", "API料金が40%削減"]}
+          ]
+        },
+        {
+          "title": "セキュリティ深掘り",
+          "selection_reason": "脆弱性情報と対策を解説。",
+          "articles": [
+            {"url": "https://example.com/vuln-patch", "title": "重要なセキュリティパッチが公開", "summary": "複数の重要な脆弱性に対するパッチが公開。", "points": ["リモートコード実行の脆弱性を修正"]}
+          ]
+        },
+        {
+          "title": "クロージング",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 20},
+        {"character_id": "ankomon", "role": "アシスタント", "type": "guest", "appearance_count": 0}
+      ]
+    }
+  }
+]

--- a/internal/eval/testdata/flow_regression_cases.json
+++ b/internal/eval/testdata/flow_regression_cases.json
@@ -1,0 +1,224 @@
+[
+  {
+    "name": "opening_with_articles",
+    "category": "position_role",
+    "position": "opening",
+    "corner": {
+      "title": "今週のテックニュース",
+      "content": "最新の技術ニュースを3〜4本紹介するコーナー。AI・クラウド・プログラミング言語などITエンジニア向けの話題を扱う。",
+      "target_duration_seconds": 300
+    },
+    "articles": [
+      {
+        "url": "https://example.com/ai-chip-perf",
+        "title": "最新AIチップの性能が従来比3倍に向上",
+        "summary": "新世代のAIチップが発表され、従来品と比較して推論速度が3倍向上した。",
+        "points": ["推論速度が従来比3倍に向上", "消費電力は20%削減", "主要クラウドで今四半期中に提供開始"]
+      },
+      {
+        "url": "https://example.com/rust-async",
+        "title": "Rustの非同期処理入門：async/awaitの使い方",
+        "summary": "Rustの非同期プログラミングの基礎と実践的な使い方を解説する記事。",
+        "points": ["async/awaitの基本構文を解説", "tokioランタイムの使い方", "エラーハンドリングのパターン紹介"]
+      }
+    ],
+    "selection_reason": "AIと開発言語という2軸でエンジニア読者に響く記事を選択。AIチップはトレンド性が高く、Rust非同期は実用性が高い。",
+    "program": {
+      "corners": [
+        {
+          "title": "今週のテックニュース",
+          "selection_reason": "AIと開発言語という2軸でエンジニア読者に響く記事を選択。",
+          "articles": [
+            {"url": "https://example.com/ai-chip-perf", "title": "最新AIチップの性能が従来比3倍に向上", "summary": "新世代のAIチップが発表された。", "points": ["推論速度が従来比3倍に向上"]},
+            {"url": "https://example.com/rust-async", "title": "Rustの非同期処理入門：async/awaitの使い方", "summary": "Rustの非同期プログラミングの解説。", "points": ["async/awaitの基本構文を解説"]}
+          ]
+        },
+        {
+          "title": "AI最前線",
+          "selection_reason": "大規模言語モデルの最新動向を扱う。",
+          "articles": [
+            {"url": "https://example.com/llm-new", "title": "新しいLLMが公開", "summary": "最新のLLMがベンチマークで最高性能を達成。", "points": ["ベンチマーク最高性能", "マルチモーダル対応"]}
+          ]
+        },
+        {
+          "title": "今週の一言",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 10},
+        {"character_id": "metan", "role": "アシスタント", "type": "regular", "appearance_count": 8}
+      ]
+    },
+    "expectation": "opening として番組全体の導入となる flow であること。リスナーを引き込む出だしで、今回のコーナーで扱うAIチップとRustの話題を簡潔に予告しつつ、詳細は当該コーナーに委ねること。番組を締める表現は含まないこと。"
+  },
+  {
+    "name": "middle_with_articles",
+    "category": "position_role",
+    "position": "middle",
+    "corner": {
+      "title": "AI最前線",
+      "content": "人工知能・機械学習・大規模言語モデルに特化したニュースを2本程度紹介するコーナー。深掘り解説を重視する。",
+      "target_duration_seconds": 240
+    },
+    "articles": [
+      {
+        "url": "https://example.com/llm-new-model",
+        "title": "新しい大規模言語モデルが公開、ベンチマークで最高性能",
+        "summary": "最新のLLMが公開され、主要ベンチマークで最高性能を達成した。",
+        "points": ["主要ベンチマーク全項目で最高スコア", "オープンソースで公開", "推論コストが前世代比40%削減"]
+      },
+      {
+        "url": "https://example.com/llm-rag",
+        "title": "RAGアーキテクチャによるLLMの精度改善手法",
+        "summary": "検索拡張生成（RAG）を活用してLLMの出力精度を高める手法を解説。",
+        "points": ["RAGの基本アーキテクチャを解説", "ハルシネーション削減効果", "実装コードサンプルあり"]
+      }
+    ],
+    "selection_reason": "最新モデルの公開とRAGによる精度改善という、LLMの「進化」と「実用化」の両面を扱う。",
+    "program": {
+      "corners": [
+        {
+          "title": "今週のテックニュース",
+          "selection_reason": "AIと開発言語の話題を紹介。",
+          "articles": [
+            {"url": "https://example.com/ai-chip-perf", "title": "最新AIチップの性能が従来比3倍に向上", "summary": "新世代のAIチップが発表された。", "points": ["推論速度が従来比3倍に向上"]}
+          ]
+        },
+        {
+          "title": "AI最前線",
+          "selection_reason": "最新モデルの公開とRAGによる精度改善。",
+          "articles": [
+            {"url": "https://example.com/llm-new-model", "title": "新しい大規模言語モデルが公開、ベンチマークで最高性能", "summary": "最新のLLMが公開された。", "points": ["主要ベンチマーク全項目で最高スコア"]},
+            {"url": "https://example.com/llm-rag", "title": "RAGアーキテクチャによるLLMの精度改善手法", "summary": "RAGを活用した精度改善手法を解説。", "points": ["RAGの基本アーキテクチャを解説"]}
+          ]
+        },
+        {
+          "title": "今週の一言",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 10},
+        {"character_id": "metan", "role": "アシスタント", "type": "regular", "appearance_count": 8}
+      ]
+    },
+    "expectation": "middle として前のコーナー（テックニュース）の話題を受けて自然につなぎ、LLMの最新モデル→RAGという順で紹介し、次のコーナー（今週の一言）へ渡す flow であること。番組を締める表現は含まないこと。"
+  },
+  {
+    "name": "ending_no_articles",
+    "category": "position_role",
+    "position": "ending",
+    "corner": {
+      "title": "今週の一言",
+      "content": "MCが今週の技術トレンドを振り返り、一言コメントで締めるコーナー。記事は使用しない。",
+      "target_duration_seconds": 60
+    },
+    "articles": [],
+    "selection_reason": "",
+    "program": {
+      "corners": [
+        {
+          "title": "今週のテックニュース",
+          "selection_reason": "AIと開発言語の話題を紹介。",
+          "articles": [
+            {"url": "https://example.com/ai-chip-perf", "title": "最新AIチップの性能が従来比3倍に向上", "summary": "新世代のAIチップが発表された。", "points": ["推論速度が従来比3倍に向上"]}
+          ]
+        },
+        {
+          "title": "AI最前線",
+          "selection_reason": "最新モデルの公開とRAGによる精度改善。",
+          "articles": [
+            {"url": "https://example.com/llm-new-model", "title": "新しい大規模言語モデルが公開、ベンチマークで最高性能", "summary": "最新のLLMが公開された。", "points": ["主要ベンチマーク全項目で最高スコア"]}
+          ]
+        },
+        {
+          "title": "今週の一言",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 10},
+        {"character_id": "metan", "role": "アシスタント", "type": "regular", "appearance_count": 8}
+      ]
+    },
+    "expectation": "ending として番組全体（AIチップ・LLM・RAGの話題）を踏まえた一言コメントで自然に締める flow であること。記事がないため記事の紹介順などは不要で、番組全体の振り返りと締めの構成になっていること。"
+  },
+  {
+    "name": "opening_no_articles_corner",
+    "category": "no_articles",
+    "position": "opening",
+    "corner": {
+      "title": "オープニングトーク",
+      "content": "番組の冒頭で今回の内容を予告し、リスナーを引き込むトークコーナー。記事は使用しない。",
+      "target_duration_seconds": 90
+    },
+    "articles": [],
+    "selection_reason": "",
+    "program": {
+      "corners": [
+        {
+          "title": "オープニングトーク",
+          "selection_reason": "",
+          "articles": []
+        },
+        {
+          "title": "セキュリティニュース",
+          "selection_reason": "ランサムウェアとゼロトラストの2記事でセキュリティの脅威と対策を両面紹介。",
+          "articles": [
+            {"url": "https://example.com/ransomware", "title": "ランサムウェア攻撃が増加", "summary": "ランサムウェア被害が過去最高を更新。", "points": ["被害額が過去最高を更新"]},
+            {"url": "https://example.com/zero-trust", "title": "ゼロトラスト導入事例", "summary": "ゼロトラストアーキテクチャの導入事例。", "points": ["中小企業でも実装可能"]}
+          ]
+        },
+        {
+          "title": "クロージングトーク",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "zunko", "role": "MC", "type": "regular", "appearance_count": 5}
+      ]
+    },
+    "expectation": "opening として番組の冒頭にふさわしい導入 flow であること。今回のセキュリティニュースコーナーの内容（ランサムウェア・ゼロトラスト）を先取りせず、リスナーへの期待を高める予告に留めること。番組を締める表現は含まないこと。"
+  },
+  {
+    "name": "middle_all_no_articles",
+    "category": "no_articles",
+    "position": "middle",
+    "corner": {
+      "title": "フリートーク",
+      "content": "MCが最近の気になるトピックについて自由に話すコーナー。記事は使用しない。",
+      "target_duration_seconds": 120
+    },
+    "articles": [],
+    "selection_reason": "",
+    "program": {
+      "corners": [
+        {
+          "title": "オープニングトーク",
+          "selection_reason": "",
+          "articles": []
+        },
+        {
+          "title": "フリートーク",
+          "selection_reason": "",
+          "articles": []
+        },
+        {
+          "title": "クロージングトーク",
+          "selection_reason": "",
+          "articles": []
+        }
+      ],
+      "casts": [
+        {"character_id": "zundamon", "role": "MC", "type": "regular", "appearance_count": 3},
+        {"character_id": "metan", "role": "アシスタント", "type": "regular", "appearance_count": 3}
+      ]
+    },
+    "expectation": "全コーナーに記事がない回の middle として、オープニングトークを受けてフリートークへ自然につなぎ、その後クロージングトークへ渡す flow であること。記事紹介の要素は不要で、会話の流れとしての構成になっていること。"
+  }
+]


### PR DESCRIPTION
## Summary

- `internal/eval/eval.go` に flow 専用の 4 評価観点（`position_role_fit` / `consistency` / `article_alignment` / `actionability`）と `AllFlowCriteria` スライスを追加
- `internal/eval/flow_eval_test.go` を `//go:build eval` 付きで実装（`VOX_EVAL_FLOW_THRESHOLD` / `VOX_EVAL_JUDGE_MODEL` / `VOX_EVAL_MIN_INTERVAL_MS` 対応）
- `testdata/` に `flow_judge.md` / `flow_regression_cases.json`（position 3種・記事有無の5ケース）/ `flow_pool_cases.json`（6ケース）を追加
- `/simplify` 指摘を受け、`selectCast`/`selectCorner` と `flowCast`/`flowCorner` を `evalCast`/`evalCorner` として `eval_harness_test.go` に統合

## 受け入れ条件

- [x] `flow_eval_test.go` を `//go:build eval` 付きで実装し、`GEMINI_API_KEY` 未設定時に `t.Skip` する
- [x] 上記4観点で 1〜5 採点し、全体平均が閾値（デフォルト 4.0、`VOX_EVAL_FLOW_THRESHOLD`）以上で合格・未満で `t.Errorf`。回帰ケースの個別失敗を強調表示する
- [x] 回帰セットに position 3種（opening/middle/ending）・記事有無のケースを含めた
- [x] レートリミット/API/ネットワークエラーは inconclusive（`t.Skip`）扱いにする
- [x] 回帰セット・汎化プール JSON、judge プロンプトを `testdata/` に追加した
- [x] judge モデルを `VOX_EVAL_JUDGE_MODEL` で切り替え可能、最低実行間隔を `VOX_EVAL_MIN_INTERVAL_MS`（デフォルト 4500）で制御している
- [x] 評価フレームワーク基盤を本プロンプト用に一般化した（複数プレースホルダ対応）。proofread の既存評価が引き続き通ること
- [x] `go test ./...`（dev CI）が `internal/eval` を除外することを確認、`gofmt -l .` / `golangci-lint run` で指摘なし
- [x] 出荷プロンプトの本文は変更していない（スコープ外）

Closes #347

---
🤖 Generated with [Claude Code](https://claude.ai/code)