### PR TITLE
refactor(model): ProofreadResult/ProofreadCorrection を model パッケージへ移動

### DIFF
--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -804,3 +804,60 @@ func TestCornerLines_EmptyAssetFields_OmittedFromJSON(t *testing.T) {
 		}
 	}
 }
+
+func TestProofreadResult_RoundTrip(t *testing.T) {
+	pr := model.ProofreadResult{
+		Corrections: []model.ProofreadCorrection{
+			{CornerIndex: 0, LineIndex: 1, Before: "まえ", After: "あと", Reason: "理由"},
+		},
+	}
+	data, err := json.Marshal(pr)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var got model.ProofreadResult
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if len(got.Corrections) != 1 {
+		t.Fatalf("Corrections: got %d, want 1", len(got.Corrections))
+	}
+	c := got.Corrections[0]
+	if c.CornerIndex != 0 {
+		t.Errorf("CornerIndex: got %d, want 0", c.CornerIndex)
+	}
+	if c.LineIndex != 1 {
+		t.Errorf("LineIndex: got %d, want 1", c.LineIndex)
+	}
+	if c.Before != "まえ" {
+		t.Errorf("Before: got %q, want まえ", c.Before)
+	}
+	if c.After != "あと" {
+		t.Errorf("After: got %q, want あと", c.After)
+	}
+	if c.Reason != "理由" {
+		t.Errorf("Reason: got %q, want 理由", c.Reason)
+	}
+}
+
+func TestProofreadResult_EmptyCorrections_NotNull(t *testing.T) {
+	pr := model.ProofreadResult{Corrections: make([]model.ProofreadCorrection, 0)}
+	data, err := json.Marshal(pr)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if !strings.Contains(string(data), `"corrections":[]`) {
+		t.Errorf("corrections should be [] not null: %s", string(data))
+	}
+}
+
+func TestProofreadCorrection_ReasonOmittedWhenEmpty(t *testing.T) {
+	c := model.ProofreadCorrection{CornerIndex: 0, LineIndex: 0, Before: "a", After: "b"}
+	data, err := json.Marshal(c)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if strings.Contains(string(data), `"reason"`) {
+		t.Errorf("reason should be omitted when empty: %s", string(data))
+	}
+}

