### PR TITLE
refactor(slack): slack.Run の依存注入化（パス受け取り・内部ロード・os.Getenv 廃止）

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -112,7 +112,6 @@ go list -f '{{.ImportPath}} => {{join .Imports " "}}' ./internal/... | grep canp
 
 | 違反 | 該当ルール | 対応タスク |
 |---|---|---|
-| `slack.Run` がパスを受け取り内部で `config.LoadConfig`・spec ロード・`os.Getenv` を実行 | §3 依存注入 | T2: slack.Run の依存注入化 |
 | `feed`（ingest.go）が SpecPath を受け取り内部で spec をロード | §3 依存注入 | T3: feed.Run の依存注入化 |
 | `Scripter.Generate` が副作用で `03_lines.json` を書き、pipeline が読み戻す暗黙契約（`cli/script.go` のファイル名リテラル直書き含む） | §4 戻り値契約・§5 パス定数 | T5: Generate の戻り値契約化 |
 | `manifest.Build` の引数が11個 | §7 params struct | T6: BuildParams 化 |

--- a/internal/cli/slackpost.go
+++ b/internal/cli/slackpost.go
@@ -2,7 +2,12 @@ package cli
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
+	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/fileio"
+	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/slack"
 	"github.com/spf13/cobra"
 )
@@ -32,13 +37,45 @@ Bot トークンは共通設定の slack.bot_token_env で指定した環境変�
   vox-radio slackpost --manifest output/manifest.json --spec config/slack-spec.yaml --dry-run
   vox-radio slackpost --manifest output/manifest.json --spec config/slack-spec.yaml --state /tmp/state.json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.LoadConfig(configPath(cmd))
+			if err != nil {
+				return fmt.Errorf("load config: %w", err)
+			}
+
+			token := os.Getenv(cfg.Slack.BotTokenEnv)
+			if token == "" && !dryRun {
+				return fmt.Errorf("bot token env var %q is not set", cfg.Slack.BotTokenEnv)
+			}
+
+			var manifest model.Manifest
+			if err := fileio.ReadJSON(manifestPath, &manifest); err != nil {
+				return fmt.Errorf("load manifest: %w", err)
+			}
+
+			audioPath := filepath.Join(filepath.Dir(manifestPath), manifest.AudioFile)
+
+			spec, err := slack.LoadSlackSpec(specPath)
+			if err != nil {
+				return fmt.Errorf("load slack spec: %w", err)
+			}
+			if err := slack.ValidateSlackSpec(spec); err != nil {
+				return fmt.Errorf("validate slack spec: %w", err)
+			}
+
+			resolvedStatePath := statePath
+			if resolvedStatePath == "" {
+				resolvedStatePath = slack.DefaultStatePath(manifestPath)
+			}
+
 			return slack.Run(slack.Options{
-				ConfigPath:   configPath(cmd),
-				ManifestPath: manifestPath,
-				SpecPath:     specPath,
-				StatePath:    statePath,
-				DryRun:       dryRun,
-				Out:          cmd.OutOrStdout(),
+				Manifest:  manifest,
+				AudioPath: audioPath,
+				Spec:      spec,
+				Token:     token,
+				APIURL:    cfg.Slack.EffectiveAPIURL(),
+				StatePath: resolvedStatePath,
+				DryRun:    dryRun,
+				Out:       cmd.OutOrStdout(),
 			}, nil)
 		},
 	}

--- a/internal/cli/slackpost.go
+++ b/internal/cli/slackpost.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/canpok1/vox-radio/internal/config"
-	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/slack"
 	"github.com/spf13/cobra"
@@ -47,8 +46,8 @@ Bot トークンは共通設定の slack.bot_token_env で指定した環境変�
 				return fmt.Errorf("bot token env var %q is not set", cfg.Slack.BotTokenEnv)
 			}
 
-			var manifest model.Manifest
-			if err := fileio.ReadJSON(manifestPath, &manifest); err != nil {
+			manifest, err := readJSON[model.Manifest](manifestPath)
+			if err != nil {
 				return fmt.Errorf("load manifest: %w", err)
 			}
 
@@ -62,9 +61,8 @@ Bot トークンは共通設定の slack.bot_token_env で指定した環境変�
 				return fmt.Errorf("validate slack spec: %w", err)
 			}
 
