### PR TITLE
ワークフロースクリプトの503対策（td横断スロットリング＋ジッター）

### DIFF
--- a/workflow-scripts/auto-analyze.sh
+++ b/workflow-scripts/auto-analyze.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=workflow-scripts/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
 if [[ $# -ne 1 ]] || ! [[ "$1" =~ ^[0-9]+$ ]] || [[ "$1" -eq 0 ]]; then
   echo "Usage: $0 <min-count>" >&2
   exit 1
@@ -53,5 +56,5 @@ while true; do
   fi
 
   PREV_STATE="$CURRENT_STATE"
-  sleep 60
+  poll_sleep
 done

--- a/workflow-scripts/auto-assign.sh
+++ b/workflow-scripts/auto-assign.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=workflow-scripts/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
 ASSIGN_COUNT=1
 
 while [[ $# -gt 0 ]]; do
@@ -91,5 +94,5 @@ while $RUNNING; do
   fi
 
   PREV_STATE="$CURRENT_STATE"
-  sleep 60
+  poll_sleep
 done

--- a/workflow-scripts/auto-solve.sh
+++ b/workflow-scripts/auto-solve.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# shellcheck source=workflow-scripts/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
 if [[ $# -gt 0 ]]; then
   echo "Usage: $0" >&2; exit 1
 fi
@@ -36,5 +39,5 @@ while $RUNNING; do
     printf "."
   fi
 
-  sleep 60
+  poll_sleep
 done

--- a/workflow-scripts/lib.sh
+++ b/workflow-scripts/lib.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# workflow-scripts 共通ライブラリ（source して使う）
+#
+# 目的: auto-assign / auto-solve / auto-analyze を同時起動しても Todoist の
+# 503（叩きすぎ）でループが落ちないようにする。
+#
+#   - td(): 実 td バイナリのラッパー。プロセス横断のスロットリング（最小間隔
+#           を保証）と、失敗時の指数バックオフ・リトライを行う。関数名を td に
+#           することで、source 側の既存 `td ...` 呼び出しをそのまま保護する。
+#   - poll_sleep(): ポーリング間隔にジッターを付け、複数ループの td 呼び出しが
+#           同じ瞬間に集中（同期）しないよう脱同期させる。
+#
+# 調整用パラメータ（環境変数で上書き可）:
+#   POLL_INTERVAL    ポーリングの基準間隔（秒, 既定 60）
+#   POLL_JITTER      基準間隔へ加算する 0..N 秒のランダム揺らぎ（既定 15）
+#   TD_MIN_GAP       td 呼び出し間の最小間隔（秒, 全ループ横断, 既定 3）
+#   TD_MAX_ATTEMPTS  td 失敗時の最大試行回数（既定 5）
+
+_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_LOCK_DIR="${_LIB_DIR}/../.tmp/locks"
+mkdir -p "$_LOCK_DIR"
+
+POLL_INTERVAL="${POLL_INTERVAL:-60}"
+POLL_JITTER="${POLL_JITTER:-15}"
+TD_MIN_GAP="${TD_MIN_GAP:-3}"
+TD_MAX_ATTEMPTS="${TD_MAX_ATTEMPTS:-5}"
+
+# 基準間隔 + ジッターだけ待つ。複数ループの脱同期に使う。
+poll_sleep() {
+  local jitter=0
+  if (( POLL_JITTER > 0 )); then
+    jitter=$(( RANDOM % (POLL_JITTER + 1) ))
+  fi
+  sleep $(( POLL_INTERVAL + jitter ))
+}
+
+# 実 td を、横断スロットリング + 指数バックオフ・リトライ付きで呼び出す。
+# 既存の `td ...` 呼び出しを変更せず保護するため、あえて td という名前にする。
+td() {
+  local stamp="${_LOCK_DIR}/td-last" lock="${_LOCK_DIR}/td-throttle"
+  local attempt=1 out rc last now wait errfile
+  errfile="$(mktemp)"
+
+  while :; do
+    # 横断スロットリング: 直前の td 呼び出しから TD_MIN_GAP 秒以上空ける。
+    # flock 中に待つことで、同時起動した複数ループの td が直列化・間隔保証される。
+    {
+      flock 8
+      last="$(cat "$stamp" 2>/dev/null || echo 0)"
+      now="$(date +%s)"
+      wait=$(( last + TD_MIN_GAP - now ))
+      if (( wait > 0 )); then
+        sleep "$wait"
+      fi
+      date +%s > "$stamp"
+    } 8>"$lock"
+
+    if out="$(command td "$@" 2>"$errfile")"; then
+      printf '%s' "$out"
+      rm -f "$errfile"
+      return 0
+    fi
+    rc=$?
+
+    if (( attempt >= TD_MAX_ATTEMPTS )); then
+      cat "$errfile" >&2
+      rm -f "$errfile"
+      return "$rc"
+    fi
+    echo "td failed (attempt ${attempt}/${TD_MAX_ATTEMPTS}); retrying with backoff..." >&2
+    sleep $(( 2 ** attempt ))
+    attempt=$(( attempt + 1 ))
+  done
+}

--- a/workflow-scripts/solve-task.sh
+++ b/workflow-scripts/solve-task.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORKSPACE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
+# shellcheck source=workflow-scripts/lib.sh
+source "${SCRIPT_DIR}/lib.sh"
+
 PRINT_MODE=false
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
auto-assign / auto-solve / auto-analyze を同時起動すると、固定 sleep 60 で
td 呼び出しが同期して集中し Todoist の 503 を誘発、さらに set -e で 1 回の
失敗でもループが落ちていた。共通ライブラリ lib.sh を新設し対処する。

- td(): 実 td をプロセス横断スロットリング（TD_MIN_GAP で最小間隔保証）＋
  指数バックオフ・リトライ（TD_MAX_ATTEMPTS）でラップ。関数名を td とし
  既存呼び出しを無改変で保護。
- poll_sleep(): ポーリング間隔にジッター（POLL_JITTER）を付与し複数ループを
  脱同期。POLL_INTERVAL で基準間隔を可変化。
- 4スクリプトで lib.sh を source し sleep 60 を poll_sleep に置換。