### PR TITLE
refactor(model): feed-spec/slack-spec の型・Load・Validate を各ドメインへ移動

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -112,7 +112,6 @@ go list -f '{{.ImportPath}} => {{join .Imports " "}}' ./internal/... | grep canp
 
 | 違反 | 該当ルール | 対応タスク |
 |---|---|---|
-| `internal/model` が `fileio` に依存（`feed_spec.go` / `slack_spec.go` の Load・Validate・Effective値） | §2 データ層・§3 spec配置 | T1: feed-spec/slack-spec をドメインへ移動 |
 | `slack.Run` がパスを受け取り内部で `config.LoadConfig`・spec ロード・`os.Getenv` を実行 | §3 依存注入 | T2: slack.Run の依存注入化 |
 | `feed`（ingest.go）が SpecPath を受け取り内部で spec をロード | §3 依存注入 | T3: feed.Run の依存注入化 |
 | `pipeline.Assembler` interface が具象型 `*assemble.Result` を返す（pipeline → assemble 依存） | §2 オーケストレーション層・§4 interface | T4: Assembler interface の具象型除去 |

--- a/internal/cli/feedgen.go
+++ b/internal/cli/feedgen.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/canpok1/vox-radio/internal/feed"
-	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/spf13/cobra"
 )
 
@@ -65,12 +64,12 @@ func newFeedgenCheckCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := args[0]
 
-			spec, err := model.LoadFeedSpecStrict(path)
+			spec, err := feed.LoadFeedSpecStrict(path)
 			if err != nil {
 				return err
 			}
 
-			if err := model.ValidateFeedSpec(spec); err != nil {
+			if err := feed.ValidateFeedSpec(spec); err != nil {
 				return err
 			}
 

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/cli"
 	"github.com/canpok1/vox-radio/internal/config"
-	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/feed"
+	"github.com/canpok1/vox-radio/internal/slack"
 )
 
 func chdirTemp(t *testing.T) string {
@@ -172,10 +173,10 @@ func TestInitCmd_GeneratedFilesLoadable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEpisodeSpec failed on generated template: %v", err)
 	}