-			resolvedStatePath := statePath
-			if resolvedStatePath == "" {
-				resolvedStatePath = slack.DefaultStatePath(manifestPath)
+			if statePath == "" {
+				statePath = slack.DefaultStatePath(manifestPath)
 			}
 
 			return slack.Run(slack.Options{
@@ -73,7 +71,7 @@ Bot トークンは共通設定の slack.bot_token_env で指定した環境変�
 				Spec:      spec,
 				Token:     token,
 				APIURL:    cfg.Slack.EffectiveAPIURL(),
-				StatePath: resolvedStatePath,
+				StatePath: statePath,
 				DryRun:    dryRun,
 				Out:       cmd.OutOrStdout(),
 			}, nil)

--- a/internal/cli/slackpost_test.go
+++ b/internal/cli/slackpost_test.go
@@ -230,3 +230,22 @@ func TestSlackpost_StateFlagAccepted_DryRunNoStateFile(t *testing.T) {
 		t.Error("state file should not exist in dry-run mode even when --state is specified")
 	}
 }
+
+func TestSlackpost_EmptyBotToken_Error(t *testing.T) {
+	dir := t.TempDir()
+	manifestPath := writeManifestForTest(t, dir)
+	specPath := writeSlackSpecForTest(t, dir, "C0123456789")
+	configPath := writeConfigForSlackTest(t, dir)
+	// env var is NOT set
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"slackpost",
+		"--manifest", manifestPath,
+		"--spec", specPath,
+	})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error when bot token env var is not set")
+	}
+}

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -29,10 +29,6 @@ func Run(opts Options, poster Poster) error {
 		opts.Out = os.Stdout
 	}
 
-	if _, err := os.Stat(opts.AudioPath); err != nil {
-		return fmt.Errorf("audio file not found: %w", err)
-	}
-
 	tmpl := opts.Spec.Slack.EffectiveMessageTemplate()
 	header := BuildHeader(opts.Manifest, tmpl)
 	blocks, fallback := BuildThreadBlocks(opts.Manifest, tmpl)
@@ -46,6 +42,10 @@ func Run(opts Options, poster Poster) error {
 			_, _ = fmt.Fprintf(opts.Out, "thread blocks:\n%s\n", blocksJSON)
 		}
 		return nil
