### PR TITLE
feat(config): program.chars_per_minute で台本の文字数換算係数を設定可能にする

### DIFF
--- a/internal/cli/skills/vox-radio/references/episode-spec.md
+++ b/internal/cli/skills/vox-radio/references/episode-spec.md
@@ -16,6 +16,7 @@
 | `direction` | string | 任意 | 番組全体の演出方針（direct ステップのみに渡る）。SE・pause の挿入タイミングに関する指示。台本生成・manifest・feed・Slack には渡されない |
 | `script_note` | string | 任意 | 番組全体の台本指示（write ステップのみに渡る）。非公開フィールド。manifest・feed・Slack には露出しない。コーナーを問わず全台本に適用したいルールや注意事項を記述する |
 | `summary_length` | int | 任意 | 番組全体サマリーの目安文字数。未指定時はデフォルト 200 文字 |
+| `chars_per_minute` | int | 任意 | 台本の文字数換算に使用する1分あたりの目安文字数。台本生成時の `length_sec` → 目標文字数換算に使用。未指定時はデフォルト 420（= 7文字/秒×60） |
 
 ## `corners` セクション
 
@@ -29,7 +30,7 @@
 | `direction` | string | 任意 | コーナーの演出方針（direct ステップのみに渡る）。SE の挿入タイミングなど。台本生成 LLM へは渡されない |
 | `script_note` | string | 任意 | コーナー個別の台本指示（write ステップのみに渡る）。非公開フィールド。manifest・feed・Slack には露出しない。このコーナーのやり取りの細かい指示を記述する |
 | `cast` | map[string]string | 任意 | キャラID → 役割説明のマップ（キーは `vox-radio.yaml` の `characters` のキーと一致させること） |
-| `length_sec` | int | 任意 | このコーナーの目標収録時間（秒）。台本生成時に文字数（≈7文字/秒）へ換算される |
+| `length_sec` | int | 任意 | このコーナーの目標収録時間（秒）。台本生成時に `program.chars_per_minute`（既定 420/分）で文字数へ換算される |
 | `summary_length` | int | 任意 | コーナーサマリーの目安文字数。未指定時はデフォルト 100 文字 |
 | `source` | SourceConfig | 任意 | データソース（省略するとこのコーナーの収集はスキップ） |
 | `start_audio` | AudioRef | 任意 | コーナー開始境界音声。`type` に `jingle`（BGM停止後再生）または `se`（BGMの下で再生）を指定し、`id` に `assets` の該当マップのキーを指定する。コーナー本編の前に確定的に挿入される |

--- a/internal/cli/templates-sample/episode-spec.yaml
+++ b/internal/cli/templates-sample/episode-spec.yaml
@@ -23,6 +23,8 @@ program:
   summary_length: 200
   # 番組のタイムゾーン（IANA tz名）。省略時は Asia/Tokyo。
   # timezone: "Asia/Tokyo"
+  # 台本生成時の1分あたり目安文字数。話速や BGM で実再生時間が前後する場合に調整する。省略時は 420（= 7文字/秒）。
+  # chars_per_minute: 420
 
 # 出演者の一覧。ここに書いた人だけが番組に登場します。
 casts:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,17 +13,17 @@ import (
 	"github.com/canpok1/vox-radio/internal/fileio"
 )
 
-// CharsPerSec is the approximate number of characters spoken per second,
-// used to convert length_sec to a target character count.
-const CharsPerSec = 7
+// DefaultCharsPerMinute is the default number of characters spoken per minute (= 7文字/秒×60),
+// used to convert length_sec to a target character count when chars_per_minute is not configured.
+const DefaultCharsPerMinute = 420
 
 // DefaultMinRequestIntervalMS is the default minimum interval (ms) between LLM API requests.
 // Based on gemini-3.1-flash-lite free tier (15 RPM) with ~10% safety margin: 60000/15 * 1.1 ≈ 4500.
 const DefaultMinRequestIntervalMS = 4500
 
 // DurationSecToTargetChars converts a duration in seconds to an approximate target character count.
