### PR TITLE
feat(eval): レートリミット制御をグローバル化し評価実行を日次分散する

### DIFF
--- a/.github/workflows/prompt-eval.yml
+++ b/.github/workflows/prompt-eval.yml
@@ -2,8 +2,13 @@ name: prompt-eval
 
 on:
   schedule:
-    - cron: '0 2 * * 0'  # 週次 (UTC 日曜 02:00)
+    - cron: '0 2 * * *'  # 毎日 02:00 UTC（曜日によって実行するプロンプトを切り替え）
   workflow_dispatch:
+    inputs:
+      run_filter:
+        description: 'テストフィルタ (例: TestProofreadEval)。空の場合は曜日フィルタを適用'
+        required: false
+        default: ''
 
 jobs:
   eval:
@@ -19,5 +24,28 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Determine test filter
+        id: filter
+        run: |
+          MANUAL_FILTER="${{ inputs.run_filter }}"
+          if [ -n "$MANUAL_FILTER" ]; then
+            echo "run=$MANUAL_FILTER" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # 曜日ベースで分散実行 (date +%u: 1=月, 2=火, ..., 7=日)
+          case "$(date +%u)" in
+            1) echo "run=TestProofreadEval|TestSummarizeEval" >> "$GITHUB_OUTPUT" ;;
+            2) echo "run=TestCornerSummaryEval" >> "$GITHUB_OUTPUT" ;;
+            3) echo "run=TestSummaryEval" >> "$GITHUB_OUTPUT" ;;
+            4) echo "run=TestSelectEval" >> "$GITHUB_OUTPUT" ;;
+            5) echo "run=TestFlowEval" >> "$GITHUB_OUTPUT" ;;
+            6) echo "run=TestWriteEval" >> "$GITHUB_OUTPUT" ;;
+            7) echo "run=TestDirectEval" >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Run prompt evaluation
-        run: make eval
+        if: steps.filter.outputs.run != ''
+        run: |
+          go test -tags=eval -count=1 -v -timeout 30m \
+            -run '${{ steps.filter.outputs.run }}' \
+            ./internal/eval/...

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ release-check:
 	goreleaser check
 
 eval:
-	go test -tags=eval -count=1 -v ./internal/eval/...
+	go test -tags=eval -count=1 -v -timeout 30m ./internal/eval/...
 
 all: build
 

--- a/internal/eval/eval_harness_test.go
+++ b/internal/eval/eval_harness_test.go
@@ -123,11 +123,10 @@ func buildEvalClients(t *testing.T) (llm.Client, llm.Client) {
 	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
 	targetCfg.MaxRetries = 2
 
-	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
+	judgeCfg := targetCfg
 	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
 		judgeCfg.Model = jm
 	}
-	judgeCfg.MaxRetries = 2
 
 	shared := llm.NewThrottler(targetCfg.MinRequestIntervalMS)
 	targetCfg.SharedThrottler = shared

--- a/internal/eval/eval_harness_test.go
+++ b/internal/eval/eval_harness_test.go
@@ -116,21 +116,24 @@ func loadSampleParams(t *testing.T) (sampleSize int, seed int64) {
 }
 
 // buildEvalClients creates target and judge LLM clients from env vars.
+// Both clients share a single Throttler so their combined request rate stays within API RPM limits.
 func buildEvalClients(t *testing.T) (llm.Client, llm.Client) {
 	t.Helper()
 
 	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
 	targetCfg.MaxRetries = 2
-	targetClient := llm.NewClient(targetCfg)
 
 	judgeCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
 	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
 		judgeCfg.Model = jm
 	}
 	judgeCfg.MaxRetries = 2
-	judgeClient := llm.NewClient(judgeCfg)
 
-	return targetClient, judgeClient
+	shared := llm.NewThrottler(targetCfg.MinRequestIntervalMS)
+	targetCfg.SharedThrottler = shared
+	judgeCfg.SharedThrottler = shared
+
+	return llm.NewClient(targetCfg), llm.NewClient(judgeCfg)
 }
 
 // harnessCase holds the per-case info needed by the eval harness.

--- a/internal/eval/eval_harness_test.go
+++ b/internal/eval/eval_harness_test.go
@@ -122,15 +122,12 @@ func buildEvalClients(t *testing.T) (llm.Client, llm.Client) {
 
 	targetCfg := eval.BuildLLMConfig("GEMINI_API_KEY", "VOX_EVAL_MODEL", "VOX_EVAL_MIN_INTERVAL_MS")
 	targetCfg.MaxRetries = 2
+	targetCfg.SharedThrottler = llm.NewThrottler(targetCfg.MinRequestIntervalMS)
 
-	judgeCfg := targetCfg
+	judgeCfg := targetCfg // inherits SharedThrottler; override model if specified
 	if jm := os.Getenv("VOX_EVAL_JUDGE_MODEL"); jm != "" {
 		judgeCfg.Model = jm
 	}
-
-	shared := llm.NewThrottler(targetCfg.MinRequestIntervalMS)
-	targetCfg.SharedThrottler = shared
-	judgeCfg.SharedThrottler = shared
 
 	return llm.NewClient(targetCfg), llm.NewClient(judgeCfg)
 }