+	}
+
+	if _, err := os.Stat(opts.AudioPath); err != nil {
+		return fmt.Errorf("audio file not found: %w", err)
 	}
 
 	if poster == nil {

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -6,21 +6,20 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 
-	"github.com/canpok1/vox-radio/internal/config"
-	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
 // Options holds the inputs for Run.
 type Options struct {
-	ConfigPath   string
-	ManifestPath string
-	SpecPath     string
-	StatePath    string // optional: override state file path (default: derived from ManifestPath)
-	DryRun       bool
-	Out          io.Writer
+	Manifest  model.Manifest
+	AudioPath string
+	Spec      SlackSpec
+	Token     string
+	APIURL    string
+	StatePath string
+	DryRun    bool
+	Out       io.Writer
 }
 
 // Run executes the slackpost workflow.
@@ -30,41 +29,17 @@ func Run(opts Options, poster Poster) error {
 		opts.Out = os.Stdout
 	}
 
-	cfg, err := config.LoadConfig(opts.ConfigPath)
-	if err != nil {
-		return fmt.Errorf("load config: %w", err)
-	}
-
-	token := os.Getenv(cfg.Slack.BotTokenEnv)
-	if token == "" && !opts.DryRun {
-		return fmt.Errorf("bot token env var %q is not set", cfg.Slack.BotTokenEnv)
-	}
-
-	var manifest model.Manifest
-	if err := fileio.ReadJSON(opts.ManifestPath, &manifest); err != nil {
-		return fmt.Errorf("load manifest: %w", err)
-	}
-
-	audioPath := filepath.Join(filepath.Dir(opts.ManifestPath), manifest.AudioFile)
-	if _, err := os.Stat(audioPath); err != nil {
+	if _, err := os.Stat(opts.AudioPath); err != nil {
 		return fmt.Errorf("audio file not found: %w", err)
 	}
 
-	spec, err := LoadSlackSpec(opts.SpecPath)
-	if err != nil {
-		return fmt.Errorf("load slack spec: %w", err)
-	}
-	if err := ValidateSlackSpec(spec); err != nil {
-		return fmt.Errorf("validate slack spec: %w", err)
-	}
-
-	tmpl := spec.Slack.EffectiveMessageTemplate()
-	header := BuildHeader(manifest, tmpl)
-	blocks, fallback := BuildThreadBlocks(manifest, tmpl)
-	audioTitle := BuildAudioTitle(manifest)
+	tmpl := opts.Spec.Slack.EffectiveMessageTemplate()
+	header := BuildHeader(opts.Manifest, tmpl)
+	blocks, fallback := BuildThreadBlocks(opts.Manifest, tmpl)
+	audioTitle := BuildAudioTitle(opts.Manifest)
 
 	if opts.DryRun {
-		_, _ = fmt.Fprintf(opts.Out, "audio: %s\n", audioPath)
+		_, _ = fmt.Fprintf(opts.Out, "audio: %s\n", opts.AudioPath)
 		_, _ = fmt.Fprintf(opts.Out, "header: %s\n", header)
 		if len(blocks) > 0 {
 			blocksJSON, _ := json.MarshalIndent(blocks, "", "  ")
@@ -74,27 +49,23 @@ func Run(opts Options, poster Poster) error {
 	}
 
 	if poster == nil {
-		poster = NewPoster(token, cfg.Slack.EffectiveAPIURL())
+		poster = NewPoster(opts.Token, opts.APIURL)
 	}
 
 	ctx := context.Background()
-	channel := spec.Slack.Channel
-
+	channel := opts.Spec.Slack.Channel
 	statePath := opts.StatePath
-	if statePath == "" {
-		statePath = DefaultStatePath(opts.ManifestPath)
-	}
 
 	// Build a base state from the current manifest; update fields progressively as each
 	// phase completes and write a checkpoint so re-runs can resume from where they left off.
 	state := PostState{
-		AudioFile:     manifest.AudioFile,
-		EpisodeNumber: manifest.EpisodeNumber,
+		AudioFile:     opts.Manifest.AudioFile,
+		EpisodeNumber: opts.Manifest.EpisodeNumber,
 		Channel:       channel,
 	}
 	needUpload := true
 
-	if loaded, err := loadState(statePath); err == nil && loaded.Matches(manifest.AudioFile, manifest.EpisodeNumber) {
+	if loaded, err := loadState(statePath); err == nil && loaded.Matches(opts.Manifest.AudioFile, opts.Manifest.EpisodeNumber) {
 		if loaded.Replied {
 			writeResult(opts.Out, loaded.Channel, loaded.FileID, loaded.ThreadTS)
 			return nil
@@ -105,12 +76,13 @@ func Run(opts Options, poster Poster) error {
 		}
 	}
 
+	var err error
 	if needUpload {
 		state.FileID, err = poster.UploadAudio(ctx, UploadParams{
 			Channel:        channel,
-			FilePath:       audioPath,
+			FilePath:       opts.AudioPath,
 			Title:          audioTitle,
-			Filename:       manifest.AudioFile,
+			Filename:       opts.Manifest.AudioFile,
 			InitialComment: header,
 		})
 		if err != nil {

--- a/internal/slack/slack_test.go
+++ b/internal/slack/slack_test.go
@@ -111,7 +111,9 @@ func TestRun_MissingAudioFile_Error(t *testing.T) {
 		Manifest:  buildTestManifest(),
 		AudioPath: audioPath,
 		Spec:      buildTestSlackSpec(),
-		DryRun:    true,
+		Token:     "xoxb-test-token",
+		StatePath: filepath.Join(dir, "state.json"),
+		DryRun:    false,
 		Out:       os.Stdout,
 	}, nil)
 	if err == nil {

--- a/internal/slack/slack_test.go
+++ b/internal/slack/slack_test.go
@@ -10,50 +10,38 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/slack"
 )
 
-func writeTestManifest(t *testing.T, dir string) string {
-	t.Helper()
-	manifest := map[string]any{
-		"title":          "ずんだもんテックラジオ",
-		"episode_number": 42,
-		"episode_title":  "テストエピソード",
-		"summary":        "",
-		"audio_file":     "episode42.mp3",
-		"corners":        []any{},
+func buildTestManifest() model.Manifest {
+	return model.Manifest{
+		Title:         "ずんだもんテックラジオ",
+		EpisodeNumber: 42,
+		EpisodeTitle:  "テストエピソード",
+		Summary:       "",
+		AudioFile:     "episode42.mp3",
+		Corners:       []model.ManifestCorner{},
 	}
-	data, err := json.Marshal(manifest)
-	if err != nil {
-		t.Fatalf("marshal manifest: %v", err)
-	}
-	path := filepath.Join(dir, "manifest.json")
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
-	return path
 }
 
-// writeTestManifestWithSummary creates a manifest that generates non-empty thread blocks.
-func writeTestManifestWithSummary(t *testing.T, dir string) string {
-	t.Helper()
-	manifest := map[string]any{
-		"title":          "ずんだもんテックラジオ",
-		"episode_number": 42,
-		"episode_title":  "テストエピソード",
-		"summary":        "今回はLLMについてです。",
-		"audio_file":     "episode42.mp3",
-		"corners":        []any{},
+func buildTestManifestWithSummary() model.Manifest {
+	return model.Manifest{
+		Title:         "ずんだもんテックラジオ",
+		EpisodeNumber: 42,
+		EpisodeTitle:  "テストエピソード",
+		Summary:       "今回はLLMについてです。",
+		AudioFile:     "episode42.mp3",
+		Corners:       []model.ManifestCorner{},
 	}
-	data, err := json.Marshal(manifest)
-	if err != nil {
-		t.Fatalf("marshal manifest: %v", err)
+}
+
+func buildTestSlackSpec() slack.SlackSpec {
+	return slack.SlackSpec{
+		Slack: slack.SlackChannelConfig{
+			Channel: "C0123456789",
+		},
 	}
-	path := filepath.Join(dir, "manifest.json")
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
-	return path
 }
 
 func writeTestAudio(t *testing.T, dir string) {
@@ -64,64 +52,18 @@ func writeTestAudio(t *testing.T, dir string) {
 	}
 }
 
-func writeTestSlackSpec(t *testing.T, dir string) string {
-	t.Helper()
-	content := `
-slack:
-  channel: "C0123456789"
-`
-	path := filepath.Join(dir, "slack-spec.yaml")
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write slack-spec: %v", err)
-	}
-	return path
-}
-
-func writeTestConfig(t *testing.T, dir string, botTokenEnv string) string {
-	t.Helper()
-	content := `
-llm:
-  provider: openai
-  temperature: 0.7
-  max_retries: 3
-  steps:
-    write: { temperature: 0.8 }
-  openai:
-    base_url: https://example.com/
-    api_key_env: OPENAI_API_KEY
-    model: gpt-4
-
-voicevox:
-  url: http://localhost:50021
-
-characters: {}
-
-slack:
-  bot_token_env: ` + botTokenEnv + `
-`
-	path := filepath.Join(dir, "vox-radio.yaml")
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-		t.Fatalf("write config: %v", err)
-	}
-	return path
-}
-
 func TestRun_DryRun_OutputsAudioPathAndComment(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifest(t, dir)
 	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+	audioPath := filepath.Join(dir, "episode42.mp3")
 
 	var buf strings.Builder
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		DryRun:       true,
-		Out:          &buf,
+		Manifest:  buildTestManifest(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		DryRun:    true,
+		Out:       &buf,
 	}, nil)
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
@@ -135,12 +77,8 @@ func TestRun_DryRun_OutputsAudioPathAndComment(t *testing.T) {
 
 func TestRun_DryRun_NoAPICallMade(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifest(t, dir)
 	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+	audioPath := filepath.Join(dir, "episode42.mp3")
 
 	posterCalled := false
 	mock := &mockPoster{
@@ -151,11 +89,11 @@ func TestRun_DryRun_NoAPICallMade(t *testing.T) {
 	}
 
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		DryRun:       true,
-		Out:          os.Stdout,
+		Manifest:  buildTestManifest(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		DryRun:    true,
+		Out:       os.Stdout,
 	}, mock)
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
@@ -167,53 +105,24 @@ func TestRun_DryRun_NoAPICallMade(t *testing.T) {
 
 func TestRun_MissingAudioFile_Error(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifest(t, dir)
-	// audio file is NOT created
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+	audioPath := filepath.Join(dir, "nonexistent.mp3")
 
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		DryRun:       true,
-		Out:          os.Stdout,
+		Manifest:  buildTestManifest(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		DryRun:    true,
+		Out:       os.Stdout,
 	}, nil)
 	if err == nil {
 		t.Error("expected error when audio file is missing")
 	}
 }
 
-func TestRun_EmptyBotToken_Error(t *testing.T) {
-	dir := t.TempDir()
-	manifestPath := writeTestManifest(t, dir)
-	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "NONEXISTENT_SLACK_TOKEN_VAR")
-
-	// env var is not set
-	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		DryRun:       false,
-		Out:          os.Stdout,
-	}, nil)
-	if err == nil {
-		t.Error("expected error when bot token env var is not set")
-	}
-}
-
 func TestRun_PostMode_CallsUploadAndThread(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifest(t, dir)
 	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+	audioPath := filepath.Join(dir, "episode42.mp3")
 
 	uploadCalled := false
 	mock := &mockPoster{
@@ -225,11 +134,12 @@ func TestRun_PostMode_CallsUploadAndThread(t *testing.T) {
 
 	var buf strings.Builder
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		DryRun:       false,
-		Out:          &buf,
+		Manifest:  buildTestManifest(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		Token:     "xoxb-test-token",
+		DryRun:    false,
+		Out:       &buf,
 	}, mock)
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
@@ -246,29 +156,22 @@ func TestRun_PostMode_CallsUploadAndThread(t *testing.T) {
 
 func TestRun_PostMode_WithSummaryCallsThreadReply(t *testing.T) {
 	dir := t.TempDir()
+	writeTestAudio(t, dir)
+	audioPath := filepath.Join(dir, "episode42.mp3")
 
-	manifest := map[string]any{
-		"title":          "ずんだもんテックラジオ",
-		"episode_number": 42,
-		"episode_title":  "テストエピソード",
-		"summary":        "今回はLLMについてです。",
-		"audio_file":     "episode42.mp3",
-		"corners": []any{
-			map[string]any{
-				"title":    "コーナー1",
-				"summary":  "コーナーのまとめ",
-				"articles": []any{},
+	manifest := model.Manifest{
+		Title:         "ずんだもんテックラジオ",
+		EpisodeNumber: 42,
+		EpisodeTitle:  "テストエピソード",
+		Summary:       "今回はLLMについてです。",
+		AudioFile:     "episode42.mp3",
+		Corners: []model.ManifestCorner{
+			{
+				Title:   "コーナー1",
+				Summary: "コーナーのまとめ",
 			},
 		},
 	}
-	data, _ := json.Marshal(manifest)
-	manifestPath := filepath.Join(dir, "manifest.json")
-	_ = os.WriteFile(manifestPath, data, 0o644)
-	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
 
 	threadCalled := false
 	mock := &mockPoster{
@@ -285,11 +188,12 @@ func TestRun_PostMode_WithSummaryCallsThreadReply(t *testing.T) {
 	}
 
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		DryRun:       false,
-		Out:          os.Stdout,
+		Manifest:  manifest,
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		Token:     "xoxb-test-token",
+		DryRun:    false,
+		Out:       os.Stdout,
 	}, mock)
 	if err != nil {
 		t.Fatalf("Run failed: %v", err)
@@ -301,22 +205,17 @@ func TestRun_PostMode_WithSummaryCallsThreadReply(t *testing.T) {
 
 func TestRun_ResolveThreadTSFails_SavesStateAndReturnsError(t *testing.T) {
 	dir := t.TempDir()
+	audioPath := filepath.Join(dir, "ep1.mp3")
+	_ = os.WriteFile(audioPath, []byte("fake"), 0o644)
 
-	manifest := map[string]any{
-		"title":          "テスト",
-		"episode_number": 1,
-		"summary":        "まとめ",
-		"audio_file":     "ep1.mp3",
-		"corners":        []any{},
+	manifest := model.Manifest{
+		Title:         "テスト",
+		EpisodeNumber: 1,
+		Summary:       "まとめ",
+		AudioFile:     "ep1.mp3",
+		Corners:       []model.ManifestCorner{},
 	}
-	data, _ := json.Marshal(manifest)
-	manifestPath := filepath.Join(dir, "manifest.json")
-	_ = os.WriteFile(manifestPath, data, 0o644)
-	_ = os.WriteFile(filepath.Join(dir, "ep1.mp3"), []byte("fake"), 0o644)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+	statePath := filepath.Join(dir, "state.json")
 
 	mock := &mockPoster{
 		uploadAudioFn: func(_ context.Context, _ slack.UploadParams) (string, error) {
@@ -328,18 +227,18 @@ func TestRun_ResolveThreadTSFails_SavesStateAndReturnsError(t *testing.T) {
 	}
 
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		DryRun:       false,
-		Out:          os.Stdout,
+		Manifest:  manifest,
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		Token:     "xoxb-test-token",
+		StatePath: statePath,
+		DryRun:    false,
+		Out:       os.Stdout,
 	}, mock)
 	if err == nil {
 		t.Fatal("Run should return error when ResolveThreadTS fails")
 	}
 
-	// State file should exist with fileID saved for resume
-	statePath := slack.DefaultStatePath(manifestPath)
 	stateData, err2 := os.ReadFile(statePath)
 	if err2 != nil {
 		t.Fatalf("state file should exist after upload: %v", err2)
@@ -359,12 +258,9 @@ func TestRun_ResolveThreadTSFails_SavesStateAndReturnsError(t *testing.T) {
 // ① 正常系で replied:true まで進む
 func TestRun_StateFile_HappyPath_RepliedTrue(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifestWithSummary(t, dir)
 	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+	audioPath := filepath.Join(dir, "episode42.mp3")
+	statePath := filepath.Join(dir, "state.json")
 
 	mock := &mockPoster{
 		uploadAudioFn: func(_ context.Context, _ slack.UploadParams) (string, error) {
@@ -379,16 +275,17 @@ func TestRun_StateFile_HappyPath_RepliedTrue(t *testing.T) {
 	}
 
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		Out:          io.Discard,
+		Manifest:  buildTestManifestWithSummary(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		Token:     "xoxb-test-token",
+		StatePath: statePath,
+		Out:       io.Discard,
 	}, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	statePath := slack.DefaultStatePath(manifestPath)
 	stateData, err := os.ReadFile(statePath)
 	if err != nil {
 		t.Fatalf("state file should exist after successful run: %v", err)
@@ -405,12 +302,9 @@ func TestRun_StateFile_HappyPath_RepliedTrue(t *testing.T) {
 // ② ts タイムアウト後の再実行で再アップロードせず返信が投稿
 func TestRun_ResumeAfterTSTimeout_SkipsUploadAndPostsReply(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifestWithSummary(t, dir)
 	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+	audioPath := filepath.Join(dir, "episode42.mp3")
+	statePath := filepath.Join(dir, "state.json")
 
 	uploadCount := 0
 	resolveCount := 0
@@ -434,13 +328,16 @@ func TestRun_ResumeAfterTSTimeout_SkipsUploadAndPostsReply(t *testing.T) {
 		},
 	}
 
-	// First run: upload succeeds, ts resolution fails
-	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		Out:          io.Discard,
-	}, mock)
+	opts := slack.Options{
+		Manifest:  buildTestManifestWithSummary(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		Token:     "xoxb-test-token",
+		StatePath: statePath,
+		Out:       io.Discard,
+	}
+
+	err := slack.Run(opts, mock)
 	if err == nil {
 		t.Error("expected error on first run (ts timeout)")
 	}
@@ -451,13 +348,7 @@ func TestRun_ResumeAfterTSTimeout_SkipsUploadAndPostsReply(t *testing.T) {
 		t.Errorf("PostThreadReply should not be called on first run, got %d", threadCount)
 	}
 
-	// Second run: resume from state file, skip upload
-	err = slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		Out:          io.Discard,
-	}, mock)
+	err = slack.Run(opts, mock)
 	if err != nil {
 		t.Fatalf("expected no error on second run: %v", err)
 	}
@@ -472,15 +363,10 @@ func TestRun_ResumeAfterTSTimeout_SkipsUploadAndPostsReply(t *testing.T) {
 // ③ replied:true 状態での再実行が何も投稿しない
 func TestRun_SkipsAllWhenAlreadyReplied(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifestWithSummary(t, dir)
 	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
+	audioPath := filepath.Join(dir, "episode42.mp3")
+	statePath := filepath.Join(dir, "state.json")
 
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
-
-	// Write state file with replied=true
-	statePath := slack.DefaultStatePath(manifestPath)
 	stateJSON := `{"audio_file":"episode42.mp3","episode_number":42,"channel":"C0123456789","file_id":"FILE_OLD","thread_ts":"TS_OLD","replied":true}`
 	_ = os.WriteFile(statePath, []byte(stateJSON), 0o644)
 
@@ -499,10 +385,12 @@ func TestRun_SkipsAllWhenAlreadyReplied(t *testing.T) {
 
 	var buf strings.Builder
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		Out:          &buf,
+		Manifest:  buildTestManifestWithSummary(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		Token:     "xoxb-test-token",
+		StatePath: statePath,
+		Out:       &buf,
 	}, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -514,7 +402,6 @@ func TestRun_SkipsAllWhenAlreadyReplied(t *testing.T) {
 		t.Error("PostThreadReply should not be called when already replied")
 	}
 
-	// Output should contain the state values
 	out := buf.String()
 	if !strings.Contains(out, "FILE_OLD") {
 		t.Errorf("output should contain file_id from state, got: %q", out)
@@ -524,15 +411,10 @@ func TestRun_SkipsAllWhenAlreadyReplied(t *testing.T) {
 // ④ audio_file 不一致の古い状態を無視
 func TestRun_IgnoresStateMismatch(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifest(t, dir) // audio_file = "episode42.mp3"
 	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
+	audioPath := filepath.Join(dir, "episode42.mp3")
+	statePath := filepath.Join(dir, "state.json")
 
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
-
-	// Write state file with different audio_file
-	statePath := slack.DefaultStatePath(manifestPath)
 	stateJSON := `{"audio_file":"different-episode.mp3","file_id":"FILE_OLD","replied":false}`
 	_ = os.WriteFile(statePath, []byte(stateJSON), 0o644)
 
@@ -545,10 +427,12 @@ func TestRun_IgnoresStateMismatch(t *testing.T) {
 	}
 
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		Out:          io.Discard,
+		Manifest:  buildTestManifest(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		Token:     "xoxb-test-token",
+		StatePath: statePath,
+		Out:       io.Discard,
 	}, mock)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -561,38 +445,21 @@ func TestRun_IgnoresStateMismatch(t *testing.T) {
 // ⑤ episode_number が異なる場合は前の状態を無視して新規投稿
 func TestRun_IgnoresStateWithDifferentEpisodeNumber(t *testing.T) {
 	dir := t.TempDir()
+	audioPath := filepath.Join(dir, "episode.mp3")
+	_ = os.WriteFile(audioPath, []byte("fake mp3"), 0o644)
+	statePath := filepath.Join(dir, "state.json")
 
-	// manifest: episode_number=14, audio_file="episode.mp3"
-	manifest := map[string]any{
-		"title":          "ずんだもんテックラジオ",
-		"episode_number": 14,
-		"episode_title":  "エピソード14",
-		"summary":        "",
-		"audio_file":     "episode.mp3",
-		"corners":        []any{},
-	}
-	data, err := json.Marshal(manifest)
-	if err != nil {
-		t.Fatalf("marshal manifest: %v", err)
-	}
-	manifestPath := filepath.Join(dir, "manifest.json")
-	if err := os.WriteFile(manifestPath, data, 0o644); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "episode.mp3"), []byte("fake mp3"), 0o644); err != nil {
-		t.Fatalf("write audio: %v", err)
+	manifest := model.Manifest{
+		Title:         "ずんだもんテックラジオ",
+		EpisodeNumber: 14,
+		EpisodeTitle:  "エピソード14",
+		Summary:       "",
+		AudioFile:     "episode.mp3",
+		Corners:       []model.ManifestCorner{},
 	}
 
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
-
-	// state: episode_number=13（異なる）, replied=true, audio_file は同名
-	statePath := slack.DefaultStatePath(manifestPath)
 	stateJSON := `{"audio_file":"episode.mp3","episode_number":13,"channel":"C_OLD","file_id":"FILE_OLD","thread_ts":"TS_OLD","replied":true}`
-	if err := os.WriteFile(statePath, []byte(stateJSON), 0o644); err != nil {
-		t.Fatalf("write state: %v", err)
-	}
+	_ = os.WriteFile(statePath, []byte(stateJSON), 0o644)
 
 	uploadCalled := false
 	mock := &mockPoster{
@@ -604,10 +471,12 @@ func TestRun_IgnoresStateWithDifferentEpisodeNumber(t *testing.T) {
 
 	var buf strings.Builder
 	if err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		Out:          &buf,
+		Manifest:  manifest,
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		Token:     "xoxb-test-token",
+		StatePath: statePath,
+		Out:       &buf,
 	}, mock); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -623,25 +492,22 @@ func TestRun_IgnoresStateWithDifferentEpisodeNumber(t *testing.T) {
 // ⑥ dry-run で状態ファイル不介入
 func TestRun_DryRun_NoStateFile(t *testing.T) {
 	dir := t.TempDir()
-	manifestPath := writeTestManifest(t, dir)
 	writeTestAudio(t, dir)
-	specPath := writeTestSlackSpec(t, dir)
-	configPath := writeTestConfig(t, dir, "TEST_SLACK_BOT_TOKEN")
-
-	t.Setenv("TEST_SLACK_BOT_TOKEN", "xoxb-test-token")
+	audioPath := filepath.Join(dir, "episode42.mp3")
+	statePath := filepath.Join(dir, "state.json")
 
 	err := slack.Run(slack.Options{
-		ConfigPath:   configPath,
-		ManifestPath: manifestPath,
-		SpecPath:     specPath,
-		DryRun:       true,
-		Out:          io.Discard,
+		Manifest:  buildTestManifest(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		StatePath: statePath,
+		DryRun:    true,
+		Out:       io.Discard,
 	}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	statePath := slack.DefaultStatePath(manifestPath)
 	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
 		t.Error("state file should not exist after dry-run")
 	}

--- a/internal/slack/slack_test.go
+++ b/internal/slack/slack_test.go
@@ -103,6 +103,23 @@ func TestRun_DryRun_NoAPICallMade(t *testing.T) {
 	}
 }
 
+// dry-run は音声ファイルの存在チェックをスキップするため、ファイルがなくても成功する
+func TestRun_DryRun_SucceedsWithMissingAudioFile(t *testing.T) {
+	dir := t.TempDir()
+	audioPath := filepath.Join(dir, "nonexistent.mp3")
+
+	err := slack.Run(slack.Options{
+		Manifest:  buildTestManifest(),
+		AudioPath: audioPath,
+		Spec:      buildTestSlackSpec(),
+		DryRun:    true,
+		Out:       io.Discard,
+	}, nil)
+	if err != nil {
+		t.Errorf("dry-run should succeed even when audio file is missing, got: %v", err)
+	}
+}
+
 func TestRun_MissingAudioFile_Error(t *testing.T) {
 	dir := t.TempDir()
 	audioPath := filepath.Join(dir, "nonexistent.mp3")


### PR DESCRIPTION
関連タスク: [`slack.Run` の依存注入化（パス受け取り・内部ロード・os.Getenv 廃止）](https://app.todoist.com/app/task/6gqvgMq4M4X7Q2VV)

## 変更概要

`internal/slack/slack.go` の `Run()` が担っていたロード・解決処理を CLI 層へ移動し、依存注入方式へ統一する。

- `slack.Options` のフィールドをパス指定から解決済み値に変更
  - `ManifestPath string` → `Manifest model.Manifest`
  - `AudioPath` は `filepath.Dir(manifestPath) + manifest.AudioFile` として CLI 層で解決
  - `SpecPath string` → `Spec SlackSpec`
  - `Token string`・`APIURL string` は CLI 層の `os.Getenv` / `cfg.Slack.EffectiveAPIURL()` で解決
- `slack.Run` 内から `config.LoadConfig`・`os.Getenv`・`fileio.ReadJSON`・`LoadSlackSpec`・`ValidateSlackSpec` を除去
- `internal/cli/slackpost.go` で上記ロード・検証を実施してから `slack.Run` へ注入
- `docs/architecture/architecture.md` §8 から T2 行を削除（違反解消）

## テスト

- `TestRun_EmptyBotToken_Error` を CLI 層 (`slackpost_test.go`) へ移動
- `TestRun_MissingAudioFile_Error` を `DryRun: false` で修正（os.Stat が dry-run 後に移動したため）
- `TestRun_DryRun_SucceedsWithMissingAudioFile` を追加（新仕様の明文化）
- dry-run / state 再開の既存テストはすべて green

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)