### PR TITLE
refactor(script): Scripter.Generate を (Script, ScriptLines, error) に変更し暗黙ファイル契約を解消

### DIFF
--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -113,7 +113,6 @@ go list -f '{{.ImportPath}} => {{join .Imports " "}}' ./internal/... | grep canp
 | 違反 | 該当ルール | 対応タスク |
 |---|---|---|
 | `feed`（ingest.go）が SpecPath を受け取り内部で spec をロード | §3 依存注入 | T3: feed.Run の依存注入化 |
-| `Scripter.Generate` が副作用で `03_lines.json` を書き、pipeline が読み戻す暗黙契約（`cli/script.go` のファイル名リテラル直書き含む） | §4 戻り値契約・§5 パス定数 | T5: Generate の戻り値契約化 |
 | `manifest.Build` の引数が11個 | §7 params struct | T6: BuildParams 化 |
 | `internal/config/config.go` が970行 | §7 ファイル分割 | T7: 責務別ファイル分割 |
 | `assemble/filter.go` の `buildRun()` 150行 / `collectRuns()` 100行 | §7 関数分割 | T8: フェーズ別ヘルパー抽出 |

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -174,13 +173,9 @@ func runScriptWrite(ctx context.Context, in, workDir string, c llm.Client, cfg *
 
 func runScriptDirect(ctx context.Context, workDir, out string, c llm.Client, llmCfg config.LLMConfig, prompts map[string]string, assetCatalog model.AssetCatalog) error {
 	linesPath := filepath.Join(workDir, fileio.FileLines)
-	data, err := os.ReadFile(linesPath)
+	scriptLines, err := readJSON[model.ScriptLines](linesPath)
 	if err != nil {
-		return fmt.Errorf("read %s: %w", fileio.FileLines, err)
-	}
-	var scriptLines model.ScriptLines
-	if err := json.Unmarshal(data, &scriptLines); err != nil {
-		return fmt.Errorf("parse %s: %w", fileio.FileLines, err)
+		return err
 	}
 
 	d := direct.NewLLMDirector(c, prompts["direct"], stepTemp(llmCfg, "direct"),

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -121,9 +121,14 @@ func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, c
 		script.WithLogger(logger),
 	)
 
-	scr, err := gen.Generate(ctx, p.Program, rd, corners, cfg.Characters)
+	scr, lines, err := gen.Generate(ctx, p.Program, rd, corners, cfg.Characters)
 	if err != nil {
 		return fmt.Errorf("generate: %w", err)
+	}
+
+	linesPath := filepath.Join(workDir, fileio.FileLines)
+	if err := writeJSON(linesPath, lines); err != nil {
+		return err
 	}
 
 	return writeJSON(out, scr)
@@ -159,7 +164,7 @@ func runScriptWrite(ctx context.Context, in, workDir string, c llm.Client, cfg *
 	}
 
 	scriptLines := model.ScriptLines{Direction: p.Program.Direction, Corners: script.BuildScriptLines(corners, allCornerLines)}
-	outPath := filepath.Join(workDir, "03_lines.json")
+	outPath := filepath.Join(workDir, fileio.FileLines)
 	if err := writeJSON(outPath, scriptLines); err != nil {
 		return err
 	}
@@ -168,14 +173,14 @@ func runScriptWrite(ctx context.Context, in, workDir string, c llm.Client, cfg *
 }
 
 func runScriptDirect(ctx context.Context, workDir, out string, c llm.Client, llmCfg config.LLMConfig, prompts map[string]string, assetCatalog model.AssetCatalog) error {
-	linesPath := filepath.Join(workDir, "03_lines.json")
+	linesPath := filepath.Join(workDir, fileio.FileLines)
 	data, err := os.ReadFile(linesPath)
 	if err != nil {
-		return fmt.Errorf("read 03_lines.json: %w", err)
+		return fmt.Errorf("read %s: %w", fileio.FileLines, err)
 	}
 	var scriptLines model.ScriptLines
 	if err := json.Unmarshal(data, &scriptLines); err != nil {
-		return fmt.Errorf("parse 03_lines.json: %w", err)
+		return fmt.Errorf("parse %s: %w", fileio.FileLines, err)
 	}
 
 	d := direct.NewLLMDirector(c, prompts["direct"], stepTemp(llmCfg, "direct"),

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -33,7 +33,7 @@ type Rundowner interface {
 
 // Scripter generates a radio script from a rundown.
 type Scripter interface {
-	Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error)
+	Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, error)
 }
 
 // Synther synthesizes voice clips from a script.
@@ -97,11 +97,14 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		chars = r.Config.Characters
 	}
 
-	scr, err := r.Scripter.Generate(ctx, r.Spec.Program, rundown, r.Spec.Corners, chars)
+	scr, scriptLines, err := r.Scripter.Generate(ctx, r.Spec.Program, rundown, r.Spec.Corners, chars)
 	if err != nil {
 		return fmt.Errorf("script: %w", err)
 	}
 	if err := fileio.WriteJSON(fileio.ScriptPath(outDir), scr); err != nil {
+		return err
+	}
+	if err := fileio.WriteJSON(fileio.LinesPath(outDir), scriptLines); err != nil {
 		return err
 	}
 
@@ -125,11 +128,6 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 	var programSummary model.ProgramSummary
 	var cornerSummaries map[string]model.CornerSummary
 	if r.ProgramSummarizer != nil || r.CornerSummarizer != nil {
-		var scriptLines model.ScriptLines
-		if err := fileio.ReadJSON(fileio.LinesPath(outDir), &scriptLines); err != nil {
-			return fmt.Errorf("read script lines for summarization: %w", err)
-		}
-
 		if r.ProgramSummarizer != nil {
 			programSummary, err = r.ProgramSummarizer.Summarize(ctx, scriptLines)
 			if err != nil {

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -44,15 +44,16 @@ func (s *stubRundowner) Run(_ context.Context, _ []config.CornerConfig, _ model.
 
 type stubScripter struct {
 	script     model.Script
+	lines      model.ScriptLines
 	err        error
 	called     bool
 	gotRundown model.Rundown
 }
 
-func (s *stubScripter) Generate(_ context.Context, _ config.ProgramConfig, rundown model.Rundown, _ []config.CornerConfig, _ map[string]config.CharacterConfig) (model.Script, error) {
+func (s *stubScripter) Generate(_ context.Context, _ config.ProgramConfig, rundown model.Rundown, _ []config.CornerConfig, _ map[string]config.CharacterConfig) (model.Script, model.ScriptLines, error) {
 	s.called = true
 	s.gotRundown = rundown
-	return s.script, s.err
+	return s.script, s.lines, s.err
 }
 
 type stubSynther struct {
@@ -183,7 +184,7 @@ func TestRunner_Run_SavesIntermediateFiles(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, path := range []string{fileio.ArticlesPath(outDir), fileio.RundownPath(outDir), fileio.ScriptPath(outDir), fileio.ManifestPath(outDir)} {
+	for _, path := range []string{fileio.ArticlesPath(outDir), fileio.RundownPath(outDir), fileio.ScriptPath(outDir), fileio.LinesPath(outDir), fileio.ManifestPath(outDir)} {
 		if _, err := os.Stat(path); err != nil {
 			t.Errorf("expected file %q to exist: %v", path, err)
 		}
@@ -304,9 +305,8 @@ func TestRunner_Run_AssembleError(t *testing.T) {
 func TestRunner_Run_CallsProgramSummarizer(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
+	s.scr.lines = model.ScriptLines{Corners: make([]model.CornerLines, 0)}
 	s.sum = &stubProgramSummarizer{summary: "今回は技術ニュースを紹介しました。"}
-
-	writeScriptLines(t, outDir, model.ScriptLines{Corners: []model.CornerLines{}})
 
 	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -321,9 +321,8 @@ func TestRunner_Run_ManifestIncludesSummary(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
 	wantSummary := "今回は技術ニュースを紹介しました。"
+	s.scr.lines = model.ScriptLines{Corners: make([]model.CornerLines, 0)}
 	s.sum = &stubProgramSummarizer{summary: wantSummary}
-
-	writeScriptLines(t, outDir, model.ScriptLines{Corners: []model.CornerLines{}})
 
 	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -356,32 +355,23 @@ func TestRunner_Run_SkipsSummaryWhenSummarizerIsNil(t *testing.T) {
 func TestRunner_Run_ProgramSummarizerError(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
+	s.scr.lines = model.ScriptLines{Corners: make([]model.CornerLines, 0)}
 	s.sum = &stubProgramSummarizer{err: errors.New("llm error")}
-
-	writeScriptLines(t, outDir, model.ScriptLines{Corners: []model.CornerLines{}})
 
 	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err == nil {
 		t.Fatal("expected error from ProgramSummarizer, got nil")
 	}
 }
 
-func writeScriptLines(t *testing.T, outDir string, sl model.ScriptLines) {
-	t.Helper()
-	if err := fileio.WriteJSON(fileio.LinesPath(outDir), sl); err != nil {
-		t.Fatalf("write script lines: %v", err)
-	}
-}
-
 func TestRunner_Run_CallsCornerSummarizer(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
-	s.csum = &stubCornerSummarizer{result: model.CornerSummary{Summary: "要約", Points: []string{"p1"}}}
-
-	writeScriptLines(t, outDir, model.ScriptLines{
+	s.scr.lines = model.ScriptLines{
 		Corners: []model.CornerLines{
 			{Title: "テストコーナー", Lines: []model.Line{{Text: "テスト"}}},
 		},
-	})
+	}
+	s.csum = &stubCornerSummarizer{result: model.CornerSummary{Summary: "要約", Points: []string{"p1"}}}
 
 	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -395,13 +385,12 @@ func TestRunner_Run_CallsCornerSummarizer(t *testing.T) {
 func TestRunner_Run_ManifestIncludesCornerSummary(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
-	s.csum = &stubCornerSummarizer{result: model.CornerSummary{Summary: "コーナー要約テスト", Points: []string{"要点A"}}}
-
-	writeScriptLines(t, outDir, model.ScriptLines{
+	s.scr.lines = model.ScriptLines{
 		Corners: []model.CornerLines{
 			{Title: "テストコーナー", Lines: []model.Line{{Text: "テスト"}}},
 		},
-	})
+	}
+	s.csum = &stubCornerSummarizer{result: model.CornerSummary{Summary: "コーナー要約テスト", Points: []string{"要点A"}}}
 
 	r := newRunner(s)
 	r.Spec = &config.EpisodeSpec{
@@ -437,13 +426,12 @@ func TestRunner_Run_SkipsCornerSummaryWhenSummarizerIsNil(t *testing.T) {
 func TestRunner_Run_CornerSummarizerError(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
-	s.csum = &stubCornerSummarizer{err: errors.New("llm error")}
-
-	writeScriptLines(t, outDir, model.ScriptLines{
+	s.scr.lines = model.ScriptLines{
 		Corners: []model.CornerLines{
 			{Title: "コーナー", Lines: []model.Line{{Text: "テスト"}}},
 		},
-	})
+	}
+	s.csum = &stubCornerSummarizer{err: errors.New("llm error")}
 
 	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err == nil {
 		t.Fatal("expected error from CornerSummarizer, got nil")
@@ -495,14 +483,13 @@ func TestRunner_Run_NoCastsRundownHasEmptySlice(t *testing.T) {
 func TestRunner_Run_ManifestIncludesConversationNotes(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
+	s.scr.lines = model.ScriptLines{Corners: make([]model.CornerLines, 0)}
 	s.sum = &stubProgramSummarizer{
 		summary: "要約",
 		notes: []model.ConversationNote{
 			{Category: "近況", CharacterIDs: []string{"zundamon"}, Note: "カフェにハマっている"},
 		},
 	}
-
-	writeScriptLines(t, outDir, model.ScriptLines{Corners: []model.CornerLines{}})
 
 	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -20,7 +20,7 @@ import (
 const regenThreshold = 0.20
 
 type ScriptGenerator interface {
-	Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error)
+	Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, error)
 }
 
 type LLMScriptGenerator struct {
@@ -59,7 +59,7 @@ func NewLLMScriptGenerator(
 	return g
 }
 
-func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, error) {
+func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, error) {
 	start := time.Now()
 
 	cornerMap := rundown.CornerMap()
@@ -73,30 +73,28 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	g.logger.With("step", "script/write").Info("開始")
 	cornerLines, err := WriteAll(ctx, g.writer, program, corners, allAssignments, cornerMap, chars)
 	if err != nil {
-		return model.Script{}, err
+		return model.Script{}, model.ScriptLines{}, err
 	}
 	cornerLines = g.regenIfNeeded(ctx, program, cornerLines, corners, allAssignments, cornerMap, chars)
-	scriptLines := BuildScriptLines(corners, cornerLines)
-	if err := g.saveIntermediate(fileio.FileLines, model.ScriptLines{Direction: program.Direction, Corners: scriptLines}); err != nil {
-		return model.Script{}, err
-	}
+	builtLines := BuildScriptLines(corners, cornerLines)
+	scriptLines := model.ScriptLines{Direction: program.Direction, Corners: builtLines}
 
 	g.logger.With("step", "script/direct").Info("開始")
-	scr, pr, err := g.director.Direct(ctx, scriptLines, g.assetCatalog, program.Direction)
+	scr, pr, err := g.director.Direct(ctx, builtLines, g.assetCatalog, program.Direction)
 	if err != nil {
-		return model.Script{}, fmt.Errorf("direct: %w", err)
+		return model.Script{}, model.ScriptLines{}, fmt.Errorf("direct: %w", err)
 	}
 
 	if pr != nil {
 		if err := g.saveIntermediate(fileio.FileProofread, pr); err != nil {
-			return model.Script{}, err
+			return model.Script{}, model.ScriptLines{}, err
 		}
 		g.logger.With("step", "script/direct").Info("校正完了", "count", len(pr.Corrections))
 	}
 
 	g.logger.With("step", "script").Info(fmt.Sprintf("完了 (%dセグメント, %.1fs)", len(scr.Segments), time.Since(start).Seconds()))
 
-	return scr, nil
+	return scr, scriptLines, nil
 }
 
 // WriteAll writes lines for each corner in order, passing previously generated corners as context.

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -76,11 +76,10 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 		return model.Script{}, model.ScriptLines{}, err
 	}
 	cornerLines = g.regenIfNeeded(ctx, program, cornerLines, corners, allAssignments, cornerMap, chars)
-	builtLines := BuildScriptLines(corners, cornerLines)
-	scriptLines := model.ScriptLines{Direction: program.Direction, Corners: builtLines}
+	scriptLines := model.ScriptLines{Direction: program.Direction, Corners: BuildScriptLines(corners, cornerLines)}
 
 	g.logger.With("step", "script/direct").Info("開始")
-	scr, pr, err := g.director.Direct(ctx, builtLines, g.assetCatalog, program.Direction)
+	scr, pr, err := g.director.Direct(ctx, scriptLines.Corners, g.assetCatalog, program.Direction)
 	if err != nil {
 		return model.Script{}, model.ScriptLines{}, fmt.Errorf("direct: %w", err)
 	}

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -110,7 +110,7 @@ func TestLLMScriptGenerator_Generate_HappyPath(t *testing.T) {
 		"",
 	)
 
-	got, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, testCorners, testChars)
+	got, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, testCorners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestLLMScriptGenerator_Generate_WriteError(t *testing.T) {
 		"",
 	)
 
-	_, err := gen.Generate(context.Background(), config.ProgramConfig{}, corneredRundown("AIコーナー", model.RundownArticle{URL: "u"}), testCorners, testChars)
+	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, corneredRundown("AIコーナー", model.RundownArticle{URL: "u"}), testCorners, testChars)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -154,7 +154,7 @@ func TestLLMScriptGenerator_Generate_CharCountRegen(t *testing.T) {
 		"",
 	)
 
-	_, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -179,7 +179,7 @@ func TestLLMScriptGenerator_Generate_NoRegenWhenWithinThreshold(t *testing.T) {
 		"",
 	)
 
-	_, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestLLMScriptGenerator_Generate_EmptyRundown(t *testing.T) {
 		"",
 	)
 
-	got, err := gen.Generate(context.Background(), config.ProgramConfig{}, model.Rundown{Casts: make([]model.RundownCast, 0)}, testCorners, testChars)
+	got, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, model.Rundown{Casts: make([]model.RundownCast, 0)}, testCorners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -213,7 +213,7 @@ func TestLLMScriptGenerator_Generate_EmptyCorners(t *testing.T) {
 		"",
 	)
 
-	got, err := gen.Generate(context.Background(), config.ProgramConfig{}, corneredRundown("AIコーナー", model.RundownArticle{URL: "u"}), []config.CornerConfig{}, testChars)
+	got, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, corneredRundown("AIコーナー", model.RundownArticle{URL: "u"}), []config.CornerConfig{}, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestLLMScriptGenerator_Generate_NoRegenWhenAllCornersHaveZeroTarget(t *test
 		"",
 	)
 
-	_, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestLLMScriptGenerator_Generate_LogsProgress(t *testing.T) {
 
 	gen := script.NewLLMScriptGenerator(mw, md, model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)}, "", script.WithLogger(logger))
 
-	_, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -280,8 +280,7 @@ func TestLLMScriptGenerator_Generate_LogsProgress(t *testing.T) {
 	}
 }
 
-func TestLLMScriptGenerator_Generate_SavesLinesIntermediateFile(t *testing.T) {
-	workDir := t.TempDir()
+func TestLLMScriptGenerator_Generate_ReturnsScriptLines(t *testing.T) {
 	rundown := corneredRundown("AIコーナー",
 		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
 	)
@@ -291,16 +290,15 @@ func TestLLMScriptGenerator_Generate_SavesLinesIntermediateFile(t *testing.T) {
 		&mockWriter{lines: lines},
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		workDir,
+		"",
 	)
 
-	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, testCorners, testChars); err != nil {
+	_, sl, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, testCorners, testChars)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	path := filepath.Join(workDir, fileio.FileLines)
-	if _, err := os.Stat(path); err != nil {
-		t.Errorf("expected intermediate file %q to exist: %v", fileio.FileLines, err)
+	if len(sl.Corners) == 0 {
+		t.Error("expected non-empty Corners in returned ScriptLines")
 	}
 }
 
@@ -338,8 +336,7 @@ func TestBuildScriptLines(t *testing.T) {
 	}
 }
 
-func TestLLMScriptGenerator_Generate_LinesFileUsesCornerStructure(t *testing.T) {
-	workDir := t.TempDir()
+func TestLLMScriptGenerator_Generate_ReturnsCornerStructureInLines(t *testing.T) {
 	rundown := corneredRundown("AIコーナー",
 		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
 	)
@@ -352,22 +349,12 @@ func TestLLMScriptGenerator_Generate_LinesFileUsesCornerStructure(t *testing.T) 
 		&mockWriter{lines: lines},
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		workDir,
+		"",
 	)
 
-	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	path := filepath.Join(workDir, fileio.FileLines)
-	data, err := os.ReadFile(path)
+	_, sl, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
-		t.Fatalf("expected intermediate file to exist: %v", err)
-	}
-
-	var sl model.ScriptLines
-	if err := json.Unmarshal(data, &sl); err != nil {
-		t.Fatalf("03_lines.json must be ScriptLines structure: %v\nContent: %s", err, data)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(sl.Corners) != 1 {
 		t.Fatalf("ScriptLines.Corners: got %d, want 1", len(sl.Corners))
@@ -453,7 +440,7 @@ func TestLLMScriptGenerator_Generate_PassesPreviousCornersAccumulated(t *testing
 		"",
 	)
 
-	_, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -650,7 +637,7 @@ func TestGenerate_UsesEpisodeCastsForAssignments(t *testing.T) {
 		{Title: "AIコーナー", Cast: map[string]string{"guest_char": "特別ゲスト役"}, LengthSec: 15},
 	}
 
-	_, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -690,7 +677,7 @@ func TestGenerate_AbsentCastNotInAssignments(t *testing.T) {
 		{Title: "AIコーナー", Cast: map[string]string{"absent_char": "休演中"}, LengthSec: 15},
 	}
 
-	_, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -705,8 +692,7 @@ func TestGenerate_AbsentCastNotInAssignments(t *testing.T) {
 	}
 }
 
-func TestLLMScriptGenerator_Generate_ProgramDirectionPersistedInLinesFile(t *testing.T) {
-	workDir := t.TempDir()
+func TestLLMScriptGenerator_Generate_ProgramDirectionInReturnedLines(t *testing.T) {
 	rundown := corneredRundown("AIコーナー",
 		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
 	)
@@ -715,28 +701,17 @@ func TestLLMScriptGenerator_Generate_ProgramDirectionPersistedInLinesFile(t *tes
 	corners := []config.CornerConfig{
 		{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
 	}
-	md := &mockDirector{}
 	gen := script.NewLLMScriptGenerator(
 		&mockWriter{lines: lines},
-		md,
+		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		workDir,
+		"",
 	)
 
 	program := config.ProgramConfig{Direction: "番組全体の演出方針テスト"}
-	if _, err := gen.Generate(context.Background(), program, rundown, corners, testChars); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	path := filepath.Join(workDir, fileio.FileLines)
-	data, err := os.ReadFile(path)
+	_, sl, err := gen.Generate(context.Background(), program, rundown, corners, testChars)
 	if err != nil {
-		t.Fatalf("expected intermediate file to exist: %v", err)
-	}
-
-	var sl model.ScriptLines
-	if err := json.Unmarshal(data, &sl); err != nil {
-		t.Fatalf("03_lines.json must be valid ScriptLines: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if sl.Direction != "番組全体の演出方針テスト" {
 		t.Errorf("ScriptLines.Direction: got %q, want 番組全体の演出方針テスト", sl.Direction)
@@ -766,7 +741,7 @@ func TestGenerate_SavesProofreadIntermediate_WhenProofreadSucceeds(t *testing.T)
 		workDir,
 	)
 
-	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+	if _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -810,7 +785,7 @@ func TestGenerate_DoesNotSaveProofreadIntermediate_WhenProofreadDisabled(t *test
 		workDir,
 	)
 
-	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+	if _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -840,7 +815,7 @@ func TestGenerate_SavesProofreadIntermediate_EmptyCorrections(t *testing.T) {
 		workDir,
 	)
 
-	if _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+	if _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
関連タスク: [`Scripter.Generate` が `model.ScriptLines` を返す契約に変更し 03_lines.json の暗黙ファイル契約を解消](https://app.todoist.com/app/task/6gqvgMxqPwGRwjpV)

## 変更概要

`Scripter.Generate` の副作用で `03_lines.json` を書き、pipeline が ReadJSON で読み戻す暗黙のファイル契約（architecture.md §4 違反、T5）を解消する。

- `pipeline.Scripter.Generate` / `script.ScriptGenerator.Generate` の戻り値を `(model.Script, model.ScriptLines, error)` に変更
- `pipeline.Runner.Run`: `fileio.ReadJSON` 読み戻しを削除し、`Generate` 戻り値の `scriptLines` を直接利用
- `script.LLMScriptGenerator.Generate`: `saveIntermediate(fileio.FileLines, ...)` を削除し `scriptLines` を return
- `cli/script.go`: `runScriptFull` で lines を明示書き出し、`"03_lines.json"` リテラルを `fileio.FileLines` 定数に統一
- `docs/architecture/architecture.md` §8 から T5 行を削除

## スコープ外

- proofread (`05_proofread.json`) の副作用書き出しはデバッグ成果物のため対象外 → フォローアップタスク #6gr242RGVvwpGvXV

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)