-	if _, err := model.LoadFeedSpec(filepath.Join(dir, "feed-spec.yaml")); err != nil {
+	if _, err := feed.LoadFeedSpec(filepath.Join(dir, "feed-spec.yaml")); err != nil {
 		t.Fatalf("LoadFeedSpec failed on generated template: %v", err)
 	}
-	slackSpec, err := model.LoadSlackSpec(filepath.Join(dir, "slack-spec.yaml"))
+	slackSpec, err := slack.LoadSlackSpec(filepath.Join(dir, "slack-spec.yaml"))
 	if err != nil {
 		t.Fatalf("LoadSlackSpec failed on generated template: %v", err)
 	}
@@ -307,10 +308,10 @@ func TestInitCmd_Sample_Loadable(t *testing.T) {
 		t.Error("第1回は地震・火山コーナー以外のローテ枠は放送されないべき")
 	}
 
-	if _, err := model.LoadFeedSpec(filepath.Join(dir, "sample", "feed-spec.yaml")); err != nil {
+	if _, err := feed.LoadFeedSpec(filepath.Join(dir, "sample", "feed-spec.yaml")); err != nil {
 		t.Fatalf("LoadFeedSpec failed on sample: %v", err)
 	}
-	if _, err := model.LoadSlackSpec(filepath.Join(dir, "sample", "slack-spec.yaml")); err != nil {
+	if _, err := slack.LoadSlackSpec(filepath.Join(dir, "sample", "slack-spec.yaml")); err != nil {
 		t.Fatalf("LoadSlackSpec failed on sample: %v", err)
 	}
 }

--- a/internal/cli/slackpost.go
+++ b/internal/cli/slackpost.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/slack"
 	"github.com/spf13/cobra"
 )
@@ -71,12 +70,12 @@ func newSlackpostCheckCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := args[0]
 
-			spec, err := model.LoadSlackSpecStrict(path)
+			spec, err := slack.LoadSlackSpecStrict(path)
 			if err != nil {
 				return err
 			}
 
-			if err := model.ValidateSlackSpec(spec); err != nil {
+			if err := slack.ValidateSlackSpec(spec); err != nil {
 				return err
 			}
 

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/canpok1/vox-radio/internal/cache"
-	"github.com/canpok1/vox-radio/internal/model"
 )
 
 type rssRoot struct {
@@ -62,7 +61,7 @@ type rssEnclosure struct {
 
 // BuildFeed generates a podcast RSS 2.0 + iTunes feed XML from cache entries.
 // Channel title/description come from the latest entry. Items are ordered newest first.
-func BuildFeed(cfg model.FeedSpec, entries []cache.Entry) (string, error) {
+func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
 	var channelTitle, channelDescription string
 	if len(entries) > 0 {
 		latest := entries[len(entries)-1]

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -8,12 +8,11 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/cache"
 	"github.com/canpok1/vox-radio/internal/feed"
-	"github.com/canpok1/vox-radio/internal/model"
 )
 
 func TestBuildFeed_GoldenOutput(t *testing.T) {
-	cfg := model.FeedSpec{
-		Feed: model.FeedConfig{
+	cfg := feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			Language:         "ja",
 			Author:           "testauthor",
 			Email:            "test@example.com",
@@ -24,7 +23,7 @@ func TestBuildFeed_GoldenOutput(t *testing.T) {
 			AudioURLTemplate: "https://example.com/releases/ep-{episode_number}/{audio_file}",
 			Credit:           "VOICEVOX:ずんだもん",
 		},
-		Output: model.OutputConfig{Public: "public"},
+		Output: feed.OutputConfig{Public: "public"},
 	}
 	entries := []cache.Entry{
 		{
@@ -81,8 +80,8 @@ func TestBuildFeed_GoldenOutput(t *testing.T) {
 }
 
 func TestBuildFeed_AudioURLTemplateSubstitution(t *testing.T) {
-	cfg := model.FeedSpec{
-		Feed: model.FeedConfig{
+	cfg := feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			AudioURLTemplate: "https://host.example/ep-{episode_number}/{audio_file}",
 		},
 	}
@@ -111,8 +110,8 @@ func TestBuildFeed_AudioURLTemplateSubstitution(t *testing.T) {
 }
 
 func TestBuildFeed_GUID(t *testing.T) {
-	cfg := model.FeedSpec{
-		Feed: model.FeedConfig{
+	cfg := feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			AudioURLTemplate: "https://host.example/ep-{episode_number}/{audio_file}",
 		},
 	}
@@ -140,8 +139,8 @@ func TestBuildFeed_GUID(t *testing.T) {
 }
 
 func TestBuildFeed_ChannelFromLatestEntry(t *testing.T) {
-	cfg := model.FeedSpec{
-		Feed: model.FeedConfig{
+	cfg := feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			AudioURLTemplate: "https://host.example/{episode_number}/{audio_file}",
 		},
 	}
@@ -185,8 +184,8 @@ func TestBuildFeed_ChannelFromLatestEntry(t *testing.T) {
 }
 
 func TestBuildFeed_EmptyEntries(t *testing.T) {
-	cfg := model.FeedSpec{
-		Feed: model.FeedConfig{
+	cfg := feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			AudioURLTemplate: "https://host.example/{episode_number}/{audio_file}",
 		},
 	}

--- a/internal/feed/ingest.go
+++ b/internal/feed/ingest.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/cache"
 	"github.com/canpok1/vox-radio/internal/fileio"
-	"github.com/canpok1/vox-radio/internal/model"
 )
 
 // Options holds input parameters for feed generation.
@@ -20,7 +19,7 @@ type Options struct {
 // Run loads cache and feed spec, generates feed.xml, and writes it to the public directory.
 // Returns the output path and the number of items written.
 func Run(opts Options) (string, int, error) {
-	cfg, err := model.LoadFeedSpec(opts.SpecPath)
+	cfg, err := LoadFeedSpec(opts.SpecPath)
 	if err != nil {
 		return "", 0, fmt.Errorf("load feed spec: %w", err)
 	}

--- a/internal/feed/ingest_test.go
+++ b/internal/feed/ingest_test.go
@@ -9,11 +9,10 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/cache"
 	"github.com/canpok1/vox-radio/internal/feed"
-	"github.com/canpok1/vox-radio/internal/model"
 	"gopkg.in/yaml.v3"
 )
 
-func writeFeedSpecYAML(t *testing.T, path string, cfg model.FeedSpec) {
+func writeFeedSpecYAML(t *testing.T, path string, cfg feed.FeedSpec) {
 	t.Helper()
 	data, err := yaml.Marshal(cfg)
 	if err != nil {
@@ -68,11 +67,11 @@ func TestRun_GeneratesFeedXML(t *testing.T) {
 	}
 	writeCacheJSONL(t, cachePath, entries)
 
-	writeFeedSpecYAML(t, specPath, model.FeedSpec{
-		Feed: model.FeedConfig{
+	writeFeedSpecYAML(t, specPath, feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			AudioURLTemplate: "https://example.com/{episode_number}/{audio_file}",
 		},
-		Output: model.OutputConfig{Public: publicDir},
+		Output: feed.OutputConfig{Public: publicDir},
 	})
 
 	_, n, err := feed.Run(feed.Options{
@@ -125,11 +124,11 @@ func TestRun_AllEntriesIncluded_WhenProgramIDsDiffer(t *testing.T) {
 	}
 	writeCacheJSONL(t, cachePath, entries)
 
-	writeFeedSpecYAML(t, specPath, model.FeedSpec{
-		Feed: model.FeedConfig{
+	writeFeedSpecYAML(t, specPath, feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			AudioURLTemplate: "https://example.com/{episode_number}/{audio_file}",
 		},
-		Output: model.OutputConfig{Public: publicDir},
+		Output: feed.OutputConfig{Public: publicDir},
 	})
 
 	_, n, err := feed.Run(feed.Options{
@@ -161,11 +160,11 @@ func TestRun_ErrorOnEpisodeNumberZero(t *testing.T) {
 	}
 	writeCacheJSONL(t, cachePath, entries)
 
-	writeFeedSpecYAML(t, specPath, model.FeedSpec{
-		Feed: model.FeedConfig{
+	writeFeedSpecYAML(t, specPath, feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			AudioURLTemplate: "https://example.com/{episode_number}/{audio_file}",
 		},
-		Output: model.OutputConfig{Public: publicDir},
+		Output: feed.OutputConfig{Public: publicDir},
 	})
 
 	_, _, err := feed.Run(feed.Options{
@@ -182,11 +181,11 @@ func TestRun_EmptyCache(t *testing.T) {
 
 	writeCacheJSONL(t, cachePath, []cache.Entry{})
 
-	writeFeedSpecYAML(t, specPath, model.FeedSpec{
-		Feed: model.FeedConfig{
+	writeFeedSpecYAML(t, specPath, feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			AudioURLTemplate: "https://example.com/{episode_number}/{audio_file}",
 		},
-		Output: model.OutputConfig{Public: publicDir},
+		Output: feed.OutputConfig{Public: publicDir},
 	})
 
 	_, n, err := feed.Run(feed.Options{

--- a/internal/feed/spec.go
+++ b/internal/feed/spec.go
@@ -1,4 +1,4 @@
-package model
+package feed
 
 import (
 	"errors"

--- a/internal/feed/spec_test.go
+++ b/internal/feed/spec_test.go
@@ -1,10 +1,10 @@
-package model_test
+package feed_test
 
 import (
 	"strings"
 	"testing"
 
-	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/feed"
 	"github.com/canpok1/vox-radio/internal/testutil"
 )
 
@@ -36,7 +36,7 @@ output:
 `
 	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(content))
 
-	cfg, err := model.LoadFeedSpec(path)
+	cfg, err := feed.LoadFeedSpec(path)
 	if err != nil {
 		t.Fatalf("LoadFeedSpec: unexpected error: %v", err)
 	}
@@ -75,23 +75,23 @@ output:
 }
 
 func TestLoadFeedSpec_FileNotExist(t *testing.T) {
-	_, err := model.LoadFeedSpec("/nonexistent/path/feed-spec.yaml")
+	_, err := feed.LoadFeedSpec("/nonexistent/path/feed-spec.yaml")
 	if err == nil {
 		t.Error("LoadFeedSpec: expected error for nonexistent file, got nil")
 	}
 }
 
 func TestFeedSpec_EffectivePublicDir_Default(t *testing.T) {
-	cfg := model.FeedSpec{}
+	cfg := feed.FeedSpec{}
 	got := cfg.EffectivePublicDir()
-	if got != model.DefaultPublicDir {
-		t.Errorf("EffectivePublicDir(): got %q, want %q", got, model.DefaultPublicDir)
+	if got != feed.DefaultPublicDir {
+		t.Errorf("EffectivePublicDir(): got %q, want %q", got, feed.DefaultPublicDir)
 	}
 }
 
 func TestFeedSpec_EffectivePublicDir_Custom(t *testing.T) {
-	cfg := model.FeedSpec{
-		Output: model.OutputConfig{Public: "dist/public"},
+	cfg := feed.FeedSpec{
+		Output: feed.OutputConfig{Public: "dist/public"},
 	}
 	got := cfg.EffectivePublicDir()
 	if got != "dist/public" {
@@ -101,7 +101,7 @@ func TestFeedSpec_EffectivePublicDir_Custom(t *testing.T) {
 
 func TestLoadFeedSpecStrict_Valid(t *testing.T) {
 	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(validFeedSpecYAML))
-	_, err := model.LoadFeedSpecStrict(path)
+	_, err := feed.LoadFeedSpecStrict(path)
 	if err != nil {
 		t.Fatalf("LoadFeedSpecStrict: unexpected error: %v", err)
 	}
@@ -109,7 +109,7 @@ func TestLoadFeedSpecStrict_Valid(t *testing.T) {
 
 func TestLoadFeedSpecStrict_UnknownKey(t *testing.T) {
 	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(validFeedSpecYAML+"\nunknown_field: value\n"))
-	_, err := model.LoadFeedSpecStrict(path)
+	_, err := feed.LoadFeedSpecStrict(path)
 	if err == nil {
 		t.Error("LoadFeedSpecStrict: expected error for unknown key, got nil")
 	}
@@ -119,22 +119,22 @@ func TestLoadFeedSpecStrict_UnknownKey(t *testing.T) {
 func TestLoadFeedSpecStrict_ProgramIDField_RaisesUnknownKey(t *testing.T) {
 	content := "program_id: my-radio\n" + validFeedSpecYAML
 	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(content))
-	_, err := model.LoadFeedSpecStrict(path)
+	_, err := feed.LoadFeedSpecStrict(path)
 	if err == nil {
 		t.Error("LoadFeedSpecStrict: expected error for program_id (unknown key), got nil")
 	}
 }
 
 func TestLoadFeedSpecStrict_FileNotExist(t *testing.T) {
-	_, err := model.LoadFeedSpecStrict("/nonexistent/path/feed-spec.yaml")
+	_, err := feed.LoadFeedSpecStrict("/nonexistent/path/feed-spec.yaml")
 	if err == nil {
 		t.Error("LoadFeedSpecStrict: expected error for nonexistent file, got nil")
 	}
 }
 
-func validSpec() model.FeedSpec {
-	return model.FeedSpec{
-		Feed: model.FeedConfig{
+func validSpec() feed.FeedSpec {
+	return feed.FeedSpec{
+		Feed: feed.FeedConfig{
 			Language:         "ja",
 			Author:           "Test Author",
 			Email:            "test@example.com",
@@ -147,7 +147,7 @@ func validSpec() model.FeedSpec {
 func TestValidateFeedSpec(t *testing.T) {
 	tests := []struct {
 		name        string
-		mutate      func(s *model.FeedSpec)
+		mutate      func(s *feed.FeedSpec)
 		wantErr     bool
 		errContains []string
 	}{
@@ -158,7 +158,7 @@ func TestValidateFeedSpec(t *testing.T) {
 		},
 		{
 			name: "optional fields empty",
-			mutate: func(s *model.FeedSpec) {
+			mutate: func(s *feed.FeedSpec) {
 				s.Feed.Category = ""
 				s.Feed.CoverImageURL = ""
 				s.Feed.Credit = ""
@@ -168,79 +168,79 @@ func TestValidateFeedSpec(t *testing.T) {
 		},
 		{
 			name:        "missing language",
-			mutate:      func(s *model.FeedSpec) { s.Feed.Language = "" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.Language = "" },
 			wantErr:     true,
 			errContains: []string{"feed.language"},
 		},
 		{
 			name:        "missing author",
-			mutate:      func(s *model.FeedSpec) { s.Feed.Author = "" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.Author = "" },
 			wantErr:     true,
 			errContains: []string{"feed.author"},
 		},
 		{
 			name:        "missing email",
-			mutate:      func(s *model.FeedSpec) { s.Feed.Email = "" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.Email = "" },
 			wantErr:     true,
 			errContains: []string{"feed.email"},
 		},
 		{
 			name:        "missing site_url",
-			mutate:      func(s *model.FeedSpec) { s.Feed.SiteURL = "" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.SiteURL = "" },
 			wantErr:     true,
 			errContains: []string{"feed.site_url"},
 		},
 		{
 			name:        "missing audio_url_template",
-			mutate:      func(s *model.FeedSpec) { s.Feed.AudioURLTemplate = "" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.AudioURLTemplate = "" },
 			wantErr:     true,
 			errContains: []string{"feed.audio_url_template"},
 		},
 		{
 			name:        "invalid email format",
-			mutate:      func(s *model.FeedSpec) { s.Feed.Email = "not-an-email" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.Email = "not-an-email" },
 			wantErr:     true,
 			errContains: []string{"feed.email"},
 		},
 		{
 			name:        "invalid site_url (relative)",
-			mutate:      func(s *model.FeedSpec) { s.Feed.SiteURL = "/relative/path" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.SiteURL = "/relative/path" },
 			wantErr:     true,
 			errContains: []string{"feed.site_url"},
 		},
 		{
 			name:        "invalid site_url (no scheme)",
-			mutate:      func(s *model.FeedSpec) { s.Feed.SiteURL = "example.com" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.SiteURL = "example.com" },
 			wantErr:     true,
 			errContains: []string{"feed.site_url"},
 		},
 		{
 			name:        "invalid audio_url_template (relative)",
-			mutate:      func(s *model.FeedSpec) { s.Feed.AudioURLTemplate = "/ep-{episode_number}/{audio_file}" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.AudioURLTemplate = "/ep-{episode_number}/{audio_file}" },
 			wantErr:     true,
 			errContains: []string{"feed.audio_url_template"},
 		},
 		{
 			name:        "cover_image_url invalid when non-empty",
-			mutate:      func(s *model.FeedSpec) { s.Feed.CoverImageURL = "not-a-url" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.CoverImageURL = "not-a-url" },
 			wantErr:     true,
 			errContains: []string{"feed.cover_image_url"},
 		},
 		{
 			name:        "audio_url_template missing episode_number placeholder",
-			mutate:      func(s *model.FeedSpec) { s.Feed.AudioURLTemplate = "https://example.com/{audio_file}" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.AudioURLTemplate = "https://example.com/{audio_file}" },
 			wantErr:     true,
 			errContains: []string{"episode_number"},
 		},
 		{
 			name:        "audio_url_template missing audio_file placeholder",
-			mutate:      func(s *model.FeedSpec) { s.Feed.AudioURLTemplate = "https://example.com/{episode_number}" },
+			mutate:      func(s *feed.FeedSpec) { s.Feed.AudioURLTemplate = "https://example.com/{episode_number}" },
 			wantErr:     true,
 			errContains: []string{"audio_file"},
 		},
 		{
 			name: "multiple errors collected",
-			mutate: func(s *model.FeedSpec) {
+			mutate: func(s *feed.FeedSpec) {
 				s.Feed.Language = ""
 				s.Feed.Author = ""
 			},
@@ -255,7 +255,7 @@ func TestValidateFeedSpec(t *testing.T) {
 			if tt.mutate != nil {
 				tt.mutate(&spec)
 			}
-			err := model.ValidateFeedSpec(spec)
+			err := feed.ValidateFeedSpec(spec)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("ValidateFeedSpec: expected error, got nil")

--- a/internal/slack/message.go
+++ b/internal/slack/message.go
@@ -10,7 +10,7 @@ import (
 )
 
 // BuildHeader builds the initial comment text for the parent mp3 upload message.
-func BuildHeader(manifest model.Manifest, tmpl model.MessageTemplate) string {
+func BuildHeader(manifest model.Manifest, tmpl MessageTemplate) string {
 	s := tmpl.Header
 	s = replacePlaceholders(s, manifest)
 
@@ -26,7 +26,7 @@ func BuildHeader(manifest model.Manifest, tmpl model.MessageTemplate) string {
 }
 
 // BuildFallback builds the fallback plain text for thread reply notifications.
-func BuildFallback(manifest model.Manifest, tmpl model.MessageTemplate) string {
+func BuildFallback(manifest model.Manifest, tmpl MessageTemplate) string {
 	s := tmpl.Fallback
 	s = replacePlaceholders(s, manifest)
 	return strings.TrimSpace(s)
@@ -43,7 +43,7 @@ func BuildAudioTitle(manifest model.Manifest) string {
 
 // BuildThreadBlocks builds the Block Kit blocks and fallback text for the thread reply.
 // Returns nil blocks when both summary and corners are empty (thread should be skipped).
-func BuildThreadBlocks(manifest model.Manifest, tmpl model.MessageTemplate) ([]slackgo.Block, string) {
+func BuildThreadBlocks(manifest model.Manifest, tmpl MessageTemplate) ([]slackgo.Block, string) {
 	var blocks []slackgo.Block
 
 	if manifest.Summary != "" {
@@ -75,7 +75,7 @@ func BuildThreadBlocks(manifest model.Manifest, tmpl model.MessageTemplate) ([]s
 	return blocks, fallback
 }
 
-func buildCornerText(corner model.ManifestCorner, tmpl model.MessageTemplate) string {
+func buildCornerText(corner model.ManifestCorner, tmpl MessageTemplate) string {
 	articlesText := buildArticlesText(corner.Articles, tmpl.Article)
 
 	s := tmpl.Corner

--- a/internal/slack/message_test.go
+++ b/internal/slack/message_test.go
@@ -37,8 +37,8 @@ func makeManifest() model.Manifest {
 	}
 }
 
-func makeTemplate() model.MessageTemplate {
-	return model.MessageTemplate{
+func makeTemplate() slack.MessageTemplate {
+	return slack.MessageTemplate{
 		Header:   "🎙️ {title} 第{episode_number}回「{episode_title}」",
 		Fallback: "{title} 第{episode_number}回 を配信しました",
 		Summary:  "*今回のまとめ*\n{summary}",

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -50,11 +50,11 @@ func Run(opts Options, poster Poster) error {
 		return fmt.Errorf("audio file not found: %w", err)
 	}
 
-	spec, err := model.LoadSlackSpec(opts.SpecPath)
+	spec, err := LoadSlackSpec(opts.SpecPath)
 	if err != nil {
 		return fmt.Errorf("load slack spec: %w", err)
 	}
-	if err := model.ValidateSlackSpec(spec); err != nil {
+	if err := ValidateSlackSpec(spec); err != nil {
 		return fmt.Errorf("validate slack spec: %w", err)
 	}
 

--- a/internal/slack/spec.go
+++ b/internal/slack/spec.go
@@ -1,4 +1,4 @@
-package model
+package slack
 
 import (
 	"errors"

--- a/internal/slack/spec_test.go
+++ b/internal/slack/spec_test.go
@@ -1,9 +1,9 @@
-package model_test
+package slack_test
 
 import (
 	"testing"
 
-	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/slack"
 	"github.com/canpok1/vox-radio/internal/testutil"
 )
 
@@ -21,7 +21,7 @@ slack:
 func TestLoadSlackSpec_ValidYAML(t *testing.T) {
 	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(validSlackSpecYAML))
 
-	spec, err := model.LoadSlackSpec(path)
+	spec, err := slack.LoadSlackSpec(path)
 	if err != nil {
 		t.Fatalf("LoadSlackSpec: unexpected error: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestLoadSlackSpec_ValidYAML(t *testing.T) {
 }
 
 func TestLoadSlackSpec_MissingFile(t *testing.T) {
-	_, err := model.LoadSlackSpec("/nonexistent/slack-spec.yaml")
+	_, err := slack.LoadSlackSpec("/nonexistent/slack-spec.yaml")
 	if err == nil {
 		t.Error("expected error for missing file")
 	}
@@ -48,7 +48,7 @@ func TestLoadSlackSpecStrict_UnknownKeyErrors(t *testing.T) {
 	content := validSlackSpecYAML + "\nunknown_key: value\n"
 	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(content))
 
-	_, err := model.LoadSlackSpecStrict(path)
+	_, err := slack.LoadSlackSpecStrict(path)
 	if err == nil {
 		t.Error("expected error for unknown key in strict mode")
 	}
@@ -57,7 +57,7 @@ func TestLoadSlackSpecStrict_UnknownKeyErrors(t *testing.T) {
 func TestLoadSlackSpecStrict_ValidYAML_Success(t *testing.T) {
 	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(validSlackSpecYAML))
 
-	_, err := model.LoadSlackSpecStrict(path)
+	_, err := slack.LoadSlackSpecStrict(path)
 	if err != nil {
 		t.Errorf("unexpected error for valid spec in strict mode: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestLoadSlackSpecStrict_ProgramIDField_RaisesUnknownKey(t *testing.T) {
 	content := "program_id: my-radio\n" + validSlackSpecYAML
 	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(content))
 
-	_, err := model.LoadSlackSpecStrict(path)
+	_, err := slack.LoadSlackSpecStrict(path)
 	if err == nil {
 		t.Error("expected error for program_id (unknown key) in strict mode, got nil")
 	}
@@ -81,7 +81,7 @@ slack:
 `
 	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(content))
 
-	spec, err := model.LoadSlackSpec(path)
+	spec, err := slack.LoadSlackSpec(path)
 	if err != nil {
 		t.Fatalf("LoadSlackSpec: unexpected error: %v", err)
 	}
@@ -91,28 +91,28 @@ slack:
 }
 
 func TestValidateSlackSpec_ValidChannel(t *testing.T) {
-	spec := model.SlackSpec{
-		Slack: model.SlackChannelConfig{Channel: "C0123456789"},
+	spec := slack.SlackSpec{
+		Slack: slack.SlackChannelConfig{Channel: "C0123456789"},
 	}
-	if err := model.ValidateSlackSpec(spec); err != nil {
+	if err := slack.ValidateSlackSpec(spec); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
 func TestValidateSlackSpec_EmptyChannel_Error(t *testing.T) {
-	spec := model.SlackSpec{
-		Slack: model.SlackChannelConfig{Channel: ""},
+	spec := slack.SlackSpec{
+		Slack: slack.SlackChannelConfig{Channel: ""},
 	}
-	if err := model.ValidateSlackSpec(spec); err == nil {
+	if err := slack.ValidateSlackSpec(spec); err == nil {
 		t.Error("expected error for empty channel")
 	}
 }
 
 func TestSlackSpec_EffectiveMessageTemplate_UsesCustomWhenSet(t *testing.T) {
-	spec := model.SlackSpec{
-		Slack: model.SlackChannelConfig{
+	spec := slack.SlackSpec{
+		Slack: slack.SlackChannelConfig{
 			Channel: "C0123456789",
-			Message: model.MessageTemplate{
+			Message: slack.MessageTemplate{
 				Header:   "custom header",
 				Fallback: "custom fallback",
 				Summary:  "custom summary",
@@ -140,8 +140,8 @@ func TestSlackSpec_EffectiveMessageTemplate_UsesCustomWhenSet(t *testing.T) {
 }
 
 func TestSlackSpec_EffectiveMessageTemplate_FallsBackToDefault(t *testing.T) {
-	spec := model.SlackSpec{
-		Slack: model.SlackChannelConfig{Channel: "C0123456789"},
+	spec := slack.SlackSpec{
+		Slack: slack.SlackChannelConfig{Channel: "C0123456789"},
 	}
 	tmpl := spec.Slack.EffectiveMessageTemplate()
 	if tmpl.Header == "" {


### PR DESCRIPTION
関連タスク: [`internal/model` から feed-spec/slack-spec の型・Load・Validate を `internal/feed`/`internal/slack` へ移動](https://app.todoist.com/app/task/6gqvgMjgxJ4R4rx3)

## Summary

- `internal/model/feed_spec.go` → `internal/feed/spec.go` へ移動（テスト同伴）
- `internal/model/slack_spec.go` → `internal/slack/spec.go` へ移動（テスト同伴）
- 参照元（`feed.go`・`ingest.go`・`message.go`・`slack.go`・`feedgen.go`・`slackpost.go`・`init_test.go`）のインポートを更新
- `docs/architecture/architecture.md` §8 の T1（既知の違反）を削除

ADR-0056 方針「単一ドメイン専用の spec はそのドメインパッケージに置く」に従った機械的な移動。`model` の internal 依存がゼロになり、`go list ./internal/model | grep canpok1` の出力が空になることを確認済み。

## Test plan

- [x] `go build ./...` が通ること
- [x] `go test ./...` が全グリーン
- [x] `golangci-lint run` で指摘なし
- [x] `go list -f '{{join .Imports "\n"}}' ./internal/model | grep canpok1` の出力が空（model の internal 依存ゼロ）

---
🤖 Generated with [Claude Code](https://claude.ai/code)