### PR TITLE
refactor(eval): write_eval_test の buildWriteOutputSchema を write.BuildLinesSchema に統合する

### DIFF
--- a/internal/eval/write_eval_test.go
+++ b/internal/eval/write_eval_test.go
@@ -7,13 +7,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/eval"
 	"github.com/canpok1/vox-radio/internal/script/llm"
+	"github.com/canpok1/vox-radio/internal/script/write"
 )
 
 // writeCornerOutline mirrors the program-level corner outline passed to write.md.
@@ -120,44 +120,6 @@ var writeJudgeSchema = json.RawMessage(`{
   "additionalProperties": false
 }`)
 
-// buildWriteOutputSchema generates a JSON Schema for the write output with preset enum values.
-func buildWriteOutputSchema(validIntonation, validPitch, validSpeed []string) json.RawMessage {
-	sorted := func(s []string) []string {
-		c := make([]string, len(s))
-		copy(c, s)
-		sort.Strings(c)
-		return c
-	}
-	intonationJSON, _ := json.Marshal(sorted(validIntonation))
-	pitchJSON, _ := json.Marshal(sorted(validPitch))
-	speedJSON, _ := json.Marshal(sorted(validSpeed))
-
-	return json.RawMessage(fmt.Sprintf(`{
-  "type": "object",
-  "required": ["lines"],
-  "properties": {
-    "lines": {
-      "type": "array",
-      "minItems": 1,
-      "items": {
-        "type": "object",
-        "required": ["speaker_role", "text"],
-        "properties": {
-          "speaker_role": {"type": "string"},
-          "style":        {"type": "string"},
-          "intonation":   {"type": "string", "enum": %s},
-          "pitch":        {"type": "string", "enum": %s},
-          "speed":        {"type": "string", "enum": %s},
-          "text":         {"type": "string"}
-        },
-        "additionalProperties": false
-      }
-    }
-  },
-  "additionalProperties": false
-}`, intonationJSON, pitchJSON, speedJSON))
-}
-
 // runWrite calls the write.md LLM with the given case inputs and returns raw JSON output.
 func runWrite(ctx context.Context, t *testing.T, client llm.Client, promptTemplate, programJSON, cornerJSON, articlesJSON string, ec writeCase) (json.RawMessage, error) {
 	t.Helper()
@@ -177,7 +139,7 @@ func runWrite(ctx context.Context, t *testing.T, client llm.Client, promptTempla
 		"{{timezone}}", ec.Timezone,
 	).Replace(promptTemplate)
 
-	schema := buildWriteOutputSchema(ec.ValidIntonation, ec.ValidPitch, ec.ValidSpeed)
+	schema := write.BuildLinesSchema(ec.ValidIntonation, ec.ValidPitch, ec.ValidSpeed)
 
 	return client.Complete(ctx, llm.CompletionRequest{
 		Messages:   []llm.Message{{Role: "user", Content: prompt}},

--- a/internal/script/write/write.go
+++ b/internal/script/write/write.go
@@ -233,15 +233,9 @@ func (w *LLMWriter) effectivePresets() config.VoicevoxPresets {
 // BuildLinesSchema generates a JSON Schema for the lines response, with intonation/pitch/speed
 // enum values derived from the given slices. Input slices are sorted before embedding.
 func BuildLinesSchema(intonation, pitch, speed []string) json.RawMessage {
-	copyAndSort := func(s []string) []string {
-		c := make([]string, len(s))
-		copy(c, s)
-		sort.Strings(c)
-		return c
-	}
-	intonationEnumJSON, _ := json.Marshal(copyAndSort(intonation))
-	pitchEnumJSON, _ := json.Marshal(copyAndSort(pitch))
-	speedEnumJSON, _ := json.Marshal(copyAndSort(speed))
+	intonationEnumJSON, _ := json.Marshal(sortedStringsCopy(intonation))
+	pitchEnumJSON, _ := json.Marshal(sortedStringsCopy(pitch))
+	speedEnumJSON, _ := json.Marshal(sortedStringsCopy(speed))
 
 	return json.RawMessage(fmt.Sprintf(`{
   "type": "object",
@@ -367,4 +361,11 @@ func sortedKeys(m map[string]float64) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func sortedStringsCopy(s []string) []string {
+	c := make([]string, len(s))
+	copy(c, s)
+	sort.Strings(c)
+	return c
 }

--- a/internal/script/write/write.go
+++ b/internal/script/write/write.go
@@ -204,7 +204,7 @@ func (w *LLMWriter) Write(ctx context.Context, program config.ProgramConfig, cor
 		"{{program_script_note}}", programScriptNoteStr,
 	).Replace(w.promptTemplate)
 
-	schema := buildLinesSchema(presets)
+	schema := BuildLinesSchema(sortedKeys(presets.Intonation), sortedKeys(presets.Pitch), sortedKeys(presets.Speed))
 
 	raw, err := w.client.Complete(ctx, llm.CompletionRequest{
 		Messages:    []llm.Message{{Role: "user", Content: prompt}},
@@ -230,16 +230,18 @@ func (w *LLMWriter) effectivePresets() config.VoicevoxPresets {
 	return w.config.Voicevox.EffectivePresets()
 }
 
-// buildLinesSchema generates a JSON Schema for the lines response, with intonation/pitch/speed
-// enum values derived from the given presets.
-func buildLinesSchema(presets config.VoicevoxPresets) json.RawMessage {
-	intonationEnum := sortedKeys(presets.Intonation)
-	pitchEnum := sortedKeys(presets.Pitch)
-	speedEnum := sortedKeys(presets.Speed)
-
-	intonationEnumJSON, _ := json.Marshal(intonationEnum)
-	pitchEnumJSON, _ := json.Marshal(pitchEnum)
-	speedEnumJSON, _ := json.Marshal(speedEnum)
+// BuildLinesSchema generates a JSON Schema for the lines response, with intonation/pitch/speed
+// enum values derived from the given slices. Input slices are sorted before embedding.
+func BuildLinesSchema(intonation, pitch, speed []string) json.RawMessage {
+	copyAndSort := func(s []string) []string {
+		c := make([]string, len(s))
+		copy(c, s)
+		sort.Strings(c)
+		return c
+	}
+	intonationEnumJSON, _ := json.Marshal(copyAndSort(intonation))
+	pitchEnumJSON, _ := json.Marshal(copyAndSort(pitch))
+	speedEnumJSON, _ := json.Marshal(copyAndSort(speed))
 
 	return json.RawMessage(fmt.Sprintf(`{
   "type": "object",

--- a/internal/script/write/write_test.go
+++ b/internal/script/write/write_test.go
@@ -780,6 +780,40 @@ func TestLLMWriter_Write_ProgramDirectionNotInPrompt(t *testing.T) {
 	}
 }
 
+func TestBuildLinesSchema_EnumValuesMatchInput(t *testing.T) {
+	schema := write.BuildLinesSchema(
+		[]string{"表現豊か", "棒読み"},
+		[]string{"高め", "低め"},
+		[]string{"早口", "ゆっくり"},
+	)
+
+	schemaStr := string(schema)
+	for _, want := range []string{"表現豊か", "棒読み", "高め", "低め", "早口", "ゆっくり"} {
+		if !strings.Contains(schemaStr, want) {
+			t.Errorf("schema should contain %q, got: %s", want, schemaStr)
+		}
+	}
+}
+
+func TestBuildLinesSchema_SortsEnumValues(t *testing.T) {
+	schema := write.BuildLinesSchema(
+		[]string{"z値", "a値"},
+		[]string{"b値"},
+		[]string{"c値"},
+	)
+
+	schemaStr := string(schema)
+	// "a値" must appear before "z値" in the JSON
+	aPos := strings.Index(schemaStr, "a値")
+	zPos := strings.Index(schemaStr, "z値")
+	if aPos == -1 || zPos == -1 {
+		t.Fatalf("schema should contain 'a値' and 'z値', got: %s", schemaStr)
+	}
+	if aPos > zPos {
+		t.Errorf("enum values should be sorted: 'a値' should appear before 'z値', got: %s", schemaStr)
+	}
+}
+
 func TestLLMWriter_Write_CornerDirectionNotInCornerJSON(t *testing.T) {
 	mc := &mockClient{response: linesJSON}
 	w := write.NewLLMWriter(mc, "{{corner}}", 0, nil)


### PR DESCRIPTION
## Summary

- `internal/eval/write_eval_test.go` の `buildWriteOutputSchema` と `internal/script/write/write.go` の `buildLinesSchema` がほぼ同一の JSON スキーマテンプレートを重複実装していたため統合
- `buildLinesSchema` を `BuildLinesSchema(intonation, pitch, speed []string) json.RawMessage` としてエクスポート
- eval テストは `write.BuildLinesSchema(ec.ValidIntonation, ec.ValidPitch, ec.ValidSpeed)` を呼ぶよう変更
- プロダクション側は `sortedKeys(presets.Xxx)` を渡して `BuildLinesSchema` に委譲
- `/simplify` 指摘: `copyAndSort` クロージャをパッケージレベル関数 `sortedStringsCopy` に昇格

Closes #359

---
🤖 Generated with [Claude Code](https://claude.ai/code)