### PR TITLE
feat(eval): direct.md の LLM-as-judge 評価を導入する

### DIFF
--- a/internal/eval/direct_eval_test.go
+++ b/internal/eval/direct_eval_test.go
@@ -1,0 +1,302 @@
+//go:build eval
+
+package eval_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/eval"
+	"github.com/canpok1/vox-radio/internal/script/llm"
+)
+
+// directLine mirrors model.Line for direct eval test input.
+type directLine struct {
+	SpeakerRole string `json:"speaker_role"`
+	Text        string `json:"text"`
+}
+
+// directCorner mirrors cornerLLMPayload passed to direct.md.
+type directCorner struct {
+	Title     string       `json:"title"`
+	Direction string       `json:"direction,omitempty"`
+	Lines     []directLine `json:"lines"`
+}
+
+// directAssetEntry mirrors model.AssetCatalogEntry.
+type directAssetEntry struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// directAssetCatalog mirrors model.AssetCatalog.
+type directAssetCatalog struct {
+	SE []directAssetEntry `json:"se"`
+}
+
+// directCase is one entry in the direct testdata files.
+type directCase struct {
+	Name             string             `json:"name"`
+	Category         string             `json:"category"`
+	ProgramDirection string             `json:"program_direction"`
+	Corners          []directCorner     `json:"corners"`
+	AssetCatalog     directAssetCatalog `json:"asset_catalog"`
+	Expectation      string             `json:"expectation,omitempty"`
+}
+
+// directInsertion mirrors the SE insertion in direct.md output.
+type directInsertion struct {
+	CornerIndex    int    `json:"corner_index"`
+	AfterLineIndex int    `json:"after_line_index"`
+	Type           string `json:"type"`
+	AssetName      string `json:"asset_name"`
+	Reason         string `json:"reason,omitempty"`
+}
+
+// directPauseInsertion mirrors the pause insertion in direct.md output.
+type directPauseInsertion struct {
+	CornerIndex    int     `json:"corner_index"`
+	AfterLineIndex int     `json:"after_line_index"`
+	DurationSec    float64 `json:"duration_sec"`
+	Reason         string  `json:"reason,omitempty"`
+}
+
+// directLineConversion mirrors the line conversion in direct.md output.
+type directLineConversion struct {
+	CornerIndex int    `json:"corner_index"`
+	LineIndex   int    `json:"line_index"`
+	Text        string `json:"text"`
+}
+
+// directOutput mirrors the full output of direct.md.
+type directOutput struct {
+	Insertions      []directInsertion      `json:"insertions"`
+	PauseInsertions []directPauseInsertion `json:"pause_insertions"`
+	LineConversions []directLineConversion `json:"line_conversions"`
+}
+
+// directOutputSchema is the JSON schema for the direct.md output.
+var directOutputSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["insertions"],
+  "properties": {
+    "insertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["corner_index", "after_line_index", "type", "asset_name"],
+        "properties": {
+          "corner_index":     {"type": "integer", "minimum": 0},
+          "after_line_index": {"type": "integer", "minimum": 0},
+          "type":             {"type": "string", "enum": ["se"]},
+          "asset_name":       {"type": "string"},
+          "reason":           {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "pause_insertions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["corner_index", "after_line_index", "duration_sec"],
+        "properties": {
+          "corner_index":     {"type": "integer", "minimum": 0},
+          "after_line_index": {"type": "integer", "minimum": 0},
+          "duration_sec":     {"type": "number", "exclusiveMinimum": 0, "maximum": 5.0},
+          "reason":           {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    },
+    "line_conversions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["corner_index", "line_index", "text"],
+        "properties": {
+          "corner_index": {"type": "integer", "minimum": 0},
+          "line_index":   {"type": "integer", "minimum": 0},
+          "text":         {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
+
+// directJudgeSchema is the JSON schema for the direct judge LLM output.
+var directJudgeSchema = json.RawMessage(`{
+  "type": "object",
+  "required": ["scores"],
+  "properties": {
+    "scores": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["criterion", "score", "reason"],
+        "properties": {
+          "criterion": {
+            "type": "string",
+            "enum": ["se_pause_placement", "index_validity", "conversion_completeness", "reading_accuracy", "content_preservation"]
+          },
+          "score": {"type": "integer", "minimum": 1, "maximum": 5},
+          "reason": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}`)
+
+// runDirect calls the direct.md LLM and returns raw JSON output.
+// programDirection must already be resolved (empty → "（なし）") by the caller.
+func runDirect(ctx context.Context, t *testing.T, client llm.Client, promptTemplate, cornersJSON, assetCatalogJSON, programDirection string) (json.RawMessage, error) {
+	t.Helper()
+	prompt := strings.NewReplacer(
+		"{{corners}}", cornersJSON,
+		"{{asset_catalog}}", assetCatalogJSON,
+		"{{program_direction}}", programDirection,
+	).Replace(promptTemplate)
+
+	return client.Complete(ctx, llm.CompletionRequest{
+		Messages:   []llm.Message{{Role: "user", Content: prompt}},
+		JSONSchema: directOutputSchema,
+	})
+}
+
+func TestDirectEval(t *testing.T) {
+	requireGeminiKey(t)
+
+	targetClient, judgeClient := buildEvalClients(t)
+
+	threshold, err := getEnvFloat("VOX_EVAL_DIRECT_THRESHOLD", 4.0)
+	if err != nil {
+		t.Fatalf("parse VOX_EVAL_DIRECT_THRESHOLD: %v", err)
+	}
+
+	sampleSize, seed := loadSampleParams(t)
+
+	directPrompt, err := eval.LoadPrompt("direct")
+	if err != nil {
+		t.Fatalf("load direct prompt: %v", err)
+	}
+
+	judgePrompt := loadTestdataString(t, "direct_judge.md")
+
+	regressionCases := loadCasesJSON[directCase](t, "direct_regression_cases.json")
+	poolCases := loadCasesJSON[directCase](t, "direct_pool_cases.json")
+
+	allCases, caseByName := buildHarnessCases(t, regressionCases, poolCases, sampleSize, seed, func(c directCase) string { return c.Name })
+
+	ctx := context.Background()
+
+	runEvalHarness(ctx, t, allCases, harnessConfig{
+		Criteria:    eval.AllDirectCriteria,
+		JudgeClient: judgeClient,
+		JudgePrompt: judgePrompt,
+		JudgeSchema: directJudgeSchema,
+		Threshold:   threshold,
+		RunCase: func(ctx context.Context, t *testing.T, c harnessCase) (map[string]string, error) {
+			ec := caseByName[c.Name]
+
+			resolvedDirection := ec.ProgramDirection
+			if strings.TrimSpace(resolvedDirection) == "" {
+				resolvedDirection = "（なし）"
+			}
+
+			cornersJSON, err := json.Marshal(ec.Corners)
+			if err != nil {
+				return nil, fmt.Errorf("marshal corners for case %s: %w", c.Name, err)
+			}
+			assetCatalogJSON, err := json.Marshal(ec.AssetCatalog)
+			if err != nil {
+				return nil, fmt.Errorf("marshal asset_catalog for case %s: %w", c.Name, err)
+			}
+
+			raw, err := runDirect(ctx, t, targetClient, directPrompt, string(cornersJSON), string(assetCatalogJSON), resolvedDirection)
+			if err != nil {
+				return nil, err
+			}
+
+			var output directOutput
+			if err := json.Unmarshal(raw, &output); err != nil {
+				return nil, fmt.Errorf("unmarshal direct output for case %s: %w", c.Name, err)
+			}
+
+			// Mechanical verification: index bounds and asset names.
+			seNames := make(map[string]bool, len(ec.AssetCatalog.SE))
+			for _, e := range ec.AssetCatalog.SE {
+				seNames[e.Name] = true
+			}
+
+			checkAfterLine := func(label string, cornerIdx, afterLineIdx int) bool {
+				if cornerIdx < 0 || cornerIdx >= len(ec.Corners) {
+					t.Errorf("*** CONSTRAINT VIOLATION *** [%s] %s.corner_index=%d out of range [0,%d)",
+						c.Name, label, cornerIdx, len(ec.Corners))
+					return false
+				}
+				if afterLineIdx < 0 || afterLineIdx >= len(ec.Corners[cornerIdx].Lines) {
+					t.Errorf("*** CONSTRAINT VIOLATION *** [%s] %s.after_line_index=%d out of range [0,%d) for corner_index=%d",
+						c.Name, label, afterLineIdx, len(ec.Corners[cornerIdx].Lines), cornerIdx)
+				}
+				return true
+			}
+
+			for i, ins := range output.Insertions {
+				if !checkAfterLine(fmt.Sprintf("insertions[%d]", i), ins.CornerIndex, ins.AfterLineIndex) {
+					continue
+				}
+				if !seNames[ins.AssetName] {
+					t.Errorf("*** CONSTRAINT VIOLATION *** [%s] insertions[%d].asset_name=%q not in SE catalog",
+						c.Name, i, ins.AssetName)
+				}
+			}
+
+			for i, p := range output.PauseInsertions {
+				checkAfterLine(fmt.Sprintf("pause_insertions[%d]", i), p.CornerIndex, p.AfterLineIndex)
+			}
+
+			// Mechanical verification: line_conversion indices must be in bounds.
+			for i, lc := range output.LineConversions {
+				if lc.CornerIndex < 0 || lc.CornerIndex >= len(ec.Corners) {
+					t.Errorf("*** CONSTRAINT VIOLATION *** [%s] line_conversions[%d].corner_index=%d out of range [0,%d)",
+						c.Name, i, lc.CornerIndex, len(ec.Corners))
+					continue
+				}
+				if lc.LineIndex < 0 || lc.LineIndex >= len(ec.Corners[lc.CornerIndex].Lines) {
+					t.Errorf("*** CONSTRAINT VIOLATION *** [%s] line_conversions[%d].line_index=%d out of range [0,%d) for corner_index=%d",
+						c.Name, i, lc.LineIndex, len(ec.Corners[lc.CornerIndex].Lines), lc.CornerIndex)
+				}
+			}
+
+			// Mechanical verification: all lines must have a conversion.
+			type lineKey struct{ cornerIdx, lineIdx int }
+			covered := make(map[lineKey]bool, len(output.LineConversions))
+			for _, lc := range output.LineConversions {
+				covered[lineKey{lc.CornerIndex, lc.LineIndex}] = true
+			}
+			for ci, corner := range ec.Corners {
+				for li := range corner.Lines {
+					if !covered[lineKey{ci, li}] {
+						t.Errorf("*** CONSTRAINT VIOLATION *** [%s] missing line_conversion for corner_index=%d line_index=%d",
+							c.Name, ci, li)
+					}
+				}
+			}
+
+			return map[string]string{
+				"program_direction": resolvedDirection,
+				"corners":           string(cornersJSON),
+				"asset_catalog":     string(assetCatalogJSON),
+				"direct_output":     string(raw),
+				"expectation":       eval.ResolveExpectation(ec.Expectation),
+			}, nil
+		},
+	})
+}

--- a/internal/eval/eval.go
+++ b/internal/eval/eval.go
@@ -53,6 +53,13 @@ const (
 	CriterionStructureCompliance  Criterion = "structure_compliance"
 	CriterionNaturalness          Criterion = "naturalness"
 	CriterionSchemaCompliance     Criterion = "schema_compliance"
+
+	// Direct-only evaluation criteria.
+	CriterionSEPausePlacement       Criterion = "se_pause_placement"
+	CriterionIndexValidity          Criterion = "index_validity"
+	CriterionConversionCompleteness Criterion = "conversion_completeness"
+	CriterionReadingAccuracy        Criterion = "reading_accuracy"
+	CriterionContentPreservation    Criterion = "content_preservation"
 )
 
 // AllCriteria lists all proofread scoring dimensions in canonical order.
@@ -110,6 +117,15 @@ var AllWriteCriteria = []Criterion{
 	CriterionStructureCompliance,
 	CriterionNaturalness,
 	CriterionSchemaCompliance,
+}
+
+// AllDirectCriteria lists all direct scoring dimensions in canonical order.
+var AllDirectCriteria = []Criterion{
+	CriterionSEPausePlacement,
+	CriterionIndexValidity,
+	CriterionConversionCompleteness,
+	CriterionReadingAccuracy,
+	CriterionContentPreservation,
 }
 
 // ScoreEntry holds the score and reason for one criterion.

--- a/internal/eval/eval_test.go
+++ b/internal/eval/eval_test.go
@@ -22,7 +22,7 @@ func TestResolveExpectation(t *testing.T) {
 }
 
 func TestCriterionValues(t *testing.T) {
-	all := slices.Concat(AllCriteria, AllSummarizeCriteria, AllCornerSummaryCriteria, AllSummaryCriteria, AllSelectCriteria, AllFlowCriteria, AllWriteCriteria)
+	all := slices.Concat(AllCriteria, AllSummarizeCriteria, AllCornerSummaryCriteria, AllSummaryCriteria, AllSelectCriteria, AllFlowCriteria, AllWriteCriteria, AllDirectCriteria)
 	for _, c := range all {
 		if c == "" {
 			t.Errorf("criterion should not be empty string")
@@ -105,6 +105,17 @@ func TestAllXxxCriteria(t *testing.T) {
 				CriterionStructureCompliance,
 				CriterionNaturalness,
 				CriterionSchemaCompliance,
+			},
+		},
+		{
+			name: "AllDirectCriteria",
+			got:  AllDirectCriteria,
+			want: []Criterion{
+				CriterionSEPausePlacement,
+				CriterionIndexValidity,
+				CriterionConversionCompleteness,
+				CriterionReadingAccuracy,
+				CriterionContentPreservation,
 			},
 		},
 	}

--- a/internal/eval/testdata/direct_judge.md
+++ b/internal/eval/testdata/direct_judge.md
@@ -1,0 +1,71 @@
+# 演出プロンプト評価（LLM-as-judge）
+
+あなたはラジオ番組の演出タスク（SE挿入位置判定・読み変換）の評価者です。
+以下の番組全体の演出方針・コーナー別セリフ列・SE一覧・正解説明・演出結果を見て、5つの観点でそれぞれ1〜5点（整数）で採点してください。
+
+## 番組全体の演出方針
+
+{{program_direction}}
+
+> `（なし）` の場合は番組全体の演出方針指示は存在しません。
+
+## コーナー別セリフ列
+
+```json
+{{corners}}
+```
+
+## 使用可能なSE一覧
+
+```json
+{{asset_catalog}}
+```
+
+## 正解説明（expectation）
+
+{{expectation}}
+
+> `expectation` が「（なし）」の場合はコーナー情報・SE一覧から妥当性を自律判断してください。
+
+## 演出結果
+
+```json
+{{direct_output}}
+```
+
+## 観点定義
+
+| 観点キー | 説明 |
+|---|---|
+| `se_pause_placement` | SE/間の配置妥当性: 転換点・溜め等の効果的な位置に挿入し、過剰でないか（SE 0〜3回・pause 0〜2回の目安、`direction`/`description` の活用） |
+| `index_validity` | インデックス整合: `corner_index`/`after_line_index`/`line_index` が範囲内・コーナー内0始まり、`asset_name` が SE カタログ内か（機械検証と二重確認） |
+| `conversion_completeness` | 変換網羅性: 全セリフに対し `line_conversions` エントリを出力しているか（機械検証と二重確認） |
+| `reading_accuracy` | 読み変換の正確さ: 連濁/熟字訓/複合語特殊読み/音訓混在/英単語かな化が正しいか |
+| `content_preservation` | 内容保持: セリフの内容・意味・件数・話者・順序を変えていないか（読み表記のみ変更） |
+
+## 採点ガイドライン
+
+- `expectation` がある場合: それを正解基準として各観点を採点する。
+- `expectation` が「（なし）」の場合: コーナー情報・SE一覧から妥当性を自律判断して採点する。
+- SE/pause を使いすぎている（全体で SE 4回以上、pause 3回以上）場合、`se_pause_placement` は大幅に減点する。
+- `direction` や SE `description` を無視した挿入がある場合、`se_pause_placement` は減点する。
+- `corner_index` や `after_line_index` がコーナー・セリフの範囲外の場合、`index_validity` は大幅に減点する。
+- `asset_name` が SE カタログに存在しない名前の場合、`index_validity` は大幅に減点する。
+- 1つでも `line_index` の変換が欠けている場合、`conversion_completeness` は大幅に減点する。
+- 読み間違えやすい語（連濁/熟字訓/英単語）の変換が誤っている場合、`reading_accuracy` は減点する。
+- セリフの内容・意味・件数・話者・順序が変わっている場合、`content_preservation` は大幅に減点する。
+- 採点後は各観点の `reason` に採点理由を簡潔に記載する。
+
+## 出力形式
+
+```json
+{
+  "scores": [
+    {"criterion": "se_pause_placement", "score": 5, "reason": "採点理由"},
+    {"criterion": "index_validity", "score": 5, "reason": "採点理由"},
+    {"criterion": "conversion_completeness", "score": 5, "reason": "採点理由"},
+    {"criterion": "reading_accuracy", "score": 5, "reason": "採点理由"},
+    {"criterion": "content_preservation", "score": 5, "reason": "採点理由"}
+  ]
+}
+```

--- a/internal/eval/testdata/direct_pool_cases.json
+++ b/internal/eval/testdata/direct_pool_cases.json
@@ -1,0 +1,190 @@
+[
+  {
+    "name": "opening_with_greeting",
+    "category": "se_pause_placement",
+    "program_direction": "オープニングは明るくテンポよく進めること",
+    "corners": [
+      {
+        "title": "オープニング",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "こんにちは！テックラジオ第10回なのだ！"},
+          {"speaker_role": "metan", "text": "今日もよろしくお願いしますわ"},
+          {"speaker_role": "zundamon", "text": "今回はAI最新情報をたっぷりお届けするのだ"},
+          {"speaker_role": "metan", "text": "ぜひ最後までお楽しみくださいませ"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "fanfare", "description": "番組開始のファンファーレ。明るく賑やかな場面に使う"},
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"},
+        {"name": "transition", "description": "話題転換に使う効果音"}
+      ]
+    }
+  },
+  {
+    "name": "punchline_pause",
+    "category": "se_pause_placement",
+    "program_direction": "",
+    "corners": [
+      {
+        "title": "ユーモアコーナー",
+        "direction": "オチの前に間を取ること",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "なぜプログラマーは眼鏡をかけるのかわかるのだ？"},
+          {"speaker_role": "metan", "text": "なぜかしら？"},
+          {"speaker_role": "zundamon", "text": "Cシャープ（視力が悪い）からなのだ！"},
+          {"speaker_role": "metan", "text": "うまいですわね"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "drum_roll", "description": "ドラムロール。発表前の盛り上げに使う"},
+        {"name": "rimshot", "description": "ギャグや笑いの場面に使うドラムの効果音"}
+      ]
+    }
+  },
+  {
+    "name": "technical_terms_reading",
+    "category": "reading_accuracy",
+    "program_direction": "",
+    "corners": [
+      {
+        "title": "技術用語解説",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "今日はDockerの使い方を説明するのだ"},
+          {"speaker_role": "metan", "text": "Kubernetesとの連携も覚えましょうか"},
+          {"speaker_role": "zundamon", "text": "CI/CDパイプラインで自動化するのだ"},
+          {"speaker_role": "metan", "text": "GitHub ActionsのYAMLファイルを書きましょうですわ"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"}
+      ]
+    }
+  },
+  {
+    "name": "multi_corner_se",
+    "category": "index_validity",
+    "program_direction": "各コーナー間に転換SEを入れること",
+    "corners": [
+      {
+        "title": "ニュースコーナー",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "AIの新しい研究が発表されたのだ"},
+          {"speaker_role": "metan", "text": "とても興味深い内容ですわ"}
+        ]
+      },
+      {
+        "title": "レビューコーナー",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "今週のおすすめ書籍を紹介するのだ"},
+          {"speaker_role": "metan", "text": "プログラミングの名著ですわね"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "transition", "description": "コーナー間の話題転換に使う効果音"},
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"}
+      ]
+    }
+  },
+  {
+    "name": "difficult_kanji_reading",
+    "category": "reading_accuracy",
+    "program_direction": "",
+    "corners": [
+      {
+        "title": "文化トーク",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "今日の特集は日本の伝統文化なのだ"},
+          {"speaker_role": "metan", "text": "明日は七夕ですよね"},
+          {"speaker_role": "zundamon", "text": "素人でも楽しめるお祭りなのだ"},
+          {"speaker_role": "metan", "text": "今年は一緒に行きましょうかしら"},
+          {"speaker_role": "zundamon", "text": "彼女も誘うのだ"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "bell", "description": "お祭りの鐘の音"},
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"}
+      ]
+    }
+  },
+  {
+    "name": "ending_pause_before_close",
+    "category": "se_pause_placement",
+    "program_direction": "エンディングは余韻を持たせること",
+    "corners": [
+      {
+        "title": "エンディング",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "今回の番組はいかがでしたのだ？"},
+          {"speaker_role": "metan", "text": "とても充実した内容でしたわ"},
+          {"speaker_role": "zundamon", "text": "来週もお楽しみなのだ"},
+          {"speaker_role": "metan", "text": "また来週お会いしましょう"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"},
+        {"name": "ending_jingle", "description": "番組終了を告げるジングル"}
+      ]
+    }
+  },
+  {
+    "name": "mixed_content_preservation",
+    "category": "content_preservation",
+    "program_direction": "",
+    "corners": [
+      {
+        "title": "特集コーナー",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "今週の特集はWeb開発なのだ"},
+          {"speaker_role": "metan", "text": "ReactとVue.jsを比較しましょうか"},
+          {"speaker_role": "zundamon", "text": "TypeScriptも使えば型安全なのだ"},
+          {"speaker_role": "metan", "text": "APIの設計も重要ですわね"},
+          {"speaker_role": "zundamon", "text": "RESTとGraphQLどちらがいいのだろうのだ"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"},
+        {"name": "transition", "description": "話題転換に使う効果音"}
+      ]
+    }
+  },
+  {
+    "name": "long_corner_index_check",
+    "category": "index_validity",
+    "program_direction": "盛り上がりポイントにSEを入れること",
+    "corners": [
+      {
+        "title": "トークコーナー",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "まず最初の話題から始めるのだ"},
+          {"speaker_role": "metan", "text": "はい、お願いしますわ"},
+          {"speaker_role": "zundamon", "text": "新しいプログラミング言語が登場したのだ"},
+          {"speaker_role": "metan", "text": "どんな特徴があるのかしら"},
+          {"speaker_role": "zundamon", "text": "型安全で高速なのだ"},
+          {"speaker_role": "metan", "text": "それは素晴らしいですわね"},
+          {"speaker_role": "zundamon", "text": "ぜひ試してみてほしいのだ"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "fanfare", "description": "発表・祝福のファンファーレ"},
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"},
+        {"name": "transition", "description": "話題転換に使う効果音"}
+      ]
+    }
+  }
+]

