### PR TITLE
feat(direct): 校正ログに修正前テキストを追加し before/after で修正内容を可視化する

### DIFF
--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -128,6 +128,7 @@ type correction struct {
 	LineIndex   int    `json:"line_index"`
 	Text        string `json:"text"`
 	Reason      string `json:"reason,omitempty"`
+	Before      string `json:"-"` // populated by runProofread from ConvertedText, not from LLM
 }
 
 type correctionsResponse struct {
@@ -222,7 +223,7 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 					LineIndex:   c.LineIndex,
 					Text:        c.Text,
 				})
-				slog.Default().Info("proofread correction", "corner_index", c.CornerIndex, "line_index", c.LineIndex, "text", c.Text, "reason", c.Reason)
+				slog.Default().Info("proofread correction", "corner_index", c.CornerIndex, "line_index", c.LineIndex, "before", c.Before, "after", c.Text, "reason", c.Reason)
 			}
 			slog.Default().Info("proofread: applied corrections", "count", len(corrections))
 		}
@@ -273,6 +274,14 @@ func (d *LLMDirector) runProofread(ctx context.Context, corners []model.CornerLi
 	var cr correctionsResponse
 	if err := json.Unmarshal(raw, &cr); err != nil {
 		return nil, fmt.Errorf("unmarshal corrections: %w", err)
+	}
+
+	beforeMap := make(map[insertKey]string, len(lines))
+	for _, pl := range lines {
+		beforeMap[insertKey{pl.CornerIndex, pl.LineIndex}] = pl.ConvertedText
+	}
+	for i := range cr.Corrections {
+		cr.Corrections[i].Before = beforeMap[insertKey{cr.Corrections[i].CornerIndex, cr.Corrections[i].LineIndex}]
 	}
 
 	return cr.Corrections, nil

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -128,7 +128,6 @@ type correction struct {
 	LineIndex   int    `json:"line_index"`
 	Text        string `json:"text"`
 	Reason      string `json:"reason,omitempty"`
-	Before      string `json:"-"` // populated by runProofread from ConvertedText, not from LLM
 }
 
 type correctionsResponse struct {
@@ -213,7 +212,7 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 
 	lineConversions := resp.LineConversions
 	if d.proofread != nil {
-		corrections, err := d.runProofread(ctx, corners, lineConversions)
+		corrections, beforeMap, err := d.runProofread(ctx, corners, lineConversions)
 		if err != nil {
 			slog.Default().Warn("proofread failed, using direct conversion", "err", err)
 		} else if len(corrections) > 0 {
@@ -223,7 +222,8 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 					LineIndex:   c.LineIndex,
 					Text:        c.Text,
 				})
-				slog.Default().Info("proofread correction", "corner_index", c.CornerIndex, "line_index", c.LineIndex, "before", c.Before, "after", c.Text, "reason", c.Reason)
+				before := beforeMap[insertKey{c.CornerIndex, c.LineIndex}]
+				slog.Default().Info("proofread correction", "corner_index", c.CornerIndex, "line_index", c.LineIndex, "before", before, "after", c.Text, "reason", c.Reason)
 			}
 			slog.Default().Info("proofread: applied corrections", "count", len(corrections))
 		}
@@ -232,7 +232,7 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 	return buildScript(corners, resp.Insertions, resp.PauseInsertions, lineConversions), nil
 }
 
