### PR TITLE
refactor(assign-tasks): .claude/ 関連の除外条件2・3を削除する

### DIFF
--- a/.claude/skills/assign-tasks/SKILL.md
+++ b/.claude/skills/assign-tasks/SKILL.md
@@ -11,13 +11,9 @@ argument-hint: "[--count N]"
 ## 手順
 
 1. `mcp__todoist__find-tasks`（`vox-radio` セクション、`labels: ["ready"]`）で未完了かつ `ready` ラベル付きのタスクを取得する。
-2. 以下の条件に該当するタスクを除外する:
-   - `assign-to-claude` または `in-progress` ラベルが付いているタスク
-   - タイトルまたは本文に `.claude/` パスへの参照を含むタスク
-   - `.claude/` ディレクトリの変更を主目的とするタスク（スキル、ルール、フック、CLAUDE.md、自動化関連）
-3. 除外対象のタスクから `ready` ラベルを除去し（`mcp__todoist__update-tasks` で `labels` を更新）、除外理由をログに記録する。
-4. 残りのタスクを `task-assigner` エージェントの優先度基準に従って優先順位付けする。
-5. 上位N件（`$ARGUMENTS` の `--count` で指定、デフォルト: 2件）に `assign-to-claude` ラベルを付与する（`mcp__todoist__update-tasks` で既存 `labels` に追加）。
+2. `assign-to-claude` または `in-progress` ラベルが付いているタスクを除外する（除外したタスクはターミナルへログ出力する）。
+3. 残りのタスクを `task-assigner` エージェントの優先度基準に従って優先順位付けする。
+4. 上位N件（`$ARGUMENTS` の `--count` で指定、デフォルト: 2件）に `assign-to-claude` ラベルを付与する（`mcp__todoist__update-tasks` で既存 `labels` に追加）。
 
 ## 出力
 


### PR DESCRIPTION
関連タスク: [assign-tasks スキルの除外条件から `.claude/` 関連の条件2・3を削除する](https://app.todoist.com/app/task/6gpx2Pj2jhhXVgH3)

## Summary

- `assign-tasks` スキル（`.claude/skills/assign-tasks/SKILL.md`）手順2の除外条件から `.claude/` パス参照・`.claude/` 変更を主目的とする2項目を削除
- `ready` ラベルは人間が着手可否を判断して付与するものであり、`.claude/` 変更タスクも `assign-to-claude` 付与 → solve-task で自律実装してよい方針に変更
- `.claude/` 除外条件とセットだった手順3（除外タスクの `ready` ラベル除去）も不要となったため削除し、手順を5ステップから4ステップに縮約

---
🤖 Generated with [Claude Code](https://claude.ai/code)