--- a/internal/eval/testdata/direct_regression_cases.json
+++ b/internal/eval/testdata/direct_regression_cases.json
@@ -1,0 +1,96 @@
+[
+  {
+    "name": "reading_hard_words",
+    "category": "reading_accuracy",
+    "program_direction": "",
+    "corners": [
+      {
+        "title": "技術ニュース",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "今日はGitHubの新機能を紹介するのだ"},
+          {"speaker_role": "metan", "text": "昨日公開されたREADME.mdを参照してみましょうか"},
+          {"speaker_role": "zundamon", "text": "小豆色のアイコンが目印なのだ"},
+          {"speaker_role": "metan", "text": "手紙を書くように丁寧に記述するのですわ"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"},
+        {"name": "transition", "description": "話題転換に使う効果音"}
+      ]
+    },
+    "expectation": "以下の読み変換が正しく行われること。今日→きょう、GitHub→ぎっとはぶ、昨日→きのう、README.md→リードミードットエムディー、小豆→あずき、手紙→てがみ。全4行（line_index 0〜3）のline_conversionsエントリが揃っていること。SE/pauseは演出指示がないため最小限（0〜1回）に抑えること。"
+  },
+  {
+    "name": "no_se_simple_talk",
+    "category": "se_pause_placement",
+    "program_direction": "",
+    "corners": [
+      {
+        "title": "雑談コーナー",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "今週末は何をしたのだ？"},
+          {"speaker_role": "metan", "text": "公園でピクニックをしましたわ"},
+          {"speaker_role": "zundamon", "text": "それは楽しそうなのだ"},
+          {"speaker_role": "metan", "text": "天気も良くてよかったですわ"},
+          {"speaker_role": "zundamon", "text": "ボクも次回は行きたいのだ"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"},
+        {"name": "drum_roll", "description": "ドラムロール。発表・盛り上げ場面に使う"},
+        {"name": "transition", "description": "話題転換に使う効果音"},
+        {"name": "fanfare", "description": "祝福・発表のファンファーレ"}
+      ]
+    },
+    "expectation": "演出方針も特定の転換点もない雑談なので、SE/pauseは極力使わないこと。使用する場合でも全体でSEは0〜1回、pauseは0回が適切。過剰に挿入しないこと。"
+  },
+  {
+    "name": "direction_guided_se",
+    "category": "se_pause_placement",
+    "program_direction": "各コーナーの締めには必ず転換SEを入れること",
+    "corners": [
+      {
+        "title": "ニュースコーナー",
+        "direction": "最後のセリフの後に転換SEを入れること",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "今週のビッグニュースを紹介するのだ"},
+          {"speaker_role": "metan", "text": "新しいプログラミング言語が登場しましたわ"},
+          {"speaker_role": "zundamon", "text": "とても注目を集めているのだ"},
+          {"speaker_role": "metan", "text": "では次のコーナーへ参りましょう"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"},
+        {"name": "transition", "description": "コーナー間の話題転換に使う効果音"}
+      ]
+    },
+    "expectation": "program_directionとcornerのdirectionが両方とも最後に転換SEを入れるよう指示している。最後のセリフ（line_index 3、after_line_index 3）の後にtransition SEが挿入されていること。"
+  },
+  {
+    "name": "all_lines_must_convert",
+    "category": "conversion_completeness",
+    "program_direction": "",
+    "corners": [
+      {
+        "title": "情報コーナー",
+        "lines": [
+          {"speaker_role": "zundamon", "text": "本日のテーマはAIなのだ"},
+          {"speaker_role": "metan", "text": "最新のLLMについて話しましょうか"},
+          {"speaker_role": "zundamon", "text": "GPT-4とGeminiを比較するのだ"}
+        ]
+      }
+    ],
+    "asset_catalog": {
+      "se": [
+        {"name": "chime", "description": "コーナー開始を知らせるチャイム音"}
+      ]
+    },
+    "expectation": "全3行（corner_index 0のline_index 0〜2）すべてにline_conversionsエントリが存在すること。本日→ほんじつ、AI→えーあい、LLM→えるえるえむ、GPT-4→じーぴーてーよん、Gemini→じぇみになどの読み変換が含まれること。"
+  }
+]


### PR DESCRIPTION
## Summary

- `internal/eval/eval.go` に Direct 評価観点 5 種 (`se_pause_placement` / `index_validity` / `conversion_completeness` / `reading_accuracy` / `content_preservation`) の定数と `AllDirectCriteria` スライスを追加
- `internal/eval/eval_test.go` の `TestCriterionValues` / `TestAllXxxCriteria` に `AllDirectCriteria` を追加
- `internal/eval/direct_eval_test.go` を `//go:build eval` で実装し、`GEMINI_API_KEY` 未設定時は `t.Skip`
  - 閾値 `VOX_EVAL_DIRECT_THRESHOLD`（デフォルト 4.0）で合格判定し、回帰ケース個別失敗を強調表示
  - インデックス境界・SE カタログ名・全 line 変換網羅・`line_conversions` インデックス範囲を機械検証
- `internal/eval/testdata/` に回帰 4 件・プール 8 件・judge プロンプトを追加

Closes #349

---
🤖 Generated with [Claude Code](https://claude.ai/code)