### PR TITLE
feat(direct): 校正ステップの結果を中間ファイル化し、stderrを件数のみ・他ステップと統一形式に揃える

### DIFF
--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script"
 	"github.com/canpok1/vox-radio/internal/script/direct"
@@ -186,7 +187,7 @@ func runScriptDirect(ctx context.Context, workDir, out string, c llm.Client, llm
 	}
 
 	if pr != nil {
-		prPath := filepath.Join(workDir, "04_proofread.json")
+		prPath := fileio.ProofreadPath(workDir)
 		if err := writeJSON(prPath, pr); err != nil {
 			return err
 		}

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -180,9 +180,17 @@ func runScriptDirect(ctx context.Context, workDir, out string, c llm.Client, llm
 	d := direct.NewLLMDirector(c, prompts["direct"], stepTemp(llmCfg, "direct"),
 		direct.WithProofread(prompts["proofread"], stepTemp(llmCfg, "proofread")),
 	)
-	scr, err := d.Direct(ctx, scriptLines.Corners, assetCatalog, scriptLines.Direction)
+	scr, pr, err := d.Direct(ctx, scriptLines.Corners, assetCatalog, scriptLines.Direction)
 	if err != nil {
 		return fmt.Errorf("direct: %w", err)
+	}
+
+	if pr != nil {
+		prPath := filepath.Join(workDir, "04_proofread.json")
+		if err := writeJSON(prPath, pr); err != nil {
+			return err
+		}
+		fmt.Printf("proofread %d corrections to %s\n", len(pr.Corrections), prPath)
 	}
 
 	if err := writeJSON(out, scr); err != nil {

--- a/internal/fileio/paths.go
+++ b/internal/fileio/paths.go
@@ -14,6 +14,7 @@ const (
 	FileSummaries = "02_summaries.json"
 	FileRundown   = "02_rundown.json"
 	FileLines     = "03_lines.json"
+	FileProofread = "04_proofread.json"
 	FileScript    = "04_script.json"
 	FileEpisode   = "episode.mp3"
 	FileManifest  = "manifest.json"
@@ -42,6 +43,7 @@ func ArticlesPath(outDir string) string  { return intermediatePath(outDir, FileA
 func SummariesPath(outDir string) string { return intermediatePath(outDir, FileSummaries) }
 func RundownPath(outDir string) string   { return intermediatePath(outDir, FileRundown) }
 func LinesPath(outDir string) string     { return intermediatePath(outDir, FileLines) }
+func ProofreadPath(outDir string) string { return intermediatePath(outDir, FileProofread) }
 func ScriptPath(outDir string) string    { return intermediatePath(outDir, FileScript) }
 
 func EpisodePath(outDir string) string {

--- a/internal/fileio/paths_test.go
+++ b/internal/fileio/paths_test.go
@@ -125,6 +125,7 @@ func TestPaths(t *testing.T) {
 		{"SummariesPath", fileio.SummariesPath(outDir), filepath.Join(outDir, "intermediate", "02_summaries.json")},
 		{"RundownPath", fileio.RundownPath(outDir), filepath.Join(outDir, "intermediate", "02_rundown.json")},
 		{"LinesPath", fileio.LinesPath(outDir), filepath.Join(outDir, "intermediate", "03_lines.json")},
+		{"ProofreadPath", fileio.ProofreadPath(outDir), filepath.Join(outDir, "intermediate", "04_proofread.json")},
 		{"ScriptPath", fileio.ScriptPath(outDir), filepath.Join(outDir, "intermediate", "04_script.json")},
 		{"EpisodePath", fileio.EpisodePath(outDir), filepath.Join(outDir, "episode.mp3")},
 	}

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -92,8 +92,23 @@ type cornerLLMPayload struct {
 	Lines     []model.Line `json:"lines"`
 }
 
+// ProofreadCorrection represents a single correction made by the proofreading pass.
+type ProofreadCorrection struct {
+	CornerIndex int    `json:"corner_index"`
+	LineIndex   int    `json:"line_index"`
+	Before      string `json:"before"`
+	After       string `json:"after"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// ProofreadResult holds the result of a proofreading pass, including all corrections applied.
+// Non-nil means the proofreading LLM ran successfully (even if Corrections is empty).
+type ProofreadResult struct {
+	Corrections []ProofreadCorrection `json:"corrections"`
+}
+
 type Director interface {
-	Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog, programDirection string) (model.Script, error)
+	Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog, programDirection string) (model.Script, *ProofreadResult, error)
 }
 
 type insertion struct {
@@ -170,7 +185,7 @@ func NewLLMDirector(client llm.Client, promptTemplate string, temperature float6
 	return d
 }
 
-func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog, programDirection string) (model.Script, error) {
+func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog, programDirection string) (model.Script, *ProofreadResult, error) {
 	payload := make([]cornerLLMPayload, len(corners))
 	for i, c := range corners {
 		payload[i] = cornerLLMPayload{
@@ -182,12 +197,12 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 
 	cornersJSON, err := json.Marshal(payload)
 	if err != nil {
-		return model.Script{}, fmt.Errorf("marshal corners: %w", err)
+		return model.Script{}, nil, fmt.Errorf("marshal corners: %w", err)
 	}
 
 	catalogJSON, err := json.Marshal(catalog)
 	if err != nil {
-		return model.Script{}, fmt.Errorf("marshal asset catalog: %w", err)
+		return model.Script{}, nil, fmt.Errorf("marshal asset catalog: %w", err)
 	}
 
 	prompt := strings.NewReplacer(
@@ -202,20 +217,23 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 		Temperature: d.temperature,
 	})
 	if err != nil {
-		return model.Script{}, fmt.Errorf("llm complete: %w", err)
+		return model.Script{}, nil, fmt.Errorf("llm complete: %w", err)
 	}
 
 	var resp insertionsResponse
 	if err := json.Unmarshal(raw, &resp); err != nil {
-		return model.Script{}, fmt.Errorf("unmarshal insertions: %w", err)
+		return model.Script{}, nil, fmt.Errorf("unmarshal insertions: %w", err)
 	}
 
 	lineConversions := resp.LineConversions
+	var pr *ProofreadResult
+
 	if d.proofread != nil {
 		corrections, beforeMap, err := d.runProofread(ctx, corners, lineConversions)
 		if err != nil {
 			slog.Default().Warn("proofread failed, using direct conversion", "err", err)
-		} else if len(corrections) > 0 {
+		} else {
+			cs := make([]ProofreadCorrection, 0, len(corrections))
 			for _, c := range corrections {
 				lineConversions = append(lineConversions, lineConversion{
 					CornerIndex: c.CornerIndex,
@@ -223,13 +241,19 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 					Text:        c.Text,
 				})
 				before := beforeMap[insertKey{c.CornerIndex, c.LineIndex}]
-				slog.Default().Info("proofread correction", "corner_index", c.CornerIndex, "line_index", c.LineIndex, "before", before, "after", c.Text, "reason", c.Reason)
+				cs = append(cs, ProofreadCorrection{
+					CornerIndex: c.CornerIndex,
+					LineIndex:   c.LineIndex,
+					Before:      before,
+					After:       c.Text,
+					Reason:      c.Reason,
+				})
 			}
-			slog.Default().Info("proofread: applied corrections", "count", len(corrections))
+			pr = &ProofreadResult{Corrections: cs}
 		}
 	}
 
-	return buildScript(corners, resp.Insertions, resp.PauseInsertions, lineConversions), nil
+	return buildScript(corners, resp.Insertions, resp.PauseInsertions, lineConversions), pr, nil
 }
 
 func (d *LLMDirector) runProofread(ctx context.Context, corners []model.CornerLines, lineConversions []lineConversion) ([]correction, map[insertKey]string, error) {

--- a/internal/script/direct/direct_test.go
+++ b/internal/script/direct/direct_test.go
@@ -4,58 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script/direct"
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
-
-// captureHandler is a slog.Handler that captures all records for test inspection.
-type captureHandler struct {
-	mu      sync.Mutex
-	records *[]slog.Record
-}
-
-func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
-func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	*h.records = append(*h.records, r.Clone())
-	return nil
-}
-func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
-func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
-
-func recordAttrMap(r slog.Record) map[string]slog.Value {
-	m := make(map[string]slog.Value)
-	r.Attrs(func(a slog.Attr) bool {
-		m[a.Key] = a.Value
-		return true
-	})
-	return m
-}
-
-func captureSlogRecords(t *testing.T) *[]slog.Record {
-	t.Helper()
-	var records []slog.Record
-	orig := slog.Default()
-	slog.SetDefault(slog.New(&captureHandler{records: &records}))
-	t.Cleanup(func() { slog.SetDefault(orig) })
-	return &records
-}
-
-func findSlogRecord(records []slog.Record, msg string) *slog.Record {
-	for i := range records {
-		if records[i].Message == msg {
-			return &records[i]
-		}
-	}
-	return nil
-}
 
 type mockClient struct {
 	response json.RawMessage
@@ -111,7 +66,7 @@ func TestLLMDirector_Direct_NoInsertions(t *testing.T) {
 		SE: []model.AssetCatalogEntry{{Name: "chime"}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, catalog, "")
+	got, _, err := d.Direct(context.Background(), corners, catalog, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -139,7 +94,7 @@ func TestLLMDirector_Direct_WithSEInsertion(t *testing.T) {
 		SE: []model.AssetCatalogEntry{{Name: "chime"}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, catalog, "")
+	got, _, err := d.Direct(context.Background(), corners, catalog, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -175,7 +130,7 @@ func TestLLMDirector_Direct_CornerBGMWrapsContent(t *testing.T) {
 		},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,7 +158,7 @@ func TestLLMDirector_Direct_StartAudio_Jingle_PrependedFirst(t *testing.T) {
 		Lines:      []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -228,7 +183,7 @@ func TestLLMDirector_Direct_EndAudio_Jingle_AppendedLast(t *testing.T) {
 		Lines:    []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -255,7 +210,7 @@ func TestLLMDirector_Direct_CornerAllAssets_Jingle_CorrectOrder(t *testing.T) {
 		Lines:      []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -298,7 +253,7 @@ func TestLLMDirector_Direct_StartAudio_SE_AfterBGM_BGMContinues(t *testing.T) {
 		},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -343,7 +298,7 @@ func TestLLMDirector_Direct_EndAudio_SE_BGMContinues(t *testing.T) {
 		},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -378,7 +333,7 @@ func TestLLMDirector_Direct_NoAssets_OnlySpeech(t *testing.T) {
 		Lines: []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -404,7 +359,7 @@ func TestLLMDirector_Direct_CornerAssetFields_NotInLLMPayload(t *testing.T) {
 		Lines:      []model.Line{{SpeakerRole: "host", Text: "hello"}},
 	}}
 
-	_, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	_, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -431,7 +386,7 @@ func TestLLMDirector_Direct_BGMDoesNotLeakToNextCorner(t *testing.T) {
 		},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -461,7 +416,7 @@ func TestLLMDirector_Direct_InsertionAfterLastLine(t *testing.T) {
 		SE: []model.AssetCatalogEntry{{Name: "transition"}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, catalog, "")
+	got, _, err := d.Direct(context.Background(), corners, catalog, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -485,7 +440,7 @@ func TestLLMDirector_Direct_StylePropagated(t *testing.T) {
 		model.Line{SpeakerRole: "metan", Style: "", Text: "大丈夫？"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -504,7 +459,7 @@ func TestLLMDirector_Direct_LLMError(t *testing.T) {
 	mc := &mockClient{err: context.Canceled}
 	d := direct.NewLLMDirector(mc, "{{corners}}", 0)
 
-	_, err := d.Direct(context.Background(), nil, emptyCatalog(), "")
+	_, _, err := d.Direct(context.Background(), nil, emptyCatalog(), "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -518,7 +473,7 @@ func TestLLMDirector_Direct_SpeechSegmentFields(t *testing.T) {
 
 	corners := oneCorner("C1", model.Line{SpeakerRole: "host", Text: "テストテキスト"})
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -544,7 +499,7 @@ func TestBuildScript_StartPauseSec_InjectedBeforeStartAudio(t *testing.T) {
 		Lines:         []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -573,7 +528,7 @@ func TestBuildScript_EndPauseSec_InjectedAfterEndAudio(t *testing.T) {
 		Lines:       []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -601,7 +556,7 @@ func TestBuildScript_ZeroStartPauseSec_NoInjection(t *testing.T) {
 		Lines:         []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -623,7 +578,7 @@ func TestBuildScript_ZeroEndPauseSec_NoInjection(t *testing.T) {
 		Lines:       []model.Line{{SpeakerRole: "host", Text: "話す"}},
 	}}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -652,7 +607,7 @@ func TestBuildScript_AdjacentCorners_BothPausesInjected(t *testing.T) {
 		},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -680,7 +635,7 @@ func TestLLMDirector_Direct_CatalogDescriptionPassedToPrompt(t *testing.T) {
 		SE: []model.AssetCatalogEntry{{Name: "chime", Description: "コーナー開始時のチャイム音"}},
 	}
 
-	_, err := d.Direct(context.Background(), []model.CornerLines{}, catalog, "")
+	_, _, err := d.Direct(context.Background(), []model.CornerLines{}, catalog, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -702,7 +657,7 @@ func TestLLMDirector_Direct_CatalogNoInternalFieldsInPrompt(t *testing.T) {
 		SE: []model.AssetCatalogEntry{{Name: "chime", Description: "テスト"}},
 	}
 
-	_, err := d.Direct(context.Background(), []model.CornerLines{}, catalog, "")
+	_, _, err := d.Direct(context.Background(), []model.CornerLines{}, catalog, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -725,7 +680,7 @@ func TestBuildScript_CopiesPresetFields(t *testing.T) {
 		model.Line{SpeakerRole: "guest", Text: "応答"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -768,7 +723,7 @@ func TestLLMDirector_Direct_WithPauseInsertion(t *testing.T) {
 		model.Line{SpeakerRole: "guest", Text: "オチ"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -801,7 +756,7 @@ func TestLLMDirector_Direct_SEAndPauseAtSameIndex_SEFirst(t *testing.T) {
 		model.Line{SpeakerRole: "guest", Text: "B"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -828,7 +783,7 @@ func TestLLMDirector_Direct_PauseZeroDurationIgnored(t *testing.T) {
 		model.Line{SpeakerRole: "guest", Text: "B"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -848,7 +803,7 @@ func TestLLMDirector_Direct_PauseNegativeDurationIgnored(t *testing.T) {
 		model.Line{SpeakerRole: "guest", Text: "B"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -874,7 +829,7 @@ func TestLLMDirector_Direct_MultiCorner(t *testing.T) {
 		}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, model.AssetCatalog{
+	got, _, err := d.Direct(context.Background(), corners, model.AssetCatalog{
 		SE: []model.AssetCatalogEntry{{Name: "chime"}},
 	}, "")
 	if err != nil {
@@ -905,7 +860,7 @@ func TestBuildScript_SameBGM_ContinuousPlay(t *testing.T) {
 		{Title: "C2", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -934,7 +889,7 @@ func TestBuildScript_DifferentBGM_SeamlessSwitch(t *testing.T) {
 		{Title: "C2", BGM: "bgm_b", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -966,7 +921,7 @@ func TestBuildScript_BGMToNoBGM_StopAtBoundary(t *testing.T) {
 		{Title: "C2", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -997,7 +952,7 @@ func TestBuildScript_LastCorner_NoBGMStop(t *testing.T) {
 		{Title: "C1", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー1"}}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1023,7 +978,7 @@ func TestBuildScript_EndAudio_Jingle_ResetsBGM(t *testing.T) {
 		{Title: "C2", BGM: "talk_bgm", Lines: []model.Line{{SpeakerRole: "host", Text: "コーナー2"}}},
 	}
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1066,7 +1021,7 @@ func TestLLMDirector_Direct_DirectionInPrompt(t *testing.T) {
 		},
 	}
 
-	_, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	_, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1087,7 +1042,7 @@ func TestLLMDirector_Direct_LineConversionApplied(t *testing.T) {
 		model.Line{SpeakerRole: "guest", Text: "README.md"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1114,7 +1069,7 @@ func TestLLMDirector_Direct_LineConversionFallback_MissingEntry(t *testing.T) {
 		model.Line{SpeakerRole: "guest", Text: "README.md"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1139,7 +1094,7 @@ func TestLLMDirector_Direct_LineConversionFallback_EmptyConversions(t *testing.T
 		model.Line{SpeakerRole: "host", Text: "AI"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1162,7 +1117,7 @@ func TestLLMDirector_Direct_LineConversionFallback_EmptyConvertedText(t *testing
 		model.Line{SpeakerRole: "host", Text: "AI"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1213,7 +1168,7 @@ func TestLLMDirector_Direct_WithProofread_CorrectsMisreading(t *testing.T) {
 		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, _, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1245,7 +1200,7 @@ func TestLLMDirector_Direct_WithProofread_FallbackOnLLMError(t *testing.T) {
 		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, pr, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("pipeline must not stop on proofread error: %v", err)
 	}
@@ -1255,6 +1210,10 @@ func TestLLMDirector_Direct_WithProofread_FallbackOnLLMError(t *testing.T) {
 	// Falls back to direct's conversion (not original text)
 	if got.Segments[0].Text != "あたまつきするのだ" {
 		t.Errorf("Segment[0].Text: got %q, want あたまつきするのだ (fallback to direct conversion)", got.Segments[0].Text)
+	}
+	// ProofreadResult is nil when proofread fails
+	if pr != nil {
+		t.Errorf("ProofreadResult should be nil when proofread fails, got %+v", pr)
 	}
 }
 
@@ -1275,7 +1234,7 @@ func TestLLMDirector_Direct_WithProofread_SkipWhenNotSet(t *testing.T) {
 		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, pr, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1288,6 +1247,10 @@ func TestLLMDirector_Direct_WithProofread_SkipWhenNotSet(t *testing.T) {
 	// Verify only one LLM call was made
 	if mc.callIdx != 1 {
 		t.Errorf("LLM call count: got %d, want 1 (no proofread call when WithProofread not set)", mc.callIdx)
+	}
+	// ProofreadResult is nil when WithProofread is not set
+	if pr != nil {
+		t.Errorf("ProofreadResult should be nil when WithProofread not set, got %+v", pr)
 	}
 }
 
@@ -1309,7 +1272,7 @@ func TestLLMDirector_Direct_WithProofread_EmptyCorrections(t *testing.T) {
 		model.Line{SpeakerRole: "host", Text: "テストテキスト"},
 	)
 
-	got, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	got, pr, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1318,6 +1281,16 @@ func TestLLMDirector_Direct_WithProofread_EmptyCorrections(t *testing.T) {
 	}
 	if got.Segments[0].Text != "てすとてきすと" {
 		t.Errorf("Segment[0].Text: got %q, want てすとてきすと (direct conversion unchanged when no corrections)", got.Segments[0].Text)
+	}
+	// ProofreadResult is non-nil even with 0 corrections (proofread ran successfully)
+	if pr == nil {
+		t.Fatal("ProofreadResult should be non-nil even when corrections is empty")
+	}
+	if pr.Corrections == nil {
+		t.Error("ProofreadResult.Corrections should be [] (not nil) when empty")
+	}
+	if len(pr.Corrections) != 0 {
+		t.Errorf("Corrections: got %d, want 0", len(pr.Corrections))
 	}
 }
 
@@ -1329,7 +1302,7 @@ func TestLLMDirector_Direct_ProgramDirectionInPrompt(t *testing.T) {
 	}
 	d := direct.NewLLMDirector(mc, "{{program_direction}}", 0)
 
-	_, err := d.Direct(context.Background(), []model.CornerLines{}, emptyCatalog(), "番組全体の演出方針")
+	_, _, err := d.Direct(context.Background(), []model.CornerLines{}, emptyCatalog(), "番組全体の演出方針")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1346,7 +1319,7 @@ func TestLLMDirector_Direct_ProgramDirectionEmptyUsesNone(t *testing.T) {
 	}
 	d := direct.NewLLMDirector(mc, "{{program_direction}}", 0)
 
-	_, err := d.Direct(context.Background(), []model.CornerLines{}, emptyCatalog(), "")
+	_, _, err := d.Direct(context.Background(), []model.CornerLines{}, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1355,10 +1328,9 @@ func TestLLMDirector_Direct_ProgramDirectionEmptyUsesNone(t *testing.T) {
 	}
 }
 
-// TestLLMDirector_Direct_WithProofread_LogsBeforeAndAfterKeys verifies that when proofread
-// applies a correction, the log record contains "before" and "after" keys (not "text").
-// before = converted text from direct step; after = corrected text from proofread LLM.
-func TestLLMDirector_Direct_WithProofread_LogsBeforeAndAfterKeys(t *testing.T) {
+// TestLLMDirector_Direct_WithProofread_ReturnsProofreadResultWithBeforeAfter verifies that
+// ProofreadResult contains Before (direct conversion) and After (proofread correction) for each correction.
+func TestLLMDirector_Direct_WithProofread_ReturnsProofreadResultWithBeforeAfter(t *testing.T) {
 	mc := &sequentialClient{
 		responses: []json.RawMessage{
 			// Call 1: direct LLM — returns wrong kana for 頭突き
@@ -1376,37 +1348,32 @@ func TestLLMDirector_Direct_WithProofread_LogsBeforeAndAfterKeys(t *testing.T) {
 		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
 	)
 
-	records := captureSlogRecords(t)
-
-	_, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	_, pr, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	corrRec := findSlogRecord(*records, "proofread correction")
-	if corrRec == nil {
-		t.Fatal("expected 'proofread correction' log record, got none")
+	if pr == nil {
+		t.Fatal("ProofreadResult should be non-nil when proofread runs successfully")
 	}
-
-	attrs := recordAttrMap(*corrRec)
-	if _, ok := attrs["text"]; ok {
-		t.Error("log should NOT have 'text' key (should be replaced by 'after')")
+	if len(pr.Corrections) != 1 {
+		t.Fatalf("Corrections: got %d, want 1", len(pr.Corrections))
 	}
-	if v, ok := attrs["before"]; !ok {
-		t.Error("log should have 'before' key")
-	} else if got := v.String(); got != "あたまつきするのだ" {
-		t.Errorf("before: got %q, want あたまつきするのだ", got)
+	c := pr.Corrections[0]
+	if c.Before != "あたまつきするのだ" {
+		t.Errorf("Before: got %q, want あたまつきするのだ (direct conversion result)", c.Before)
 	}
-	if v, ok := attrs["after"]; !ok {
-		t.Error("log should have 'after' key")
-	} else if got := v.String(); got != "ずつきするのだ" {
-		t.Errorf("after: got %q, want ずつきするのだ", got)
+	if c.After != "ずつきするのだ" {
+		t.Errorf("After: got %q, want ずつきするのだ (proofread correction)", c.After)
+	}
+	if c.Reason != "頭突き→ずつき（連濁の取りこぼし）" {
+		t.Errorf("Reason: got %q, want 頭突き→ずつき（連濁の取りこぼし）", c.Reason)
 	}
 }
 
-// TestLLMDirector_Direct_WithProofread_LogsBeforeFromOriginalWhenNoDirectConversion verifies
-// that when proofread corrects a line that had no direct conversion, "before" is the original text.
-func TestLLMDirector_Direct_WithProofread_LogsBeforeFromOriginalWhenNoDirectConversion(t *testing.T) {
+// TestLLMDirector_Direct_WithProofread_ReturnsBeforeFromOriginalWhenNoDirectConversion verifies
+// that when proofread corrects a line with no direct conversion, Before is the original text.
+func TestLLMDirector_Direct_WithProofread_ReturnsBeforeFromOriginalWhenNoDirectConversion(t *testing.T) {
 	mc := &sequentialClient{
 		responses: []json.RawMessage{
 			// Call 1: direct LLM — no line conversions
@@ -1424,21 +1391,18 @@ func TestLLMDirector_Direct_WithProofread_LogsBeforeFromOriginalWhenNoDirectConv
 		model.Line{SpeakerRole: "host", Text: "頭突きするのだ"},
 	)
 
-	records := captureSlogRecords(t)
-
-	_, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
+	_, pr, err := d.Direct(context.Background(), corners, emptyCatalog(), "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	corrRec := findSlogRecord(*records, "proofread correction")
-	if corrRec == nil {
-		t.Fatal("expected 'proofread correction' log, got none")
+	if pr == nil {
+		t.Fatal("ProofreadResult should be non-nil when proofread runs successfully")
 	}
-	attrs := recordAttrMap(*corrRec)
-	if v, ok := attrs["before"]; !ok {
-		t.Error("log should have 'before' key")
-	} else if got := v.String(); got != "頭突きするのだ" {
-		t.Errorf("before: got %q, want 頭突きするのだ (original text when no direct conversion)", got)
+	if len(pr.Corrections) != 1 {
+		t.Fatalf("Corrections: got %d, want 1", len(pr.Corrections))
+	}
+	if pr.Corrections[0].Before != "頭突きするのだ" {
+		t.Errorf("Before: got %q, want 頭突きするのだ (original text when no direct conversion)", pr.Corrections[0].Before)
 	}
 }

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -91,7 +91,7 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 		if err := g.saveIntermediate(fileio.FileProofread, pr); err != nil {
 			return model.Script{}, err
 		}
-		g.logger.With("step", "script/direct").Info(fmt.Sprintf("校正完了 (%d件修正)", len(pr.Corrections)))
+		g.logger.With("step", "script/direct").Info("校正完了", "count", len(pr.Corrections))
 	}
 
 	g.logger.With("step", "script").Info(fmt.Sprintf("完了 (%dセグメント, %.1fs)", len(scr.Segments), time.Since(start).Seconds()))

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -82,9 +82,16 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	}
 
 	g.logger.With("step", "script/direct").Info("開始")
-	scr, err := g.director.Direct(ctx, scriptLines, g.assetCatalog, program.Direction)
+	scr, pr, err := g.director.Direct(ctx, scriptLines, g.assetCatalog, program.Direction)
 	if err != nil {
 		return model.Script{}, fmt.Errorf("direct: %w", err)
+	}
+
+	if pr != nil {
+		if err := g.saveIntermediate(fileio.FileProofread, pr); err != nil {
+			return model.Script{}, err
+		}
+		g.logger.With("step", "script/direct").Info(fmt.Sprintf("校正完了 (%d件修正)", len(pr.Corrections)))
 	}
 
 	g.logger.With("step", "script").Info(fmt.Sprintf("完了 (%dセグメント, %.1fs)", len(scr.Segments), time.Since(start).Seconds()))

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script"
+	"github.com/canpok1/vox-radio/internal/script/direct"
 	"github.com/canpok1/vox-radio/internal/script/write"
 )
 
@@ -45,16 +46,17 @@ func (m *mockWriter) Write(_ context.Context, _ config.ProgramConfig, corner con
 }
 
 type mockDirector struct {
-	script model.Script
-	err    error
+	script          model.Script
+	proofreadResult *direct.ProofreadResult
+	err             error
 }
 
-func (m *mockDirector) Direct(_ context.Context, corners []model.CornerLines, _ model.AssetCatalog, _ string) (model.Script, error) {
+func (m *mockDirector) Direct(_ context.Context, corners []model.CornerLines, _ model.AssetCatalog, _ string) (model.Script, *direct.ProofreadResult, error) {
 	if m.err != nil {
-		return model.Script{}, m.err
+		return model.Script{}, nil, m.err
 	}
 	if m.script.Segments != nil {
-		return m.script, nil
+		return m.script, m.proofreadResult, nil
 	}
 	segs := make([]model.ScriptSegment, 0)
 	for _, corner := range corners {
@@ -62,7 +64,7 @@ func (m *mockDirector) Direct(_ context.Context, corners []model.CornerLines, _ 
 			segs = append(segs, model.ScriptSegment{Type: model.SegmentTypeSpeech, SpeakerRole: l.SpeakerRole, Text: l.Text})
 		}
 	}
-	return model.Script{Segments: segs}, nil
+	return model.Script{Segments: segs}, m.proofreadResult, nil
 }
 
 var testChars = map[string]config.CharacterConfig{
@@ -721,5 +723,124 @@ func TestLLMScriptGenerator_Generate_ProgramDirectionPersistedInLinesFile(t *tes
 	}
 	if sl.Direction != "番組全体の演出方針テスト" {
 		t.Errorf("ScriptLines.Direction: got %q, want 番組全体の演出方針テスト", sl.Direction)
+	}
+}
+
+func TestGenerate_SavesProofreadIntermediate_WhenProofreadSucceeds(t *testing.T) {
+	workDir := t.TempDir()
+	rundown := corneredRundown("AIコーナー",
+		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
+	)
+	lines := []model.Line{{SpeakerRole: "zundamon", Text: "テスト"}}
+	corners := []config.CornerConfig{
+		{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
+	}
+
+	pr := &direct.ProofreadResult{
+		Corrections: []direct.ProofreadCorrection{
+			{CornerIndex: 0, LineIndex: 0, Before: "まえ", After: "あと", Reason: "理由"},
+		},
+	}
+	md := &mockDirector{proofreadResult: pr}
+	gen := script.NewLLMScriptGenerator(
+		&mockWriter{lines: lines},
+		md,
+		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
+		workDir,
+	)
+
+	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path := filepath.Join(workDir, fileio.FileProofread)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected %s to exist: %v", fileio.FileProofread, err)
+	}
+
+	var got direct.ProofreadResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("%s must be valid ProofreadResult JSON: %v", fileio.FileProofread, err)
+	}
+	if len(got.Corrections) != 1 {
+		t.Fatalf("Corrections: got %d, want 1", len(got.Corrections))
+	}
+	if got.Corrections[0].Before != "まえ" {
+		t.Errorf("Before: got %q, want まえ", got.Corrections[0].Before)
+	}
+	if got.Corrections[0].After != "あと" {
+		t.Errorf("After: got %q, want あと", got.Corrections[0].After)
+	}
+}
+
+func TestGenerate_DoesNotSaveProofreadIntermediate_WhenProofreadDisabled(t *testing.T) {
+	workDir := t.TempDir()
+	rundown := corneredRundown("AIコーナー",
+		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
+	)
+	lines := []model.Line{{SpeakerRole: "zundamon", Text: "テスト"}}
+	corners := []config.CornerConfig{
+		{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
+	}
+
+	// proofreadResult is nil (proofread not set or failed)
+	md := &mockDirector{proofreadResult: nil}
+	gen := script.NewLLMScriptGenerator(
+		&mockWriter{lines: lines},
+		md,
+		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
+		workDir,
+	)
+
+	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path := filepath.Join(workDir, fileio.FileProofread)
+	if _, err := os.Stat(path); err == nil {
+		t.Errorf("%s should NOT exist when proofread is disabled, but it does", fileio.FileProofread)
+	}
+}
+
+func TestGenerate_SavesProofreadIntermediate_EmptyCorrections(t *testing.T) {
+	workDir := t.TempDir()
+	rundown := corneredRundown("AIコーナー",
+		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
+	)
+	lines := []model.Line{{SpeakerRole: "zundamon", Text: "テスト"}}
+	corners := []config.CornerConfig{
+		{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
+	}
+
+	// proofread ran but found 0 corrections
+	pr := &direct.ProofreadResult{Corrections: make([]direct.ProofreadCorrection, 0)}
+	md := &mockDirector{proofreadResult: pr}
+	gen := script.NewLLMScriptGenerator(
+		&mockWriter{lines: lines},
+		md,
+		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
+		workDir,
+	)
+
+	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	path := filepath.Join(workDir, fileio.FileProofread)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected %s to exist even with 0 corrections: %v", fileio.FileProofread, err)
+	}
+
+	var got direct.ProofreadResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("%s must be valid ProofreadResult JSON: %v", fileio.FileProofread, err)
+	}
+	if got.Corrections == nil {
+		t.Error("Corrections should be [] not null in JSON output")
+	}
+	if len(got.Corrections) != 0 {
+		t.Errorf("Corrections: got %d, want 0", len(got.Corrections))
 	}
 }


### PR DESCRIPTION
## Summary

- `ProofreadCorrection` / `ProofreadResult` 型を `internal/script/direct` パッケージに追加
- `Director.Direct()` の戻り値を `(model.Script, *ProofreadResult, error)` に変更
  - `pr == nil`: 校正未設定または失敗（ファイル・ログなし）
  - `pr != nil`: 校正成功（0件でも `04_proofread.json` を保存）
- `04_proofread.json` を中間ファイルとして保存（`saveIntermediate` 経由）
- per-correction slog を削除し、件数のみのログ `script/direct: 校正完了 (N件修正)` を出力
- `internal/fileio/paths.go` に `FileProofread` 定数・`ProofreadPath` ヘルパーを追加

## Changes

- `internal/fileio/paths.go` — `FileProofread` 定数・`ProofreadPath` 追加
- `internal/script/direct/direct.go` — 型追加・インターフェース変更・実装変更
- `internal/script/direct/direct_test.go` — 全テスト更新（ログ検証 → ProofreadResult 内容検証）
- `internal/script/script.go` — 呼び出し側更新・中間ファイル保存・件数ログ出力
- `internal/script/script_test.go` — mockDirector 更新・3テスト追加
- `internal/cli/script.go` — 呼び出し側更新（single-step direct 対応）
- `internal/fileio/paths_test.go` — `ProofreadPath` テストケース追加

---
🤖 Generated with [Claude Code](https://claude.ai/code)