### PR TITLE
fix(slack): episode_number 不一致時に前回 state を誤再利用するバグを修正

### DIFF
--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -94,7 +94,7 @@ func Run(opts Options, poster Poster) error {
 	}
 	needUpload := true
 
-	if loaded, err := loadState(statePath); err == nil && loaded.AudioFile == manifest.AudioFile && loaded.EpisodeNumber == manifest.EpisodeNumber {
+	if loaded, err := loadState(statePath); err == nil && loaded.Matches(manifest.AudioFile, manifest.EpisodeNumber) {
 		if loaded.Replied {
 			writeResult(opts.Out, loaded.Channel, loaded.FileID, loaded.ThreadTS)
 			return nil

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -94,7 +94,7 @@ func Run(opts Options, poster Poster) error {
 	}
 	needUpload := true
 
-	if loaded, err := loadState(statePath); err == nil && loaded.AudioFile == manifest.AudioFile {
+	if loaded, err := loadState(statePath); err == nil && loaded.AudioFile == manifest.AudioFile && loaded.EpisodeNumber == manifest.EpisodeNumber {
 		if loaded.Replied {
 			writeResult(opts.Out, loaded.Channel, loaded.FileID, loaded.ThreadTS)
 			return nil

--- a/internal/slack/slack_test.go
+++ b/internal/slack/slack_test.go
@@ -558,6 +558,68 @@ func TestRun_IgnoresStateMismatch(t *testing.T) {
 	}
 }
 
+// ⑤ episode_number が異なる場合は前の状態を無視して新規投稿
+func TestRun_IgnoresStateWithDifferentEpisodeNumber(t *testing.T) {
+	dir := t.TempDir()
+
+	// manifest: episode_number=14, audio_file="episode.mp3"
+	manifest := map[string]any{
+		"title":          "ずんだもんテックラジオ",
+		"episode_number": 14,
+		"episode_title":  "エピソード14",
+		"summary":        "",
+		"audio_file":     "episode.mp3",
+		"corners":        []any{},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "episode.mp3"), []byte("fake mp3"), 0o644); err != nil {
+		t.Fatalf("write audio: %v", err)
+	}
+
+	specPath := writeTestSlackSpec(t, dir)
+	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
+	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+
+	// state: episode_number=13（異なる）, replied=true, audio_file は同名
+	statePath := slack.DefaultStatePath(manifestPath)
+	stateJSON := `{"audio_file":"episode.mp3","episode_number":13,"channel":"C_OLD","file_id":"FILE_OLD","thread_ts":"TS_OLD","replied":true}`
+	if err := os.WriteFile(statePath, []byte(stateJSON), 0o644); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	uploadCalled := false
+	mock := &mockPoster{
+		uploadAudioFn: func(_ context.Context, _ slack.UploadParams) (string, error) {
+			uploadCalled = true
+			return "FILE_NEW", nil
+		},
+	}
+
+	var buf strings.Builder
+	if err := slack.Run(slack.Options{
+		ConfigPath:   configPath,
+		ManifestPath: manifestPath,
+		SpecPath:     specPath,
+		Out:          &buf,
+	}, mock); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !uploadCalled {
+		t.Error("UploadAudio should be called when episode_number differs from state")
+	}
+	out := buf.String()
+	if strings.Contains(out, "FILE_OLD") {
+		t.Errorf("output should not contain old file_id from mismatched state, got: %q", out)
+	}
+}
+
 // ⑥ dry-run で状態ファイル不介入
 func TestRun_DryRun_NoStateFile(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/slack/state.go
+++ b/internal/slack/state.go
@@ -27,6 +27,11 @@ func DefaultStatePath(manifestPath string) string {
 	return filepath.Join(dir, stem+".slackpost-state.json")
 }
 
+// Matches reports whether this state corresponds to the given audio file and episode number.
+func (s *PostState) Matches(audioFile string, episodeNumber int) bool {
+	return s.AudioFile == audioFile && s.EpisodeNumber == episodeNumber
+}
+
 func loadState(path string) (*PostState, error) {
 	var s PostState
 	if err := fileio.ReadJSON(path, &s); err != nil {

--- a/internal/slack/state_test.go
+++ b/internal/slack/state_test.go
@@ -38,6 +38,28 @@ func TestDefaultStatePath(t *testing.T) {
 	}
 }
 
+func TestPostState_Matches(t *testing.T) {
+	s := PostState{AudioFile: "episode.mp3", EpisodeNumber: 13}
+	tests := []struct {
+		name          string
+		audioFile     string
+		episodeNumber int
+		want          bool
+	}{
+		{"same audio and episode", "episode.mp3", 13, true},
+		{"different episode_number", "episode.mp3", 14, false},
+		{"different audio_file", "other.mp3", 13, false},
+		{"both different", "other.mp3", 99, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := s.Matches(tt.audioFile, tt.episodeNumber); got != tt.want {
+				t.Errorf("Matches(%q, %d) = %v, want %v", tt.audioFile, tt.episodeNumber, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSaveAndLoadState_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.slackpost-state.json")


### PR DESCRIPTION
関連タスク: [slackpost --state が別エピソードの投稿済み状態を誤再利用し新規投稿をスキップする](https://app.todoist.com/app/task/6gqG3RwxR27vXG2V)

## Summary

- `slackpost --state` で、`audio_file` が同名（例: `episode.mp3`）の場合に前回エピソードの `replied: true` 状態が再利用され、新規投稿がスキップされるバグを修正
- 冪等判定条件に `episode_number` の一致チェックを追加（`AudioFile` のみの比較から `AudioFile && EpisodeNumber` の両方一致へ）
- 一致判定ロジックを `PostState.Matches()` メソッドに抽出し、将来のフィールド追加時の変更箇所を1か所に集約

## Changes

- `internal/slack/state.go`: `PostState.Matches(audioFile string, episodeNumber int) bool` を追加
- `internal/slack/slack.go`: インライン条件を `loaded.Matches(...)` 呼び出しに変更
- `internal/slack/state_test.go`: `TestPostState_Matches` のテーブル駆動テストを追加
- `internal/slack/slack_test.go`: バグ再現テスト `TestRun_IgnoresStateWithDifferentEpisodeNumber` を追加

## Test plan

- [ ] `go test ./internal/slack/...` がすべて PASS
- [ ] 同名 `audio_file` で `episode_number` が異なるシナリオを再現するテストが RED→GREEN であることを確認済み

---
🤖 Generated with [Claude Code](https://claude.ai/code)