### PR TITLE
refactor(pipeline): Assembler interface から assemble.Result 依存を除去

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -114,7 +114,6 @@ go list -f '{{.ImportPath}} => {{join .Imports " "}}' ./internal/... | grep canp
 |---|---|---|
 | `slack.Run` がパスを受け取り内部で `config.LoadConfig`・spec ロード・`os.Getenv` を実行 | §3 依存注入 | T2: slack.Run の依存注入化 |
 | `feed`（ingest.go）が SpecPath を受け取り内部で spec をロード | §3 依存注入 | T3: feed.Run の依存注入化 |
-| `pipeline.Assembler` interface が具象型 `*assemble.Result` を返す（pipeline → assemble 依存） | §2 オーケストレーション層・§4 interface | T4: Assembler interface の具象型除去 |
 | `Scripter.Generate` が副作用で `03_lines.json` を書き、pipeline が読み戻す暗黙契約（`cli/script.go` のファイル名リテラル直書き含む） | §4 戻り値契約・§5 パス定数 | T5: Generate の戻り値契約化 |
 | `manifest.Build` の引数が11個 | §7 params struct | T6: BuildParams 化 |
 | `internal/config/config.go` が970行 | §7 ファイル分割 | T7: 責務別ファイル分割 |

--- a/internal/cli/episodegen.go
+++ b/internal/cli/episodegen.go
@@ -26,6 +26,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// assemblerAdapter wraps *assemble.Assembler to satisfy pipeline.Assembler (which returns error only).
+type assemblerAdapter struct {
+	inner *assemble.Assembler
+}
+
+func (a *assemblerAdapter) Run(ctx context.Context, scr model.Script, clips model.ClipsMeta, clipsDir, outPath string) error {
+	_, err := a.inner.Run(ctx, scr, clips, clipsDir, outPath)
+	return err
+}
+
 func newEpisodegenCmd() *cobra.Command {
 	var outDir string
 	var specPath string
@@ -118,7 +128,7 @@ func newEpisodegenCmd() *cobra.Command {
 				Rundowner:         rundowner,
 				Scripter:          scripter,
 				Synther:           synth.New(engineURL, cfg, synth.WithLogger(logger)),
-				Assembler:         assemble.New(p.Assets, p.Program, assemble.WithLogger(logger), assemble.WithFFmpegWriter(logFile)),
+				Assembler:         &assemblerAdapter{inner: assemble.New(p.Assets, p.Program, assemble.WithLogger(logger), assemble.WithFFmpegWriter(logFile))},
 				ProgramSummarizer: programsummary.NewLLMProgramSummarizer(llmClient, prompts["summary"], stepTemp(cfg.LLM, "summary"), p.Program.EffectiveSummaryLength(), programsummary.WithLogger(logger)),
 				CornerSummarizer:  programsummary.NewLLMCornerSummarizer(llmClient, prompts["corner_summary"], stepTemp(cfg.LLM, "corner_summary"), programsummary.WithLogger(logger)),
 			}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/canpok1/vox-radio/internal/assemble"
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/manifest"
@@ -44,7 +43,7 @@ type Synther interface {
 
 // Assembler produces an MP3 episode from clips and a script.
 type Assembler interface {
-	Run(ctx context.Context, scr model.Script, clips model.ClipsMeta, clipsDir, outPath string) (*assemble.Result, error)
+	Run(ctx context.Context, scr model.Script, clips model.ClipsMeta, clipsDir, outPath string) error
 }
 
 // Options configures a single pipeline run.
@@ -114,7 +113,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		clips = &model.ClipsMeta{Clips: make([]model.ClipMeta, 0)}
 	}
 
-	if _, err := r.Assembler.Run(ctx, scr, *clips, fileio.ClipsDir(outDir), fileio.EpisodePath(outDir)); err != nil {
+	if err := r.Assembler.Run(ctx, scr, *clips, fileio.ClipsDir(outDir), fileio.EpisodePath(outDir)); err != nil {
 		return fmt.Errorf("assemble: %w", err)
 	}
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/canpok1/vox-radio/internal/assemble"
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
@@ -70,18 +69,17 @@ func (s *stubSynther) Run(_ context.Context, _ model.Script, outDir string) (*mo
 }
 
 type stubAssembler struct {
-	result           *assemble.Result
 	err              error
 	called           bool
 	capturedClipsDir string
 	capturedOutPath  string
 }
 
-func (s *stubAssembler) Run(_ context.Context, _ model.Script, _ model.ClipsMeta, clipsDir, outPath string) (*assemble.Result, error) {
+func (s *stubAssembler) Run(_ context.Context, _ model.Script, _ model.ClipsMeta, clipsDir, outPath string) error {
 	s.called = true
 	s.capturedClipsDir = clipsDir
 	s.capturedOutPath = outPath
-	return s.result, s.err
+	return s.err
 }
 
 type stubProgramSummarizer struct {
@@ -129,7 +127,7 @@ func defaultStubs() stubs {
 		rnd: &stubRundowner{rundown: model.Rundown{Corners: make([]model.RundownCorner, 0)}},
 		scr: &stubScripter{script: model.Script{Segments: make([]model.ScriptSegment, 0)}},
 		syn: &stubSynther{clips: &model.ClipsMeta{Clips: make([]model.ClipMeta, 0)}},
-		asm: &stubAssembler{result: &assemble.Result{}},
+		asm: &stubAssembler{},
 	}
 }
 


### PR DESCRIPTION
関連タスク: [`pipeline.Assembler` interface から `assemble.Result` 依存を除去](https://app.todoist.com/app/task/6gqvgP3CrX98hRPV)

## Summary

- `pipeline.Assembler.Run` の戻り値を `(*assemble.Result, error)` から `error` のみに変更し、`pipeline` パッケージが `internal/assemble` をインポートする唯一の原因を除去した
- 呼び出し箇所（`pipeline.go`）では結果が `_, err :=` で破棄されていたため、機能変更なし
- `cli/episodegen.go` に `assemblerAdapter` を追加し、`*assemble.Assembler`（戻り値あり）を新しいインターフェースにラップ
- `docs/architecture/architecture.md` §8 の既知違反リストから T4 行を削除

## 受け入れ条件の達成確認

- [x] `go list -f '{{join .Imports "\n"}}' ./internal/pipeline | grep internal/assemble` の出力が空
- [x] 既存テスト・e2e が green（`go test ./...` 全パス）
- [x] `docs/architecture/architecture.md` §8 から T4 行を削除

---
🤖 Generated with [Claude Code](https://claude.ai/code)