-func DurationSecToTargetChars(sec int) int {
-	return sec * CharsPerSec
+func DurationSecToTargetChars(sec, charsPerMinute int) int {
+	return sec * charsPerMinute / 60
 }
 
 type FeedEntry struct {
@@ -276,13 +276,14 @@ func (c CacheConfig) EffectiveLLMContextEntries() int {
 // ProgramConfig holds program-wide settings for content generation.
 type ProgramConfig struct {
 	// ID is required: it is the cache key (episodes are stored per program.id).
-	ID            string `yaml:"id"`
-	Title         string `yaml:"title"`
-	Description   string `yaml:"description"`
-	Direction     string `yaml:"direction,omitempty"`   // 番組全体の演出指示（direct専用）
-	ScriptNote    string `yaml:"script_note,omitempty"` // 番組全体の台本指示（write専用・非公開）
-	SummaryLength int    `yaml:"summary_length,omitempty"`
-	Timezone      string `yaml:"timezone,omitempty"` // IANA tz名。未設定時は DefaultProgramTimezone
+	ID             string `yaml:"id"`
+	Title          string `yaml:"title"`
+	Description    string `yaml:"description"`
+	Direction      string `yaml:"direction,omitempty"`   // 番組全体の演出指示（direct専用）
+	ScriptNote     string `yaml:"script_note,omitempty"` // 番組全体の台本指示（write専用・非公開）
+	SummaryLength  int    `yaml:"summary_length,omitempty"`
+	Timezone       string `yaml:"timezone,omitempty"`         // IANA tz名。未設定時は DefaultProgramTimezone
+	CharsPerMinute int    `yaml:"chars_per_minute,omitempty"` // 台本の文字数換算に使用する1分あたりの文字数。未設定時は DefaultCharsPerMinute
 }
 
 // EffectiveSummaryLength returns the configured SummaryLength, falling back to DefaultProgramSummaryLength.
@@ -291,6 +292,14 @@ func (p ProgramConfig) EffectiveSummaryLength() int {
 		return DefaultProgramSummaryLength
 	}
 	return p.SummaryLength
+}
+
+// EffectiveCharsPerMinute returns the configured CharsPerMinute, falling back to DefaultCharsPerMinute.
+func (p ProgramConfig) EffectiveCharsPerMinute() int {
+	if p.CharsPerMinute <= 0 {
+		return DefaultCharsPerMinute
+	}
+	return p.CharsPerMinute
 }
 
 // EffectiveTimezone returns Timezone, falling back to DefaultProgramTimezone.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,19 +12,45 @@ import (
 
 func TestDurationSecToTargetChars(t *testing.T) {
 	tests := []struct {
-		sec  int
-		want int
+		sec            int
+		charsPerMinute int
+		want           int
 	}{
-		{sec: 0, want: 0},
-		{sec: 1, want: 7},
-		{sec: 14, want: 98},
-		{sec: 30, want: 210},
+		// デフォルト値 420/分（= 旧 7文字/秒）での従来値一致
+		{sec: 0, charsPerMinute: 420, want: 0},
+		{sec: 14, charsPerMinute: 420, want: 98},
+		{sec: 30, charsPerMinute: 420, want: 210},
+		// 任意値での確認
+		{sec: 60, charsPerMinute: 300, want: 300},
+		{sec: 120, charsPerMinute: 300, want: 600},
 	}
 	for _, tt := range tests {
-		got := config.DurationSecToTargetChars(tt.sec)
+		got := config.DurationSecToTargetChars(tt.sec, tt.charsPerMinute)
 		if got != tt.want {
-			t.Errorf("DurationSecToTargetChars(%d) = %d, want %d", tt.sec, got, tt.want)
+			t.Errorf("DurationSecToTargetChars(%d, %d) = %d, want %d", tt.sec, tt.charsPerMinute, got, tt.want)
 		}
+	}
+}
+
+func TestProgramConfig_EffectiveCharsPerMinute(t *testing.T) {
+	tests := []struct {
+		name           string
+		charsPerMinute int
+		want           int
+	}{
+		{name: "unset (0) returns default", charsPerMinute: 0, want: config.DefaultCharsPerMinute},
+		{name: "negative returns default", charsPerMinute: -1, want: config.DefaultCharsPerMinute},
+		{name: "explicit value returned", charsPerMinute: 300, want: 300},
+		{name: "explicit default value returned", charsPerMinute: 420, want: 420},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := config.ProgramConfig{CharsPerMinute: tt.charsPerMinute}
+			got := p.EffectiveCharsPerMinute()
+			if got != tt.want {
+				t.Errorf("EffectiveCharsPerMinute() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -152,7 +152,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, program config.P
 	}
 	totalTarget := 0
 	for _, c := range corners {
-		totalTarget += config.DurationSecToTargetChars(c.LengthSec)
+		totalTarget += config.DurationSecToTargetChars(c.LengthSec, program.EffectiveCharsPerMinute())
 	}
 	if totalTarget <= 0 {
 		return cornerLines
@@ -170,7 +170,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, program config.P
 	worstIdx := 0
 	worstDev := 0.0
 	for i, corner := range corners {
-		targetChars := config.DurationSecToTargetChars(corner.LengthSec)
+		targetChars := config.DurationSecToTargetChars(corner.LengthSec, program.EffectiveCharsPerMinute())
 		if targetChars <= 0 {
 			continue
 		}

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -150,9 +150,10 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, program config.P
 	if len(corners) == 0 {
 		return cornerLines
 	}
+	charsPerMin := program.EffectiveCharsPerMinute()
 	totalTarget := 0
 	for _, c := range corners {
-		totalTarget += config.DurationSecToTargetChars(c.LengthSec, program.EffectiveCharsPerMinute())
+		totalTarget += config.DurationSecToTargetChars(c.LengthSec, charsPerMin)
 	}
 	if totalTarget <= 0 {
 		return cornerLines
@@ -170,7 +171,7 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, program config.P
 	worstIdx := 0
 	worstDev := 0.0
 	for i, corner := range corners {
-		targetChars := config.DurationSecToTargetChars(corner.LengthSec, program.EffectiveCharsPerMinute())
+		targetChars := config.DurationSecToTargetChars(corner.LengthSec, charsPerMin)
 		if targetChars <= 0 {
 			continue
 		}

--- a/internal/script/write/write.go
+++ b/internal/script/write/write.go
@@ -149,7 +149,7 @@ func (w *LLMWriter) Write(ctx context.Context, program config.ProgramConfig, cor
 		Content:           corner.Content,
 		ScriptNote:        corner.ScriptNote,
 		Cast:              castEntries,
-		TargetChars:       config.DurationSecToTargetChars(corner.LengthSec),
+		TargetChars:       config.DurationSecToTargetChars(corner.LengthSec, program.EffectiveCharsPerMinute()),
 		AppearanceCount:   w.cornerAppearanceCount,
 		LastEpisodeNumber: w.cornerLastEpisodeNumber,
 	}

--- a/internal/script/write/write_test.go
+++ b/internal/script/write/write_test.go
@@ -305,7 +305,7 @@ func TestLLMWriter_Write_PromptContainsConvertedTargetChars(t *testing.T) {
 	mc := &mockClient{response: linesJSON}
 	w := write.NewLLMWriter(mc, "c={{corner}}", 0, nil)
 
-	// 14sec * 7chars/sec = 98 chars
+	// 14sec * 420chars/min / 60 = 98 chars
 	corner := config.CornerConfig{Title: "Test", Content: "内容", LengthSec: 14}
 	_, _ = w.Write(context.Background(), config.ProgramConfig{}, corner, nil, nil, nil, nil, "", nil)
 
@@ -314,7 +314,7 @@ func TestLLMWriter_Write_PromptContainsConvertedTargetChars(t *testing.T) {
 	}
 	prompt := mc.captured[0].Messages[0].Content
 	if !strings.Contains(prompt, `"target_chars":98`) {
-		t.Errorf("prompt should contain target_chars:98 (14sec*7), got: %s", prompt)
+		t.Errorf("prompt should contain target_chars:98 (14sec*420/min), got: %s", prompt)
 	}
 	if strings.Contains(prompt, "length_sec") {
 		t.Errorf("prompt should not expose length_sec to LLM, got: %s", prompt)


### PR DESCRIPTION
関連タスク: [台本の文字数換算係数を設定可能にする（program.chars_per_minute を追加）](https://app.todoist.com/app/task/6gqG92c23C6rPQ93)

## Summary

- `ProgramConfig` に `chars_per_minute` フィールド（`CharsPerMinute int`）を追加し、番組ごとに1分あたりの目安文字数を設定可能にした
- `DurationSecToTargetChars` のシグネチャを `(sec, charsPerMinute int)` に変更し、`sec * charsPerMinute / 60` で換算
- `EffectiveCharsPerMinute()` を追加（未設定時は `DefaultCharsPerMinute = 420`、従来の 7文字/秒×60 と同一）
- 呼び出し箇所（`write.go`, `script.go` 2か所）を新シグネチャに更新
- リファレンス・テンプレートサンプルにフィールド説明を追記

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/config/config.go` | `const CharsPerSec` 削除 → `DefaultCharsPerMinute = 420` 追加、`DurationSecToTargetChars` シグネチャ変更、`ProgramConfig.CharsPerMinute` フィールド追加、`EffectiveCharsPerMinute()` メソッド追加 |
| `internal/config/config_test.go` | `TestDurationSecToTargetChars` を新シグネチャ対応に更新、`TestProgramConfig_EffectiveCharsPerMinute` 追加 |
| `internal/script/script.go` | `regenIfNeeded` の呼び出し箇所を更新（`charsPerMin` ローカル変数でキャッシュ） |
| `internal/script/write/write.go` | `Write` の呼び出し箇所を更新 |
| `internal/script/write/write_test.go` | 旧式換算コメント（`14sec*7`）を新式（`14sec*420/min/60`）に更新 |
| `internal/cli/skills/vox-radio/references/episode-spec.md` | `program` 表に `chars_per_minute` 行追加、`length_sec` 説明を更新 |
| `internal/cli/templates-sample/episode-spec.yaml` | `chars_per_minute` のコメント例を追加 |

## 後方互換性

- 未設定時は `DefaultCharsPerMinute = 420`（= 旧 `CharsPerSec = 7` × 60）を使用するため、既存の挙動は変わらない

---
🤖 Generated with [Claude Code](https://claude.ai/code)