--- a/internal/script/llm/client.go
+++ b/internal/script/llm/client.go
@@ -37,16 +37,25 @@ type Config struct {
 	Temperature          float64
 	MinRequestIntervalMS int
 	DifyChat             *DifyChatClientConfig
+	// SharedThrottler, if non-nil, is used instead of creating a new throttler from MinRequestIntervalMS.
+	// Use NewThrottler and share the pointer across multiple clients to enforce a combined rate limit.
+	SharedThrottler *Throttler
 }
 
-// throttler manages rate limiting for LLM API calls.
-type throttler struct {
+// Throttler manages rate limiting for LLM API calls and can be shared across multiple clients.
+type Throttler struct {
 	minIntervalMS int
 	mu            sync.Mutex
 	lastTime      time.Time
 }
 
-func (t *throttler) throttle(ctx context.Context) error {
+// NewThrottler creates a Throttler with the given minimum interval between requests.
+// Pass the returned pointer to Config.SharedThrottler to share it across multiple clients.
+func NewThrottler(minIntervalMS int) *Throttler {
+	return &Throttler{minIntervalMS: minIntervalMS}
+}
+
+func (t *Throttler) throttle(ctx context.Context) error {
 	if t.minIntervalMS <= 0 {
 		return nil
 	}
@@ -77,7 +86,7 @@ type openAIClient struct {
 	cfg      Config
 	hc       *http.Client
 	endpoint string
-	throttler
+	t        *Throttler
 }
 
 // NewClient creates a new LLM client, selecting the implementation based on Config.Provider.
@@ -98,11 +107,15 @@ func newOpenAIClient(cfg Config) Client {
 	if cfg.Model == "" {
 		cfg.Model = DefaultModel
 	}
+	t := cfg.SharedThrottler
+	if t == nil {
+		t = &Throttler{minIntervalMS: cfg.MinRequestIntervalMS}
+	}
 	return &openAIClient{
-		cfg:       cfg,
-		hc:        &http.Client{Timeout: 60 * time.Second},
-		endpoint:  strings.TrimRight(cfg.BaseURL, "/") + "/chat/completions",
-		throttler: throttler{minIntervalMS: cfg.MinRequestIntervalMS},
+		cfg:      cfg,
+		hc:       &http.Client{Timeout: 60 * time.Second},
+		endpoint: strings.TrimRight(cfg.BaseURL, "/") + "/chat/completions",
+		t:        t,
 	}
 }
 
@@ -175,7 +188,7 @@ func (c *openAIClient) Complete(ctx context.Context, req CompletionRequest) (jso
 }
 
 func (c *openAIClient) callAPI(ctx context.Context, req CompletionRequest, msgs []Message) (json.RawMessage, error) {
-	if err := c.throttle(ctx); err != nil {
+	if err := c.t.throttle(ctx); err != nil {
 		return nil, err
 	}
 

--- a/internal/script/llm/client.go
+++ b/internal/script/llm/client.go
@@ -55,6 +55,13 @@ func NewThrottler(minIntervalMS int) *Throttler {
 	return &Throttler{minIntervalMS: minIntervalMS}
 }
 
+func resolveThrottler(cfg Config) *Throttler {
+	if cfg.SharedThrottler != nil {
+		return cfg.SharedThrottler
+	}
+	return NewThrottler(cfg.MinRequestIntervalMS)
+}
+
 func (t *Throttler) throttle(ctx context.Context) error {
 	if t.minIntervalMS <= 0 {
 		return nil
@@ -107,15 +114,11 @@ func newOpenAIClient(cfg Config) Client {
 	if cfg.Model == "" {
 		cfg.Model = DefaultModel
 	}
-	t := cfg.SharedThrottler
-	if t == nil {
-		t = &Throttler{minIntervalMS: cfg.MinRequestIntervalMS}
-	}
 	return &openAIClient{
 		cfg:      cfg,
 		hc:       &http.Client{Timeout: 60 * time.Second},
 		endpoint: strings.TrimRight(cfg.BaseURL, "/") + "/chat/completions",
-		t:        t,
+		t:        resolveThrottler(cfg),
 	}
 }
 

--- a/internal/script/llm/client_test.go
+++ b/internal/script/llm/client_test.go
@@ -294,6 +294,62 @@ func TestComplete_ThrottlesRequests(t *testing.T) {
 	}
 }
 
+func TestNewThrottler_CreatesWithInterval(t *testing.T) {
+	th := llm.NewThrottler(100)
+	if th == nil {
+		t.Fatal("NewThrottler returned nil")
+	}
+}
+
+func TestComplete_SharedThrottler_AcrossClients(t *testing.T) {
+	var receivedAt []time.Time
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAt = append(receivedAt, time.Now())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(makeAPIResponse(t, `{"value":"hello"}`))
+	}))
+	defer ts.Close()
+
+	const intervalMS = 50
+	shared := llm.NewThrottler(intervalMS)
+
+	c1 := llm.NewClient(llm.Config{
+		BaseURL:         ts.URL,
+		APIKey:          "test-key",
+		Model:           "test-model",
+		SharedThrottler: shared,
+	})
+	c2 := llm.NewClient(llm.Config{
+		BaseURL:         ts.URL,
+		APIKey:          "test-key",
+		Model:           "test-model",
+		SharedThrottler: shared,
+	})
+
+	req := llm.CompletionRequest{
+		Messages: []llm.Message{{Role: "user", Content: "hello"}},
+	}
+
+	_, err := c1.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("c1 request failed: %v", err)
+	}
+	_, err = c2.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("c2 request failed: %v", err)
+	}
+
+	if len(receivedAt) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(receivedAt))
+	}
+	gap := receivedAt[1].Sub(receivedAt[0])
+	minGap := time.Duration(intervalMS) * time.Millisecond
+	const tolerance = 5 * time.Millisecond
+	if gap < minGap-tolerance {
+		t.Errorf("cross-client requests too close: gap=%v, want >= %v", gap, minGap-tolerance)
+	}
+}
+
 func TestComplete_ThrottleContextCancellation(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/script/llm/dify_chat.go
+++ b/internal/script/llm/dify_chat.go
@@ -39,15 +39,11 @@ func newDifyChatClient(cfg Config) Client {
 		Timeout:   60 * time.Second,
 	})
 
