### PR TITLE
feat(Makefile): run-sample のログを out-dir 直下に出力する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ docs:
 
 run-sample: build
 	./$(BINARY_NAME) init --sample
-	./$(BINARY_NAME) --config sample/vox-radio.yaml episodegen --spec "$(PROFILE)" --out-dir "$(OUT_DIR)"
+	./$(BINARY_NAME) --config sample/vox-radio.yaml episodegen --spec "$(PROFILE)" --out-dir "$(OUT_DIR)" --log-dir "$(OUT_DIR)"
 
 check-samples: build
 	./$(BINARY_NAME) --config internal/cli/templates/vox-radio.yaml config check


### PR DESCRIPTION
関連タスク: [make run-sample のログを mp3 と同じ out-dir 直下に出力する（Makefile変更）](https://app.todoist.com/app/task/6gpwqcwpWpG3VCJg)

## Summary

- `make run-sample` の `episodegen` 呼び出しに `--log-dir "$(OUT_DIR)"` を追加
- mp3（`episode.mp3`）と同じ `out-dir` 直下にログファイルが出力されるようになり、実行結果とログの突き合わせが容易になる
- CLI コードの変更なし（Makefile のみ）

---
🤖 Generated with [Claude Code](https://claude.ai/code)