--- a/internal/model/proofread.go
+++ b/internal/model/proofread.go
@@ -1,0 +1,16 @@
+package model
+
+// ProofreadCorrection represents a single correction made by the proofreading pass.
+type ProofreadCorrection struct {
+	CornerIndex int    `json:"corner_index"`
+	LineIndex   int    `json:"line_index"`
+	Before      string `json:"before"`
+	After       string `json:"after"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// ProofreadResult holds the result of a proofreading pass, including all corrections applied.
+// Non-nil means the proofreading LLM ran successfully (even if Corrections is empty).
+type ProofreadResult struct {
+	Corrections []ProofreadCorrection `json:"corrections"`
+}

--- a/internal/script/direct/direct.go
+++ b/internal/script/direct/direct.go
@@ -92,23 +92,8 @@ type cornerLLMPayload struct {
 	Lines     []model.Line `json:"lines"`
 }
 
-// ProofreadCorrection represents a single correction made by the proofreading pass.
-type ProofreadCorrection struct {
-	CornerIndex int    `json:"corner_index"`
-	LineIndex   int    `json:"line_index"`
-	Before      string `json:"before"`
-	After       string `json:"after"`
-	Reason      string `json:"reason,omitempty"`
-}
-
-// ProofreadResult holds the result of a proofreading pass, including all corrections applied.
-// Non-nil means the proofreading LLM ran successfully (even if Corrections is empty).
-type ProofreadResult struct {
-	Corrections []ProofreadCorrection `json:"corrections"`
-}
-
 type Director interface {
-	Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog, programDirection string) (model.Script, *ProofreadResult, error)
+	Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog, programDirection string) (model.Script, *model.ProofreadResult, error)
 }
 
 type insertion struct {
@@ -185,7 +170,7 @@ func NewLLMDirector(client llm.Client, promptTemplate string, temperature float6
 	return d
 }
 
-func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog, programDirection string) (model.Script, *ProofreadResult, error) {
+func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, catalog model.AssetCatalog, programDirection string) (model.Script, *model.ProofreadResult, error) {
 	payload := make([]cornerLLMPayload, len(corners))
 	for i, c := range corners {
 		payload[i] = cornerLLMPayload{
@@ -226,14 +211,14 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 	}
 
 	lineConversions := resp.LineConversions
-	var pr *ProofreadResult
+	var pr *model.ProofreadResult
 
 	if d.proofread != nil {
 		corrections, beforeMap, err := d.runProofread(ctx, corners, lineConversions)
 		if err != nil {
 			slog.Default().Warn("proofread failed, using direct conversion", "err", err)
 		} else {
-			cs := make([]ProofreadCorrection, 0, len(corrections))
+			cs := make([]model.ProofreadCorrection, 0, len(corrections))
 			for _, c := range corrections {
 				lineConversions = append(lineConversions, lineConversion{
 					CornerIndex: c.CornerIndex,
@@ -241,7 +226,7 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 					Text:        c.Text,
 				})
 				before := beforeMap[insertKey{c.CornerIndex, c.LineIndex}]
-				cs = append(cs, ProofreadCorrection{
+				cs = append(cs, model.ProofreadCorrection{
 					CornerIndex: c.CornerIndex,
 					LineIndex:   c.LineIndex,
 					Before:      before,
@@ -249,7 +234,7 @@ func (d *LLMDirector) Direct(ctx context.Context, corners []model.CornerLines, c
 					Reason:      c.Reason,
 				})
 			}
-			pr = &ProofreadResult{Corrections: cs}
+			pr = &model.ProofreadResult{Corrections: cs}
 		}
 	}
 

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script"
-	"github.com/canpok1/vox-radio/internal/script/direct"
 	"github.com/canpok1/vox-radio/internal/script/write"
 )
 
@@ -47,11 +46,11 @@ func (m *mockWriter) Write(_ context.Context, _ config.ProgramConfig, corner con
 
 type mockDirector struct {
 	script          model.Script
-	proofreadResult *direct.ProofreadResult
+	proofreadResult *model.ProofreadResult
 	err             error
 }
 
-func (m *mockDirector) Direct(_ context.Context, corners []model.CornerLines, _ model.AssetCatalog, _ string) (model.Script, *direct.ProofreadResult, error) {
+func (m *mockDirector) Direct(_ context.Context, corners []model.CornerLines, _ model.AssetCatalog, _ string) (model.Script, *model.ProofreadResult, error) {
 	if m.err != nil {
 		return model.Script{}, nil, m.err
 	}
@@ -736,8 +735,8 @@ func TestGenerate_SavesProofreadIntermediate_WhenProofreadSucceeds(t *testing.T)
 		{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
 	}
 
-	pr := &direct.ProofreadResult{
-		Corrections: []direct.ProofreadCorrection{
+	pr := &model.ProofreadResult{
+		Corrections: []model.ProofreadCorrection{
 			{CornerIndex: 0, LineIndex: 0, Before: "まえ", After: "あと", Reason: "理由"},
 		},
 	}
@@ -759,7 +758,7 @@ func TestGenerate_SavesProofreadIntermediate_WhenProofreadSucceeds(t *testing.T)
 		t.Fatalf("expected %s to exist: %v", fileio.FileProofread, err)
 	}
 
-	var got direct.ProofreadResult
+	var got model.ProofreadResult
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("%s must be valid ProofreadResult JSON: %v", fileio.FileProofread, err)
 	}
@@ -814,7 +813,7 @@ func TestGenerate_SavesProofreadIntermediate_EmptyCorrections(t *testing.T) {
 	}
 
 	// proofread ran but found 0 corrections
-	pr := &direct.ProofreadResult{Corrections: make([]direct.ProofreadCorrection, 0)}
+	pr := &model.ProofreadResult{Corrections: make([]model.ProofreadCorrection, 0)}
 	md := &mockDirector{proofreadResult: pr}
 	gen := script.NewLLMScriptGenerator(
 		&mockWriter{lines: lines},
@@ -833,7 +832,7 @@ func TestGenerate_SavesProofreadIntermediate_EmptyCorrections(t *testing.T) {
 		t.Fatalf("expected %s to exist even with 0 corrections: %v", fileio.FileProofread, err)
 	}
 
-	var got direct.ProofreadResult
+	var got model.ProofreadResult
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("%s must be valid ProofreadResult JSON: %v", fileio.FileProofread, err)
 	}


### PR DESCRIPTION
## Summary

- `ProofreadCorrection` / `ProofreadResult` 型を `internal/script/direct` パッケージから `internal/model` パッケージへ移動
- `Director` インターフェースの戻り値型を `*model.ProofreadResult` に変更
- 複数のコンシューマ（`internal/script/script.go`, `internal/cli/script.go`, `internal/cli/episodegen.go`, テスト）が同一型を参照するため、`model.ScriptLines` / `model.Script` 等の他の中間型と同様に `model` パッケージで一元管理する

## Changes

- `internal/model/proofread.go`: 新規作成（`ProofreadCorrection`, `ProofreadResult` 型の定義）
- `internal/script/direct/direct.go`: ローカル型定義を削除し `model.ProofreadResult` / `model.ProofreadCorrection` を使用
- `internal/script/script_test.go`: `direct.ProofreadResult` → `model.ProofreadResult` に更新（`direct` import 削除）
- `internal/model/model_test.go`: 新型のテスト追加（RoundTrip, EmptyCorrections, omitempty）

---
🤖 Generated with [Claude Code](https://claude.ai/code)