-func (d *LLMDirector) runProofread(ctx context.Context, corners []model.CornerLines, lineConversions []lineConversion) ([]correction, error) {
+func (d *LLMDirector) runProofread(ctx context.Context, corners []model.CornerLines, lineConversions []lineConversion) ([]correction, map[insertKey]string, error) {
 	convMap := buildConversionMap(lineConversions)
 
 	totalLines := 0
@@ -255,9 +255,14 @@ func (d *LLMDirector) runProofread(ctx context.Context, corners []model.CornerLi
 		}
 	}
 
+	beforeMap := make(map[insertKey]string, len(lines))
+	for _, pl := range lines {
+		beforeMap[insertKey{pl.CornerIndex, pl.LineIndex}] = pl.ConvertedText
+	}
+
 	linesJSON, err := json.Marshal(lines)
 	if err != nil {
-		return nil, fmt.Errorf("marshal proofread lines: %w", err)
+		return nil, nil, fmt.Errorf("marshal proofread lines: %w", err)
 	}
 
 	prompt := strings.NewReplacer("{{lines}}", string(linesJSON)).Replace(d.proofread.prompt)
@@ -268,23 +273,15 @@ func (d *LLMDirector) runProofread(ctx context.Context, corners []model.CornerLi
 		Temperature: d.proofread.temperature,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("proofread llm: %w", err)
+		return nil, nil, fmt.Errorf("proofread llm: %w", err)
 	}
 
 	var cr correctionsResponse
 	if err := json.Unmarshal(raw, &cr); err != nil {
-		return nil, fmt.Errorf("unmarshal corrections: %w", err)
+		return nil, nil, fmt.Errorf("unmarshal corrections: %w", err)
 	}
 
-	beforeMap := make(map[insertKey]string, len(lines))
-	for _, pl := range lines {
-		beforeMap[insertKey{pl.CornerIndex, pl.LineIndex}] = pl.ConvertedText
-	}
-	for i := range cr.Corrections {
-		cr.Corrections[i].Before = beforeMap[insertKey{cr.Corrections[i].CornerIndex, cr.Corrections[i].LineIndex}]
-	}
-
-	return cr.Corrections, nil
+	return cr.Corrections, beforeMap, nil
 }
 
 func stringOrNone(s string) string {

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -4,13 +4,40 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script/direct"
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
+
+// captureHandler is a slog.Handler that captures all records for test inspection.
+type captureHandler struct {
+	mu      sync.Mutex
+	records *[]slog.Record
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	*h.records = append(*h.records, r.Clone())
+	return nil
+}
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func recordAttrMap(r slog.Record) map[string]slog.Value {
+	m := make(map[string]slog.Value)
+	r.Attrs(func(a slog.Attr) bool {
+		m[a.Key] = a.Value
+		return true
+	})
+	return m
+}
 
 type mockClient struct {
 	response json.RawMessage
@@ -1308,4 +1335,107 @@ func TestLLMDirector_Direct_ProgramDirectionEmptyUsesNone(t *testing.T) {
 	if !strings.Contains(capturedPrompt, "（なし）") {
 		t.Errorf("empty program_direction should be rendered as （なし）, got: %s", capturedPrompt)
 	}
+}
+
+// TestLLMDirector_Direct_WithProofread_LogsBeforeAndAfterKeys verifies that when proofread
+// applies a correction, the log record contains "before" and "after" keys (not "text").
+// before = converted text from direct step; after = corrected text from proofread LLM.
+func TestLLMDirector_Direct_WithProofread_LogsBeforeAndAfterKeys(t *testing.T) {
+	mc := &sequentialClient{
+		responses: []json.RawMessage{
+			// Call 1: direct LLM — returns wrong kana for 頭突き
+			json.RawMessage(`{"insertions":[],"line_conversions":[{"corner_index":0,"line_index":0,"text":"あたまつきするのだ"}]}`),
+			// Call 2: proofread LLM — corrects to the right reading
+			json.RawMessage(`{"corrections":[{"corner_index":0,"line_index":0,"text":"ずつきするのだ","reason":"頭突き→ずつき（連濁の取りこぼし）"}]}`),
+		},
+		errs: []error{nil, nil},
+	}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0,
+		direct.WithProofread("{{lines}}", 0),
+	)
+
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
+	)
+
+	var records []slog.Record
+	origLogger := slog.Default()
+	slog.SetDefault(slog.New(&captureHandler{records: &records}))
+	defer slog.SetDefault(origLogger)
+
+	_, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var corrRec *slog.Record
+	for i := range records {
+		if records[i].Message == "proofread correction" {
+			corrRec = &records[i]
+			break
+		}
+	}
+	if corrRec == nil {
+		t.Fatal("expected 'proofread correction' log record, got none")
+	}
+
+	attrs := recordAttrMap(*corrRec)
+	if _, ok := attrs["text"]; ok {
+		t.Error("log should NOT have 'text' key (should be replaced by 'after')")
+	}
+	if v, ok := attrs["before"]; !ok {
+		t.Error("log should have 'before' key")
+	} else if got := v.String(); got != "あたまつきするのだ" {
+		t.Errorf("before: got %q, want あたまつきするのだ", got)
+	}
+	if v, ok := attrs["after"]; !ok {
+		t.Error("log should have 'after' key")
+	} else if got := v.String(); got != "ずつきするのだ" {
+		t.Errorf("after: got %q, want ずつきするのだ", got)
+	}
+}
+
+// TestLLMDirector_Direct_WithProofread_LogsBeforeFromOriginalWhenNoDirectConversion verifies
+// that when proofread corrects a line that had no direct conversion, "before" is the original text.
+func TestLLMDirector_Direct_WithProofread_LogsBeforeFromOriginalWhenNoDirectConversion(t *testing.T) {
+	mc := &sequentialClient{
+		responses: []json.RawMessage{
+			// Call 1: direct LLM — no line conversions
+			json.RawMessage(`{"insertions":[]}`),
+			// Call 2: proofread LLM — corrects original text directly
+			json.RawMessage(`{"corrections":[{"corner_index":0,"line_index":0,"text":"ずつきするのだ","reason":"頭突き→ずつき"}]}`),
+		},
+		errs: []error{nil, nil},
+	}
+	d := direct.NewLLMDirector(mc, "{{corners}}", 0,
+		direct.WithProofread("{{lines}}", 0),
+	)
+
+	corners := oneCorner("C1",
+		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
+	)
+
+	var records []slog.Record
+	origLogger := slog.Default()
+	slog.SetDefault(slog.New(&captureHandler{records: &records}))
+	defer slog.SetDefault(origLogger)
+
+	_, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, r := range records {
+		if r.Message != "proofread correction" {
+			continue
+		}
+		attrs := recordAttrMap(r)
+		if v, ok := attrs["before"]; !ok {
+			t.Error("log should have 'before' key")
+		} else if got := v.String(); got != "頭突きするのだ" {
+			t.Errorf("before: got %q, want 頭突きするのだ (original text when no direct conversion)", got)
+		}
+		return
+	}
+	t.Fatal("expected 'proofread correction' log, got none")
 }

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -39,6 +39,24 @@ func recordAttrMap(r slog.Record) map[string]slog.Value {
 	return m
 }
 