-	t := cfg.SharedThrottler
-	if t == nil {
-		t = &Throttler{minIntervalMS: cfg.MinRequestIntervalMS}
-	}
 	return &difyChatClient{
 		cfg:        cfg,
 		dcCfg:      DifyChatClientConfig{BaseURL: dc.BaseURL, APIKey: dc.APIKey, User: user, Inputs: dc.Inputs},
 		baseClient: bc,
-		t:          t,
+		t:          resolveThrottler(cfg),
 	}
 }
 

--- a/internal/script/llm/dify_chat.go
+++ b/internal/script/llm/dify_chat.go
@@ -19,7 +19,7 @@ type difyChatClient struct {
 	cfg        Config
 	dcCfg      DifyChatClientConfig
 	baseClient *base.Client
-	throttler
+	t          *Throttler
 }
 
 func newDifyChatClient(cfg Config) Client {
@@ -39,11 +39,15 @@ func newDifyChatClient(cfg Config) Client {
 		Timeout:   60 * time.Second,
 	})
 
+	t := cfg.SharedThrottler
+	if t == nil {
+		t = &Throttler{minIntervalMS: cfg.MinRequestIntervalMS}
+	}
 	return &difyChatClient{
 		cfg:        cfg,
 		dcCfg:      DifyChatClientConfig{BaseURL: dc.BaseURL, APIKey: dc.APIKey, User: user, Inputs: dc.Inputs},
 		baseClient: bc,
-		throttler:  throttler{minIntervalMS: cfg.MinRequestIntervalMS},
+		t:          t,
 	}
 }
 
@@ -94,7 +98,7 @@ func (c *difyChatClient) Complete(ctx context.Context, req CompletionRequest) (j
 }
 
 func (c *difyChatClient) callDify(ctx context.Context, query, conversationID string, inputs map[string]any) (json.RawMessage, string, error) {
-	if err := c.throttle(ctx); err != nil {
+	if err := c.t.throttle(ctx); err != nil {
 		return nil, "", err
 	}
 


### PR DESCRIPTION
## Summary

- `llm.Throttler` を公開型に昇格し、`NewThrottler` コンストラクタと `Config.SharedThrottler` フィールドを追加。複数クライアントがポインタを共有することで合算リクエストレートを制御できるようにする
- eval ハーネス（`buildEvalClients`）で target/judge 両クライアントが同一 `Throttler` を参照するよう変更。デフォルト 4500ms 間隔を共有するため合算 RPM が約 13/分となり、Gemini 無料枠の RPM=15 を超えない
- `prompt-eval` workflow を週1一括から毎日実行＋曜日別プロンプト選択に変更し、8プロンプトを月〜日に分散（RPM/RPD 圧力を低減）
- `make eval` と workflow の `go test` に `-timeout 30m` を追加し、全件実行時のタイムアウトを防止

## 受け入れ条件の対応

- [x] target / judge を含む全 API 呼び出しが単一のレート制御下に置かれ、デフォルト設定の `make eval` 全件実行で 429 による inconclusive スキップが発生しない
- [x] prompt-eval workflow が全プロンプト同日一括ではなく日次分散実行になっている
- [x] 上記間隔設定でも `go test` がタイムアウトせず全プロンプトが完走する

Closes #362

---
🤖 Generated with [Claude Code](https://claude.ai/code)