+func captureSlogRecords(t *testing.T) *[]slog.Record {
+	t.Helper()
+	var records []slog.Record
+	orig := slog.Default()
+	slog.SetDefault(slog.New(&captureHandler{records: &records}))
+	t.Cleanup(func() { slog.SetDefault(orig) })
+	return &records
+}
+
+func findSlogRecord(records []slog.Record, msg string) *slog.Record {
+	for i := range records {
+		if records[i].Message == msg {
+			return &records[i]
+		}
+	}
+	return nil
+}
+
 type mockClient struct {
 	response json.RawMessage
 	err      error
@@ -1358,23 +1376,14 @@ func TestLLMDirector_Direct_WithProofread_LogsBeforeAndAfterKeys(t *testing.T) {
 		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
 	)
 
-	var records []slog.Record
-	origLogger := slog.Default()
-	slog.SetDefault(slog.New(&captureHandler{records: &records}))
-	defer slog.SetDefault(origLogger)
+	records := captureSlogRecords(t)
 
 	_, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	var corrRec *slog.Record
-	for i := range records {
-		if records[i].Message == "proofread correction" {
-			corrRec = &records[i]
-			break
-		}
-	}
+	corrRec := findSlogRecord(*records, "proofread correction")
 	if corrRec == nil {
 		t.Fatal("expected 'proofread correction' log record, got none")
 	}
@@ -1415,27 +1424,21 @@ func TestLLMDirector_Direct_WithProofread_LogsBeforeFromOriginalWhenNoDirectConv
 		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
 	)
 
-	var records []slog.Record
-	origLogger := slog.Default()
-	slog.SetDefault(slog.New(&captureHandler{records: &records}))
-	defer slog.SetDefault(origLogger)
+	records := captureSlogRecords(t)
 
 	_, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, r := range records {
-		if r.Message != "proofread correction" {
-			continue
-		}
-		attrs := recordAttrMap(r)
-		if v, ok := attrs["before"]; !ok {
-			t.Error("log should have 'before' key")
-		} else if got := v.String(); got != "頭突きするのだ" {
-			t.Errorf("before: got %q, want 頭突きするのだ (original text when no direct conversion)", got)
-		}
-		return
+	corrRec := findSlogRecord(*records, "proofread correction")
+	if corrRec == nil {
+		t.Fatal("expected 'proofread correction' log, got none")
 	}
-	t.Fatal("expected 'proofread correction' log, got none")
+	attrs := recordAttrMap(*corrRec)
+	if v, ok := attrs["before"]; !ok {
+		t.Error("log should have 'before' key")
+	} else if got := v.String(); got != "頭突きするのだ" {
+		t.Errorf("before: got %q, want 頭突きするのだ (original text when no direct conversion)", got)
+	}
 }


### PR DESCRIPTION
## Summary

校正（proofread）ステップで修正が発生したとき、ログから「どの行を・修正前 → 修正後・なぜ」が一目で分かるようにする。

### 変更内容

- `correction` 構造体を LLM レスポンスの純粋な写像に保ったまま、`runProofread` が `beforeMap`（修正前テキストのマップ）も返す設計に変更
- `Direct` 側で `beforeMap` を使って `before` を解決し、ログに追加
- ログの `text` キーを `before`/`after` に変更し修正前後を対比可能にする

**変更前のログ:**
```
[15:04:05] direct: proofread correction corner_index=0 line_index=2 text=ずつきするのだ reason=頭突き→ずつき（連濁の取りこぼし）
```

**変更後のログ:**
```
[15:04:05] direct: proofread correction corner_index=0 line_index=2 before=あたまつきするのだ after=ずつきするのだ reason=頭突き→ずつき（連濁の取りこぼし）
```

### テスト追加

- `TestLLMDirector_Direct_WithProofread_LogsBeforeAndAfterKeys`: 直接変換後テキストが `before` として記録される
- `TestLLMDirector_Direct_WithProofread_LogsBeforeFromOriginalWhenNoDirectConversion`: 直接変換なし時は元テキストが `before` として記録される
- `captureHandler` / `captureSlogRecords` / `findSlogRecord` テストヘルパーを追加

### 変更なし

- プロンプト (`prompts/proofread.md`) / JSON スキーマ (`correctionsSchema`) は変更なし
- CLI ドキュメント（サブコマンド・フラグ変更なし）

Closes #364

---
🤖 Generated with [Claude Code](https://claude.ai/code)