### PR TITLE
feat(dedup): 記事の重複判定をURLから内容ベースDedupKeyへ移行（ADR-0058）

### DIFF
--- a/e2e/fake_llm.go
+++ b/e2e/fake_llm.go
@@ -31,7 +31,7 @@ var llmRoutes = []llmStepRoute{
 	{step: "corner_summary", header: "# [D] コーナー要約プロンプト"},
 }
 
-var urlInPromptRe = regexp.MustCompile(`"url":\s*"([^"]+)"`)
+var idInPromptRe = regexp.MustCompile(`"id":\s*"([^"]+)"`)
 
 // fakeLLM は OpenAI 互換 /chat/completions を模倣するモックサーバー。
 // レスポンスは各ステップの JSON Schema（クライアント側で検証される）に適合する固定値を返す。
@@ -104,22 +104,22 @@ func cannedResponse(step, prompt string) (string, error) {
 	case "summarize":
 		return `{"summary":"記事の一行要約です。","points":["要点1","要点2","要点3"]}`, nil
 	case "select":
-		// 候補記事の URL は fake feed の動的ポートを含むため、プロンプト本文から抽出して全件選択する。
-		matches := urlInPromptRe.FindAllStringSubmatch(prompt, -1)
+		// 候補記事の ID は DedupKey（sha256:...）のためプロンプト本文から抽出して全件選択する。
+		matches := idInPromptRe.FindAllStringSubmatch(prompt, -1)
 		if len(matches) == 0 {
-			return "", fmt.Errorf("select prompt contains no candidate urls")
+			return "", fmt.Errorf("select prompt contains no candidate ids")
 		}
-		urls := make([]string, 0, len(matches))
+		ids := make([]string, 0, len(matches))
 		seen := map[string]struct{}{}
 		for _, m := range matches {
 			if _, ok := seen[m[1]]; ok {
 				continue
 			}
 			seen[m[1]] = struct{}{}
-			urls = append(urls, m[1])
+			ids = append(ids, m[1])
 		}
 		b, _ := json.Marshal(map[string]any{
-			"selected_urls":    urls,
+			"selected_ids":     ids,
 			"selection_reason": "テスト用に候補記事を全件選択",
 		})
 		return string(b), nil

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -13,10 +13,11 @@ import (
 
 // ArticleEntry holds article data for a single episode history entry.
 type ArticleEntry struct {
-	Title   string   `json:"title"`
-	URL     string   `json:"url"`
-	Summary string   `json:"summary"`
-	Points  []string `json:"points"`
+	DedupKey string   `json:"dedup_key,omitempty"` // 重複判定キー（sha256:hex）。旧エントリでは空
+	Title    string   `json:"title"`
+	URL      string   `json:"url,omitempty"`
+	Summary  string   `json:"summary"`
+	Points   []string `json:"points"`
 }
 
 // CornerEntry holds corner data for a single episode history entry.
@@ -185,13 +186,15 @@ func Recent(entries []Entry, n int) []Entry {
 }
 
 // BuildEntryFromManifest constructs a cache Entry from a program ID, manifest, rundown, and media info.
-// Rundown data (summary, points) is merged into the manifest's article references by URL.
+// Rundown data (summary, points) is merged into the manifest's article references by DedupKey.
 // bytes and durationSec are from mediainfo (0 if not available).
 func BuildEntryFromManifest(programID string, m model.Manifest, rd model.Rundown, bytes int64, durationSec int) Entry {
-	rdArticleByURL := make(map[string]model.RundownArticle)
+	rdArticleByDedupKey := make(map[string]model.RundownArticle)
 	for _, c := range rd.Corners {
 		for _, a := range c.Articles {
-			rdArticleByURL[a.URL] = a
+			if a.DedupKey != "" {
+				rdArticleByDedupKey[a.DedupKey] = a
+			}
 		}
 	}
 
@@ -200,11 +203,12 @@ func BuildEntryFromManifest(programID string, m model.Manifest, rd model.Rundown
 		articles := make([]ArticleEntry, len(mc.Articles))
 		for j, ar := range mc.Articles {
 			ae := ArticleEntry{
-				Title:  ar.Title,
-				URL:    ar.URL,
-				Points: make([]string, 0),
+				DedupKey: ar.DedupKey,
+				Title:    ar.Title,
+				URL:      ar.URL,
+				Points:   make([]string, 0),
 			}
-			if rda, ok := rdArticleByURL[ar.URL]; ok {
+			if rda, ok := rdArticleByDedupKey[ar.DedupKey]; ok {
 				ae.Summary = rda.Summary
 				if rda.Points != nil {
 					ae.Points = rda.Points
@@ -336,6 +340,7 @@ func NextEpisodeNumber(entries []Entry) int {
 }
 
 // PastURLs extracts all unique article URLs from entries, in order.
+// Deprecated: Use PastDedupKeys for new code. PastURLs is kept for legacy cache entries.
 func PastURLs(entries []Entry) []string {
 	urls := make([]string, 0)
 	seen := make(map[string]bool)
@@ -350,4 +355,22 @@ func PastURLs(entries []Entry) []string {
 		}
 	}
 	return urls
+}
+
+// PastDedupKeys extracts all unique article DedupKeys from entries, in order.
+// Entries without a DedupKey (legacy) are skipped.
+func PastDedupKeys(entries []Entry) []string {
+	keys := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, e := range entries {
+		for _, corner := range e.Corners {
+			for _, a := range corner.Articles {
+				if a.DedupKey != "" && !seen[a.DedupKey] {
+					seen[a.DedupKey] = true
+					keys = append(keys, a.DedupKey)
+				}
+			}
+		}
+	}
+	return keys
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -318,6 +318,8 @@ func TestPastURLs_EmptyEntries(t *testing.T) {
 }
 
 func TestBuildEntryFromManifest_BasicMapping(t *testing.T) {
+	const key1 = "sha256:aaa1111111111111111111111111111111111111111111111111111111111111"
+	const key2 = "sha256:bbb2222222222222222222222222222222222222222222222222222222222222"
 	m := model.Manifest{
 		Title:    "テストエピソード",
 		Summary:  "全体要約",
@@ -326,8 +328,8 @@ func TestBuildEntryFromManifest_BasicMapping(t *testing.T) {
 			{
 				Title: "コーナーA",
 				Articles: []model.ArticleRef{
-					{Title: "記事1", URL: "https://example.com/1"},
-					{Title: "記事2", URL: "https://example.com/2"},
+					{DedupKey: key1, Title: "記事1", URL: "https://example.com/1"},
+					{DedupKey: key2, Title: "記事2", URL: "https://example.com/2"},
 				},
 			},
 		},
@@ -337,7 +339,7 @@ func TestBuildEntryFromManifest_BasicMapping(t *testing.T) {
 			{
 				Title: "コーナーA",
 				Articles: []model.RundownArticle{
-					{URL: "https://example.com/1", Title: "記事1", Summary: "記事1の要約", Points: []string{"ポイント1"}},
+					{DedupKey: key1, URL: "https://example.com/1", Title: "記事1", Summary: "記事1の要約", Points: []string{"ポイント1"}},
 				},
 			},
 		},
@@ -369,6 +371,9 @@ func TestBuildEntryFromManifest_BasicMapping(t *testing.T) {
 
 	// Article with rundown data should have summary and points merged
 	a1 := got.Corners[0].Articles[0]
+	if a1.DedupKey != key1 {
+		t.Errorf("Articles[0].DedupKey: got %q, want %q", a1.DedupKey, key1)
+	}
 	if a1.URL != "https://example.com/1" {
 		t.Errorf("Articles[0].URL: got %q, want %q", a1.URL, "https://example.com/1")
 	}
@@ -381,11 +386,14 @@ func TestBuildEntryFromManifest_BasicMapping(t *testing.T) {
 
 	// Article without rundown data should still be included, with empty summary/points
 	a2 := got.Corners[0].Articles[1]
+	if a2.DedupKey != key2 {
+		t.Errorf("Articles[1].DedupKey: got %q, want %q", a2.DedupKey, key2)
+	}
 	if a2.URL != "https://example.com/2" {
 		t.Errorf("Articles[1].URL: got %q, want %q", a2.URL, "https://example.com/2")
 	}
 	if a2.Summary != "" {
-		t.Errorf("Articles[1].Summary: expected empty for unknown URL, got %q", a2.Summary)
+		t.Errorf("Articles[1].Summary: expected empty for unknown DedupKey, got %q", a2.Summary)
 	}
 	if len(a2.Points) != 0 {
 		t.Errorf("Articles[1].Points: expected empty, got %v", a2.Points)
@@ -872,5 +880,69 @@ func TestBuildEntryFromManifest_CastsNeverNil(t *testing.T) {
 	}
 	if len(got.Casts) != 0 {
 		t.Errorf("BuildEntryFromManifest: Casts: got %d, want 0", len(got.Casts))
+	}
+}
+
+func TestPastDedupKeys_ExtractsAllKeys(t *testing.T) {
+	entries := []cache.Entry{
+		{Corners: []cache.CornerEntry{
+			{Articles: []cache.ArticleEntry{
+				{DedupKey: "sha256:aaa"},
+				{DedupKey: "sha256:bbb"},
+			}},
+		}},
+		{Corners: []cache.CornerEntry{
+			{Articles: []cache.ArticleEntry{
+				{DedupKey: "sha256:ccc"},
+			}},
+		}},
+	}
+	got := cache.PastDedupKeys(entries)
+	if len(got) != 3 {
+		t.Fatalf("PastDedupKeys: got %d keys, want 3", len(got))
+	}
+}
+
+func TestPastDedupKeys_DeduplicatesKeys(t *testing.T) {
+	entries := []cache.Entry{
+		{Corners: []cache.CornerEntry{
+			{Articles: []cache.ArticleEntry{{DedupKey: "sha256:aaa"}}},
+		}},
+		{Corners: []cache.CornerEntry{
+			{Articles: []cache.ArticleEntry{{DedupKey: "sha256:aaa"}}},
+		}},
+	}
+	got := cache.PastDedupKeys(entries)
+	if len(got) != 1 {
+		t.Fatalf("PastDedupKeys: got %d keys (expected dedup=1)", len(got))
+	}
+}
+
+func TestPastDedupKeys_SkipsEmptyKeys(t *testing.T) {
+	// 旧エントリで DedupKey が空の場合はスキップ
+	entries := []cache.Entry{
+		{Corners: []cache.CornerEntry{
+			{Articles: []cache.ArticleEntry{
+				{URL: "https://example.com/1"}, // DedupKey なし（旧エントリ）
+				{DedupKey: "sha256:aaa"},
+			}},
+		}},
+	}
+	got := cache.PastDedupKeys(entries)
+	if len(got) != 1 {
+		t.Fatalf("PastDedupKeys: got %d keys, want 1 (empty DedupKey skipped)", len(got))
+	}
+	if got[0] != "sha256:aaa" {
+		t.Errorf("PastDedupKeys: got %q, want sha256:aaa", got[0])
+	}
+}
+
+func TestPastDedupKeys_EmptyEntries(t *testing.T) {
+	got := cache.PastDedupKeys([]cache.Entry{})
+	if got == nil {
+		t.Error("PastDedupKeys: expected non-nil slice for empty entries")
+	}
+	if len(got) != 0 {
+		t.Errorf("PastDedupKeys: expected empty slice, got %d", len(got))
 	}
 }

--- a/internal/cli/episodegen.go
+++ b/internal/cli/episodegen.go
@@ -91,7 +91,7 @@ func newEpisodegenCmd() *cobra.Command {
 			}
 			cacheMgr := cache.New(programCachePath(p.Program.ID))
 			recent := cache.Recent(entries, cfg.Cache.EffectiveLLMContextEntries())
-			excludedURLs := cache.PastURLs(entries)
+			excludedDedupKeys := cache.PastDedupKeys(entries)
 			castAppearances := cache.CastAppearances(entries)
 			cornerAppearances := cache.CornerAppearances(entries)
 			writer.SetPastEpisodes(recent)
@@ -105,7 +105,7 @@ func newEpisodegenCmd() *cobra.Command {
 
 			collector := collect.New(nil, collect.WithLogger(logger), collect.WithLocation(loc), collect.WithSanitizePolicy(cfg.Security.PromptInjection))
 			summarizer := summarize.NewLLMSummarizer(llmClient, prompts["summarize"], stepTemp(cfg.LLM, "summarize"))
-			rundowner := rundown.NewLLMRundowner(selector, summarizer, flowDesigner, collector, excludedURLs, rundown.WithLogger(logger))
+			rundowner := rundown.NewLLMRundowner(selector, summarizer, flowDesigner, collector, excludedDedupKeys, rundown.WithLogger(logger))
 			rundowner.SetCornerAppearances(cornerAppearances)
 
 			scripter := script.NewLLMScriptGenerator(
@@ -124,7 +124,7 @@ func newEpisodegenCmd() *cobra.Command {
 				Spec:              p,
 				Config:            cfg,
 				Collector:         collector,
-				ExcludedURLs:      excludedURLs,
+				ExcludedDedupKeys: excludedDedupKeys,
 				Rundowner:         rundowner,
 				Scripter:          scripter,
 				Synther:           synth.New(engineURL, cfg, synth.WithLogger(logger)),

--- a/internal/cli/prompts/select.md
+++ b/internal/cli/prompts/select.md
@@ -21,7 +21,7 @@
 {{corner}}
 ```
 
-## 候補記事（タイトルと URL のみ）
+## 候補記事（id・タイトル・URL）
 
 ```json
 {{articles}}
@@ -33,21 +33,21 @@
 
 ```json
 {
-  "selected_urls": [
-    "https://example.com/article/1",
-    "https://example.com/article/2"
+  "selected_ids": [
+    "sha256:a1b2c3d4...",
+    "sha256:e5f6g7h8..."
   ],
   "selection_reason": "AIチップ性能向上の記事が最も注目度が高く、次にその普及課題の記事を選んだ。この2本でコーナーの趣旨を網羅できる"
 }
 ```
 
-- `selected_urls`: 番組で紹介する記事の URL を**紹介順**に並べてください
+- `selected_ids`: 番組で紹介する記事の `id` を**紹介順**に並べてください
 - `selection_reason`: なぜこの記事をこの順で選んだか・どんな意図か、自由文で記述してください
 
 ## 注意事項
 
 - コーナーの趣旨（`content`）と目標放送時間（`target_duration_seconds`）に合った記事を選んでください
-- 候補記事がない場合でも最低1件は選ぶようにしてください（候補にある URL のみを使用してください）
-- `selected_urls` に含める URL は必ず候補記事の中から選んでください
+- 候補記事がない場合でも最低1件は選ぶようにしてください（候補にある `id` のみを使用してください）
+- `selected_ids` に含める `id` は必ず候補記事の中から選んでください
 - `selection_reason` は記事の選び方の意図・根拠を記述してください（話の流れの詳細設計は不要）
 - 日本語で回答してください

--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -98,16 +98,16 @@ func (c *Collector) FetchFullText(ctx context.Context, url string) (string, erro
 }
 
 // RunAll collects articles per corner, skipping corners with no source.
-// excludedURLs is a list of URLs to skip when fetching from feeds (nil means no exclusion).
-func (c *Collector) RunAll(ctx context.Context, corners []config.CornerConfig, excludedURLs []string) (model.Articles, error) {
+// excludedDedupKeys is a list of DedupKeys to skip when fetching from feeds (nil means no exclusion).
+func (c *Collector) RunAll(ctx context.Context, corners []config.CornerConfig, excludedDedupKeys []string) (model.Articles, error) {
 	logger := c.logger.With("step", "collect")
 	start := time.Now()
 
 	var excluded map[string]struct{}
-	if len(excludedURLs) > 0 {
-		excluded = make(map[string]struct{}, len(excludedURLs))
-		for _, u := range excludedURLs {
-			excluded[u] = struct{}{}
+	if len(excludedDedupKeys) > 0 {
+		excluded = make(map[string]struct{}, len(excludedDedupKeys))
+		for _, k := range excludedDedupKeys {
+			excluded[k] = struct{}{}
 		}
 	}
 

--- a/internal/collect/collect_test.go
+++ b/internal/collect/collect_test.go
@@ -237,7 +237,7 @@ func TestCollector_Run_WarnOnEmptyFeed(t *testing.T) {
 
 func TestCollector_Run_ExcludesURLsAndFillsFromLater(t *testing.T) {
 	// feed.xml has 3 articles: article/1, article/2, article/3
-	// Exclude article/1; with maxItems=2 should return article/2 and article/3
+	// Exclude article/1 by DedupKey; with maxItems=2 should return article/2 and article/3
 	rssData := loadTestdata(t, "feed.xml")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/rss+xml")
@@ -245,13 +245,15 @@ func TestCollector_Run_ExcludesURLsAndFillsFromLater(t *testing.T) {
 	}))
 	defer server.Close()
 
+	feedURL := server.URL + "/feed.xml"
 	cfg := config.FeedsConfig{
 		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed.xml", MaxItems: 2},
+			{URL: feedURL, MaxItems: 2},
 		},
 	}
+	// article/1 has no GUID, so material = normalizeContent(title, body)
 	excluded := map[string]struct{}{
-		"https://example.com/article/1": {},
+		collect.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"): {},
 	}
 
 	c := collect.New(server.Client())
@@ -283,14 +285,15 @@ func TestCollector_Run_WarnWhenInsufficientNonExcludedArticles(t *testing.T) {
 	var buf strings.Builder
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
+	feedURL := server.URL + "/feed.xml"
 	cfg := config.FeedsConfig{
 		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed.xml", MaxItems: 3},
+			{URL: feedURL, MaxItems: 3},
 		},
 	}
 	excluded := map[string]struct{}{
-		"https://example.com/article/1": {},
-		"https://example.com/article/2": {},
+		collect.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"):  {},
+		collect.FeedDedupKey(feedURL, "", "オープンソース活動の活発化", "オープンソースプロジェクトへの参加者が増加している。"): {},
 	}
 
 	c := collect.New(server.Client(), collect.WithLogger(logger))
@@ -310,8 +313,8 @@ func TestCollector_Run_WarnWhenInsufficientNonExcludedArticles(t *testing.T) {
 	}
 }
 
-func TestCollector_Run_UnlimitedWithExcludedURLs(t *testing.T) {
-	// maxItems=0 means unlimited; exclude article/1; should return article/2 and article/3
+func TestCollector_Run_UnlimitedWithExcludedDedupKeys(t *testing.T) {
+	// maxItems=0 means unlimited; exclude article/1 by DedupKey; should return article/2 and article/3
 	rssData := loadTestdata(t, "feed.xml")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/rss+xml")
@@ -319,13 +322,14 @@ func TestCollector_Run_UnlimitedWithExcludedURLs(t *testing.T) {
 	}))
 	defer server.Close()
 
+	feedURL := server.URL + "/feed.xml"
 	cfg := config.FeedsConfig{
 		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed.xml", MaxItems: 0},
+			{URL: feedURL, MaxItems: 0},
 		},
 	}
 	excluded := map[string]struct{}{
-		"https://example.com/article/1": {},
+		collect.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"): {},
 	}
 
 	c := collect.New(server.Client())
@@ -412,8 +416,8 @@ func TestCollector_RunAll_CollectsPerCorner(t *testing.T) {
 	}
 }
 
-func TestCollector_RunAll_ExcludesURLsViaFeed(t *testing.T) {
-	// feed.xml has 3 articles; exclude article/1; maxItems=2 should return article/2 and article/3
+func TestCollector_RunAll_ExcludesDedupKeysViaFeed(t *testing.T) {
+	// feed.xml has 3 articles; exclude article/1 by DedupKey; maxItems=2 should return article/2 and article/3
 	rssData := loadTestdata(t, "feed.xml")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/rss+xml")
@@ -421,18 +425,21 @@ func TestCollector_RunAll_ExcludesURLsViaFeed(t *testing.T) {
 	}))
 	defer server.Close()
 
+	feedURL := server.URL + "/feed.xml"
 	corners := []config.CornerConfig{
 		{
 			Title: "ニュース",
 			Source: &config.SourceConfig{
-				Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 2}},
+				Feeds: []config.FeedEntry{{URL: feedURL, MaxItems: 2}},
 			},
 		},
 	}
-	excludedURLs := []string{"https://example.com/article/1"}
+	excludedDedupKeys := []string{
+		collect.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"),
+	}
 
 	c := collect.New(server.Client())
-	result, err := c.RunAll(context.Background(), corners, excludedURLs)
+	result, err := c.RunAll(context.Background(), corners, excludedDedupKeys)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -687,5 +694,96 @@ func TestCollector_Run_RSS_PublishedEmptyWhenNil(t *testing.T) {
 	art := result[2]
 	if art.Published != "" {
 		t.Errorf("Published should be empty when no pubDate, got %q", art.Published)
+	}
+}
+
+func TestCollector_Run_RSS_SetsDedupKey(t *testing.T) {
+	rssData := loadTestdata(t, "feed.xml")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write(rssData)
+	}))
+	defer server.Close()
+
+	feedURL := server.URL + "/feed.xml"
+	cfg := config.FeedsConfig{
+		Feeds: []config.FeedEntry{{URL: feedURL, MaxItems: 1}},
+	}
+
+	c := collect.New(server.Client())
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("no articles returned")
+	}
+	art := result[0]
+	if art.DedupKey == "" {
+		t.Error("DedupKey must not be empty for RSS article")
+	}
+	// DedupKey は sha256: プレフィックスを持つ
+	if len(art.DedupKey) != len("sha256:")+64 {
+		t.Errorf("DedupKey has unexpected length: %q", art.DedupKey)
+	}
+}
+
+func TestCollector_Run_Article_SetsDedupKey(t *testing.T) {
+	htmlData := loadTestdata(t, "article.html")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(htmlData)
+	}))
+	defer server.Close()
+
+	cfg := config.FeedsConfig{
+		Articles: []string{server.URL + "/article.html"},
+	}
+
+	c := collect.New(server.Client())
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("no articles returned")
+	}
+	art := result[0]
+	if art.DedupKey == "" {
+		t.Error("DedupKey must not be empty for HTML article")
+	}
+	if len(art.DedupKey) != len("sha256:")+64 {
+		t.Errorf("DedupKey has unexpected length: %q", art.DedupKey)
+	}
+}
+
+func TestCollector_Run_RSS_NamespaceIsolation(t *testing.T) {
+	// 2つのフィードで同じ内容の記事でも DedupKey は異なること（フィード間衝突回避）
+	rssData := loadTestdata(t, "feed.xml")
+	server1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write(rssData)
+	}))
+	defer server1.Close()
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write(rssData)
+	}))
+	defer server2.Close()
+
+	c := collect.New(server1.Client())
+	result1, err := c.Run(context.Background(), config.FeedsConfig{Feeds: []config.FeedEntry{{URL: server1.URL + "/feed.xml", MaxItems: 1}}}, nil)
+	if err != nil {
+		t.Fatalf("feed1: %v", err)
+	}
+	result2, err := c.Run(context.Background(), config.FeedsConfig{Feeds: []config.FeedEntry{{URL: server2.URL + "/feed.xml", MaxItems: 1}}}, nil)
+	if err != nil {
+		t.Fatalf("feed2: %v", err)
+	}
+	if len(result1) == 0 || len(result2) == 0 {
+		t.Fatal("no articles from one of the feeds")
+	}
+	if result1[0].DedupKey == result2[0].DedupKey {
+		t.Errorf("same content from different feed URLs must have different DedupKeys, both got %q", result1[0].DedupKey)
 	}
 }

--- a/internal/collect/dedupkey.go
+++ b/internal/collect/dedupkey.go
@@ -1,0 +1,44 @@
+package collect
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+var whitespaceRe = regexp.MustCompile(`\s+`)
+
+// dedupKey computes a content-based deduplication key for an article.
+// The key is "sha256:<hex>" where the hash is sha256(namespace + "\x00" + material).
+// namespace isolates the key domain (feed URL or page URL) to avoid cross-feed collisions.
+// material is the identifying content (guid or normalized text).
+func dedupKey(namespace, material string) string {
+	h := sha256.Sum256([]byte(namespace + "\x00" + material))
+	return "sha256:" + hex.EncodeToString(h[:])
+}
+
+// FeedDedupKey computes the DedupKey for a feed item.
+// Use guid as material when non-empty; fall back to NormalizeContent(title, body).
+// feedURL is the namespace (feed's source URL).
+func FeedDedupKey(feedURL, guid, title, body string) string {
+	material := guid
+	if material == "" {
+		material = normalizeContent(title, body)
+	}
+	return dedupKey(feedURL, material)
+}
+
+// HTMLDedupKey computes the DedupKey for an HTML article page.
+// pageURL is both the namespace and the stable identifier.
+func HTMLDedupKey(pageURL, title, body string) string {
+	return dedupKey(pageURL, normalizeContent(title, body))
+}
+
+// normalizeContent returns a canonical form of title+body for use as dedup material.
+// Leading/trailing whitespace is trimmed and runs of whitespace are collapsed to a single space.
+func normalizeContent(title, body string) string {
+	normTitle := whitespaceRe.ReplaceAllString(strings.TrimSpace(title), " ")
+	normBody := whitespaceRe.ReplaceAllString(strings.TrimSpace(body), " ")
+	return normTitle + "\n" + normBody
+}

--- a/internal/collect/dedupkey_test.go
+++ b/internal/collect/dedupkey_test.go
@@ -1,0 +1,84 @@
+package collect
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDedupKey_Format(t *testing.T) {
+	k := dedupKey("https://feed.example.com/rss", "guid-123")
+	if !strings.HasPrefix(k, "sha256:") {
+		t.Errorf("dedupKey must start with sha256:, got %q", k)
+	}
+	if len(k) != len("sha256:")+64 {
+		t.Errorf("dedupKey length: got %d, want %d", len(k), len("sha256:")+64)
+	}
+}
+
+func TestDedupKey_Deterministic(t *testing.T) {
+	k1 := dedupKey("https://feed.example.com/rss", "guid-123")
+	k2 := dedupKey("https://feed.example.com/rss", "guid-123")
+	if k1 != k2 {
+		t.Errorf("same inputs must produce same key: %q != %q", k1, k2)
+	}
+}
+
+func TestDedupKey_DifferentMaterial(t *testing.T) {
+	k1 := dedupKey("https://feed.example.com/rss", "guid-123")
+	k2 := dedupKey("https://feed.example.com/rss", "guid-456")
+	if k1 == k2 {
+		t.Errorf("different materials must produce different keys")
+	}
+}
+
+func TestDedupKey_NamespaceIsolation(t *testing.T) {
+	// 同じ material でも namespace が異なれば別のキーになる（フィード間のguid衝突を回避）
+	k1 := dedupKey("https://feed1.example.com/rss", "item-1")
+	k2 := dedupKey("https://feed2.example.com/rss", "item-1")
+	if k1 == k2 {
+		t.Errorf("same material with different namespace must produce different keys")
+	}
+}
+
+func TestNormalizeContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		body  string
+		want  string
+	}{
+		{
+			name:  "basic",
+			title: "タイトル",
+			body:  "本文",
+			want:  "タイトル\n本文",
+		},
+		{
+			name:  "trim whitespace",
+			title: "  タイトル  ",
+			body:  "  本文  ",
+			want:  "タイトル\n本文",
+		},
+		{
+			name:  "collapse whitespace",
+			title: "タイトル  スペース",
+			body:  "本文\t\tタブ",
+			want:  "タイトル スペース\n本文 タブ",
+		},
+		{
+			name:  "empty body",
+			title: "タイトル",
+			body:  "",
+			want:  "タイトル\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeContent(tt.title, tt.body)
+			if got != tt.want {
+				t.Errorf("normalizeContent(%q, %q) = %q, want %q", tt.title, tt.body, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/collect/html.go
+++ b/internal/collect/html.go
@@ -30,10 +30,13 @@ func (c *Collector) fetchArticle(ctx context.Context, rawURL string) (*model.Art
 		return nil, fmt.Errorf("parse HTML: %w", err)
 	}
 
+	title := findTitle(doc)
+	body := findBody(doc)
 	return &model.Article{
-		URL:   rawURL,
-		Title: findTitle(doc),
-		Body:  findBody(doc),
+		DedupKey: dedupKey(rawURL, normalizeContent(title, body)),
+		URL:      rawURL,
+		Title:    title,
+		Body:     body,
 	}, nil
 }
 

--- a/internal/collect/html.go
+++ b/internal/collect/html.go
@@ -33,7 +33,7 @@ func (c *Collector) fetchArticle(ctx context.Context, rawURL string) (*model.Art
 	title := findTitle(doc)
 	body := findBody(doc)
 	return &model.Article{
-		DedupKey: dedupKey(rawURL, normalizeContent(title, body)),
+		DedupKey: HTMLDedupKey(rawURL, title, body),
 		URL:      rawURL,
 		Title:    title,
 		Body:     body,

--- a/internal/collect/rss.go
+++ b/internal/collect/rss.go
@@ -24,17 +24,27 @@ func (c *Collector) fetchFeed(ctx context.Context, url string, maxItems int, exc
 
 	articles := make([]model.Article, 0, len(feed.Items))
 	for _, item := range feed.Items {
-		if _, skip := excluded[item.Link]; skip {
-			continue
-		}
 		body := item.Content
 		if body == "" {
 			body = item.Description
 		}
+		bodyText := extractTextFromHTML(body)
+
+		// GUID が非空なら識別材料として使い、空なら正規化本文にフォールバック
+		material := item.GUID
+		if material == "" {
+			material = normalizeContent(item.Title, bodyText)
+		}
+		key := dedupKey(url, material)
+
+		if _, skip := excluded[key]; skip {
+			continue
+		}
 		articles = append(articles, model.Article{
+			DedupKey:  key,
 			URL:       item.Link,
 			Title:     item.Title,
-			Body:      extractTextFromHTML(body),
+			Body:      bodyText,
 			Source:    source,
 			Author:    extractAuthor(item),
 			Published: extractPublished(item, c.loc),

--- a/internal/collect/rss.go
+++ b/internal/collect/rss.go
@@ -28,17 +28,21 @@ func (c *Collector) fetchFeed(ctx context.Context, url string, maxItems int, exc
 		if body == "" {
 			body = item.Description
 		}
-		bodyText := extractTextFromHTML(body)
 
-		// GUID が非空なら識別材料として使い、空なら正規化本文にフォールバック
-		material := item.GUID
-		if material == "" {
-			material = normalizeContent(item.Title, bodyText)
+		// GUID が非空なら DedupKey に bodyText 不要 → 除外チェック後まで HTML パースを遅延
+		var bodyText string
+		if item.GUID == "" {
+			bodyText = extractTextFromHTML(body)
 		}
-		key := dedupKey(url, material)
+		key := FeedDedupKey(url, item.GUID, item.Title, bodyText)
 
 		if _, skip := excluded[key]; skip {
 			continue
+		}
+
+		// GUID 非空で遅延した場合はここで HTML パース
+		if item.GUID != "" {
+			bodyText = extractTextFromHTML(body)
 		}
 		articles = append(articles, model.Article{
 			DedupKey:  key,

--- a/internal/eval/select_eval_test.go
+++ b/internal/eval/select_eval_test.go
@@ -15,7 +15,8 @@ import (
 
 // selectArticle mirrors the articleForPrompt passed to select.md.
 type selectArticle struct {
-	URL   string `json:"url"`
+	ID    string `json:"id"`
+	URL   string `json:"url,omitempty"`
 	Title string `json:"title"`
 }
 
@@ -32,9 +33,9 @@ type selectCase struct {
 // selectOutputSchema is the JSON schema for the select.md output.
 var selectOutputSchema = json.RawMessage(`{
   "type": "object",
-  "required": ["selected_urls", "selection_reason"],
+  "required": ["selected_ids", "selection_reason"],
   "properties": {
-    "selected_urls": {
+    "selected_ids": {
       "type": "array",
       "items": {"type": "string"},
       "minItems": 1
@@ -71,7 +72,7 @@ var selectJudgeSchema = json.RawMessage(`{
 
 // selectOutput mirrors the select.md output for mechanical verification.
 type selectOutput struct {
-	SelectedURLs    []string `json:"selected_urls"`
+	SelectedIDs     []string `json:"selected_ids"`
 	SelectionReason string   `json:"selection_reason"`
 }
 
@@ -149,16 +150,16 @@ func TestSelectEval(t *testing.T) {
 			if err := json.Unmarshal(raw, &output); err != nil {
 				return nil, fmt.Errorf("unmarshal select output for case %s: %w", c.Name, err)
 			}
-			candidateURLs := make(map[string]bool, len(ec.Articles))
+			candidateIDs := make(map[string]bool, len(ec.Articles))
 			for _, a := range ec.Articles {
-				candidateURLs[a.URL] = true
+				candidateIDs[a.ID] = true
 			}
-			if len(output.SelectedURLs) == 0 {
-				t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected_urls is empty (min 1 required)", c.Name)
+			if len(output.SelectedIDs) == 0 {
+				t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected_ids is empty (min 1 required)", c.Name)
 			}
-			for _, u := range output.SelectedURLs {
-				if !candidateURLs[u] {
-					t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected URL %q is not in candidate set", c.Name, u)
+			for _, id := range output.SelectedIDs {
+				if !candidateIDs[id] {
+					t.Errorf("*** CONSTRAINT VIOLATION *** [%s] selected ID %q is not in candidate set", c.Name, id)
 				}
 			}
 

--- a/internal/model/article.go
+++ b/internal/model/article.go
@@ -1,7 +1,8 @@
 package model
 
 type Article struct {
-	URL       string `json:"url"`
+	DedupKey  string `json:"dedup_key"`     // 重複判定キー（sha256:hex）。collect が設定する
+	URL       string `json:"url,omitempty"` // 表示用リンク（空可）
 	Title     string `json:"title"`
 	Body      string `json:"body"`
 	Source    string `json:"source,omitempty"`    // 媒体名（RSS feed.Title）

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -2,8 +2,9 @@ package model
 
 // ArticleRef is a reference to an article included in a manifest corner.
 type ArticleRef struct {
-	Title string `json:"title"`
-	URL   string `json:"url"`
+	DedupKey string `json:"dedup_key"` // 重複判定キー（sha256:hex）
+	Title    string `json:"title"`
+	URL      string `json:"url,omitempty"` // 表示用リンク（空可）
 }
 
 // CornerSummary holds the LLM-generated summary for a single corner.

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -60,8 +60,8 @@ func TestArticles_Fields(t *testing.T) {
 		t.Error("expected at least one article in corner")
 	}
 	a := ca.Articles[0]
-	if a.URL == "" {
-		t.Error("URL must not be empty")
+	if a.DedupKey == "" {
+		t.Error("DedupKey must not be empty")
 	}
 	if a.Title == "" {
 		t.Error("Title must not be empty")
@@ -318,8 +318,8 @@ func TestRundown_Fields(t *testing.T) {
 		t.Error("Articles must not be empty")
 	}
 	a := c.Articles[0]
-	if a.URL == "" {
-		t.Error("Article.URL must not be empty")
+	if a.DedupKey == "" {
+		t.Error("Article.DedupKey must not be empty")
 	}
 	if a.Title == "" {
 		t.Error("Article.Title must not be empty")

--- a/internal/model/rundown.go
+++ b/internal/model/rundown.go
@@ -1,7 +1,8 @@
 package model
 
 type RundownArticle struct {
-	URL       string   `json:"url"`
+	DedupKey  string   `json:"dedup_key"`     // 重複判定キー（sha256:hex）
+	URL       string   `json:"url,omitempty"` // 表示用リンク（空可）
 	Title     string   `json:"title"`
 	Summary   string   `json:"summary"`
 	Points    []string `json:"points"`

--- a/internal/model/testdata/articles.json
+++ b/internal/model/testdata/articles.json
@@ -4,11 +4,13 @@
       "corner_title": "今日のテックニュース",
       "articles": [
         {
+          "dedup_key": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
           "url": "https://example.com/article/1",
           "title": "AIチップの最新動向",
           "body": "新型AIチップが発表された。従来比2倍の性能を実現する。"
         },
         {
+          "dedup_key": "sha256:b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
           "url": "https://example.com/article/2",
           "title": "オープンソース活動の活発化",
           "body": "オープンソースプロジェクトへの参加者が増加している。"

--- a/internal/model/testdata/rundown.json
+++ b/internal/model/testdata/rundown.json
@@ -1,10 +1,12 @@
 {
   "corners": [
     {
+      "id": "tech-news",
       "title": "AIチップ特集",
       "flow": "新型AIチップの発表から性能比較、普及の課題まで順に紹介する",
       "articles": [
         {
+          "dedup_key": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
           "url": "https://example.com/article/1",
           "title": "新型AIチップ発表",
           "summary": "最新のAIチップが発表され、従来比2倍の性能を実現した",
@@ -17,10 +19,12 @@
       ]
     },
     {
+      "id": "oss",
       "title": "オープンソース動向",
       "flow": "参加者数の増加トレンドから企業の貢献状況まで解説する",
       "articles": [
         {
+          "dedup_key": "sha256:b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
           "url": "https://example.com/article/2",
           "title": "オープンソース参加者増加",
           "summary": "2025年のオープンソース活動が活発化し参加者数が増加した",
@@ -31,5 +35,6 @@
         }
       ]
     }
-  ]
+  ],
+  "casts": []
 }

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -23,7 +23,7 @@ type CornerSummarizer interface {
 
 // Collector gathers articles per corner from configured sources.
 type Collector interface {
-	RunAll(ctx context.Context, corners []config.CornerConfig, excludedURLs []string) (model.Articles, error)
+	RunAll(ctx context.Context, corners []config.CornerConfig, excludedDedupKeys []string) (model.Articles, error)
 }
 
 // Rundowner selects articles and designs the talk flow for each corner.
@@ -65,7 +65,7 @@ type Runner struct {
 	Assembler         Assembler
 	ProgramSummarizer ProgramSummarizer // optional; if nil, program summary is omitted from manifest
 	CornerSummarizer  CornerSummarizer  // optional; if nil, corner summaries are omitted from manifest
-	ExcludedURLs      []string          // URLs to exclude from feed collection (past-used articles)
+	ExcludedDedupKeys []string          // DedupKeys to exclude from feed collection (past-used articles)
 }
 
 // Run executes the full pipeline, writing intermediate files to <outDir>/intermediate/.
@@ -76,7 +76,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("create output dirs: %w", err)
 	}
 
-	articles, err := r.Collector.RunAll(ctx, r.Spec.Corners, r.ExcludedURLs)
+	articles, err := r.Collector.RunAll(ctx, r.Spec.Corners, r.ExcludedDedupKeys)
 	if err != nil {
 		return fmt.Errorf("collect: %w", err)
 	}

--- a/internal/rundown/rundown.go
+++ b/internal/rundown/rundown.go
@@ -37,7 +37,7 @@ type LLMRundowner struct {
 	summarizer        summarize.Summarizer
 	flowDesigner      flow.Designer
 	fetcher           ArticleFetcher
-	excludedURLs      map[string]struct{}
+	excludedDedupKeys map[string]struct{}
 	cornerAppearances map[string]cache.CornerAppearance
 	logger            *slog.Logger
 }
@@ -51,19 +51,19 @@ func (r *LLMRundowner) SetCornerAppearances(m map[string]cache.CornerAppearance)
 
 // NewLLMRundowner creates a LLMRundowner.
 // fetcher may be nil (skips full-text fetch).
-// excludedURLs is the set of article URLs to exclude before selection (nil = no exclusion).
-func NewLLMRundowner(selector sel.Selector, summarizer summarize.Summarizer, designer flow.Designer, fetcher ArticleFetcher, excludedURLs []string, opts ...Option) *LLMRundowner {
-	excluded := make(map[string]struct{}, len(excludedURLs))
-	for _, u := range excludedURLs {
-		excluded[u] = struct{}{}
+// excludedDedupKeys is the set of article DedupKeys to exclude before selection (nil = no exclusion).
+func NewLLMRundowner(selector sel.Selector, summarizer summarize.Summarizer, designer flow.Designer, fetcher ArticleFetcher, excludedDedupKeys []string, opts ...Option) *LLMRundowner {
+	excluded := make(map[string]struct{}, len(excludedDedupKeys))
+	for _, k := range excludedDedupKeys {
+		excluded[k] = struct{}{}
 	}
 	r := &LLMRundowner{
-		selector:     selector,
-		summarizer:   summarizer,
-		flowDesigner: designer,
-		fetcher:      fetcher,
-		excludedURLs: excluded,
-		logger:       slog.Default(),
+		selector:          selector,
+		summarizer:        summarizer,
+		flowDesigner:      designer,
+		fetcher:           fetcher,
+		excludedDedupKeys: excluded,
+		logger:            slog.Default(),
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -88,7 +88,7 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 
 		filtered := make([]model.Article, 0, len(cornerArticles))
 		for _, a := range cornerArticles {
-			if _, excluded := r.excludedURLs[a.URL]; !excluded {
+			if _, excluded := r.excludedDedupKeys[a.DedupKey]; !excluded {
 				filtered = append(filtered, a)
 			}
 		}
@@ -118,36 +118,38 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 			return model.Rundown{}, fmt.Errorf("select corner %q: %w", corner.Title, err)
 		}
 
-		// Build URL→Article index for fast lookup
-		articleByURL := make(map[string]model.Article, len(cornerArticles))
+		// Build DedupKey→Article index for fast lookup
+		articleByDedupKey := make(map[string]model.Article, len(cornerArticles))
 		for _, a := range cornerArticles {
-			articleByURL[a.URL] = a
+			articleByDedupKey[a.DedupKey] = a
 		}
 
-		rdArticles := make([]model.RundownArticle, 0, len(selected.SelectedURLs))
-		for _, url := range selected.SelectedURLs {
-			a, ok := articleByURL[url]
+		rdArticles := make([]model.RundownArticle, 0, len(selected.SelectedIDs))
+		for _, id := range selected.SelectedIDs {
+			a, ok := articleByDedupKey[id]
 			if !ok {
 				continue
 			}
-			if r.fetcher != nil {
-				if fullText, err := r.fetcher.FetchFullText(ctx, url); err != nil {
-					r.logger.Warn("full text fetch failed, using feed body", "url", url, "err", err)
+			fetchURL := a.URL
+			if r.fetcher != nil && fetchURL != "" {
+				if fullText, err := r.fetcher.FetchFullText(ctx, fetchURL); err != nil {
+					r.logger.Warn("full text fetch failed, using feed body", "url", fetchURL, "err", err)
 				} else if fullText == "" {
-					r.logger.Warn("full text fetch returned empty body, using feed body", "url", url)
+					r.logger.Warn("full text fetch returned empty body, using feed body", "url", fetchURL)
 				} else {
 					a.Body = fullText
 				}
 			}
 			sum, err := r.summarizer.Summarize(ctx, a)
 			if err != nil {
-				return model.Rundown{}, fmt.Errorf("summarize %q: %w", url, err)
+				return model.Rundown{}, fmt.Errorf("summarize %q: %w", id, err)
 			}
 			points := sum.Points
 			if points == nil {
 				points = make([]string, 0)
 			}
 			rdArticles = append(rdArticles, model.RundownArticle{
+				DedupKey:  a.DedupKey,
 				URL:       a.URL,
 				Title:     a.Title,
 				Summary:   sum.Summary,

--- a/internal/rundown/rundown_test.go
+++ b/internal/rundown/rundown_test.go
@@ -133,7 +133,7 @@ func defaultCorner(title string) config.CornerConfig {
 }
 
 func TestLLMRundowner_Run_BakesCornerAppearance(t *testing.T) {
-	ms := &mockSelector{result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "理由"}}
+	ms := &mockSelector{result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"}}
 	mfd := &mockFlowDesigner{flow: "flow"}
 	rd := newRundowner(ms, &mockSummarizer{}, nil, nil, mfd)
 	rd.SetCornerAppearances(map[string]cache.CornerAppearance{
@@ -146,7 +146,7 @@ func TestLLMRundowner_Run_BakesCornerAppearance(t *testing.T) {
 	}
 	articles := model.Articles{
 		Corners: []model.CornerArticles{
-			{CornerTitle: "テック", Articles: []model.Article{{URL: "u1", Title: "t", Body: "b"}}},
+			{CornerTitle: "テック", Articles: []model.Article{{DedupKey: "u1", URL: "u1", Title: "t", Body: "b"}}},
 			{CornerTitle: "オープニング", Articles: []model.Article{}},
 		},
 	}
@@ -175,7 +175,7 @@ func TestLLMRundowner_Run_BakesCornerAppearance(t *testing.T) {
 }
 
 func TestLLMRundowner_Run_PassesCornerAppearanceToSelector(t *testing.T) {
-	ms := &appearanceCapturingSelector{result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "理由"}}
+	ms := &appearanceCapturingSelector{result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"}}
 	mfd := &mockFlowDesigner{flow: "flow"}
 	rd := rundown.NewLLMRundowner(ms, &mockSummarizer{}, mfd, nil, nil)
 	rd.SetCornerAppearances(map[string]cache.CornerAppearance{
@@ -185,7 +185,7 @@ func TestLLMRundowner_Run_PassesCornerAppearanceToSelector(t *testing.T) {
 	corners := []config.CornerConfig{{ID: "tech", Title: "テック", Content: "内容", LengthSec: 60}}
 	articles := model.Articles{
 		Corners: []model.CornerArticles{
-			{CornerTitle: "テック", Articles: []model.Article{{URL: "u1", Title: "t", Body: "b"}}},
+			{CornerTitle: "テック", Articles: []model.Article{{DedupKey: "u1", URL: "u1", Title: "t", Body: "b"}}},
 		},
 	}
 
@@ -201,21 +201,21 @@ func TestLLMRundowner_Run_PassesCornerAppearanceToSelector(t *testing.T) {
 }
 
 func article(url string) model.Article {
-	return model.Article{URL: url, Title: "記事: " + url, Body: "本文"}
+	return model.Article{DedupKey: url, URL: url, Title: "記事: " + url, Body: "本文"}
 }
 
-func newRundowner(ms *mockSelector, msum *mockSummarizer, mf *mockFetcher, excludedURLs []string, mfd *mockFlowDesigner, opts ...rundown.Option) *rundown.LLMRundowner {
+func newRundowner(ms *mockSelector, msum *mockSummarizer, mf *mockFetcher, excludedDedupKeys []string, mfd *mockFlowDesigner, opts ...rundown.Option) *rundown.LLMRundowner {
 	var fetcher rundown.ArticleFetcher
 	if mf != nil {
 		fetcher = mf
 	}
-	return rundown.NewLLMRundowner(ms, msum, mfd, fetcher, excludedURLs, opts...)
+	return rundown.NewLLMRundowner(ms, msum, mfd, fetcher, excludedDedupKeys, opts...)
 }
 
 // --- tests ---
 
 func TestLLMRundowner_Run_EmptyArticles_SkipsSelection(t *testing.T) {
-	ms := &mockSelector{result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "理由"}}
+	ms := &mockSelector{result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"}}
 	mfd := &mockFlowDesigner{flow: "空コーナーの導入です"}
 	rd := newRundowner(ms, &mockSummarizer{}, nil, nil, mfd)
 
@@ -273,7 +273,7 @@ func TestLLMRundowner_Run_NoArticleCorner_FlowNotEmpty(t *testing.T) {
 func TestLLMRundowner_Run_SelectsAndSummarizes(t *testing.T) {
 	ms := &mockSelector{
 		result: sel.SelectResult{
-			SelectedURLs:    []string{"https://example.com/1"},
+			SelectedIDs:     []string{"https://example.com/1"},
 			SelectionReason: "AIチップ記事が最も関連性高い",
 		},
 	}
@@ -294,8 +294,8 @@ func TestLLMRundowner_Run_SelectsAndSummarizes(t *testing.T) {
 			{
 				CornerTitle: "テックニュース",
 				Articles: []model.Article{
-					{URL: "https://example.com/1", Title: "記事1", Body: "本文1"},
-					{URL: "https://example.com/2", Title: "記事2", Body: "本文2"},
+					{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "記事1", Body: "本文1"},
+					{DedupKey: "https://example.com/2", URL: "https://example.com/2", Title: "記事2", Body: "本文2"},
 				},
 			},
 		},
@@ -356,7 +356,7 @@ func TestLLMRundowner_Run_SelectorError(t *testing.T) {
 }
 
 func TestLLMRundowner_Run_SummarizerError(t *testing.T) {
-	ms := &mockSelector{result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "理由"}}
+	ms := &mockSelector{result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"}}
 	msum := &mockSummarizer{err: errors.New("sum error")}
 	mfd := &mockFlowDesigner{flow: "flow"}
 	rd := newRundowner(ms, msum, nil, nil, mfd)
@@ -376,7 +376,7 @@ func TestLLMRundowner_Run_SummarizerError(t *testing.T) {
 
 func TestLLMRundowner_Run_PreservesCornerOrder(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"},
 	}
 	mfd := &mockFlowDesigner{flow: "flow"}
 	rd := newRundowner(ms, &mockSummarizer{}, nil, nil, mfd)
@@ -386,7 +386,7 @@ func TestLLMRundowner_Run_PreservesCornerOrder(t *testing.T) {
 	for _, t := range cornerTitles {
 		cornerArticles = append(cornerArticles, model.CornerArticles{
 			CornerTitle: t,
-			Articles:    []model.Article{{URL: "u1", Title: "t", Body: "b"}},
+			Articles:    []model.Article{{DedupKey: "u1", URL: "u1", Title: "t", Body: "b"}},
 		})
 	}
 
@@ -429,9 +429,9 @@ func TestLLMRundowner_Run_ArticlesNotNilForEmptyCorner(t *testing.T) {
 	}
 }
 
-func TestLLMRundowner_Run_ExcludedURLsFilteredBeforeSelect(t *testing.T) {
+func TestLLMRundowner_Run_ExcludedDedupKeysFilteredBeforeSelect(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"https://example.com/2"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"https://example.com/2"}, SelectionReason: "理由"},
 	}
 	mfd := &mockFlowDesigner{flow: "flow"}
 	rd := newRundowner(ms, &mockSummarizer{}, nil, []string{"https://example.com/1"}, mfd)
@@ -441,8 +441,8 @@ func TestLLMRundowner_Run_ExcludedURLsFilteredBeforeSelect(t *testing.T) {
 			{
 				CornerTitle: "テック",
 				Articles: []model.Article{
-					{URL: "https://example.com/1", Title: "除外記事", Body: "body"},
-					{URL: "https://example.com/2", Title: "対象記事", Body: "body"},
+					{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "除外記事", Body: "body"},
+					{DedupKey: "https://example.com/2", URL: "https://example.com/2", Title: "対象記事", Body: "body"},
 				},
 			},
 		},
@@ -471,8 +471,8 @@ func TestLLMRundowner_Run_AllArticlesExcluded_EmptyCorner(t *testing.T) {
 			{
 				CornerTitle: "テック",
 				Articles: []model.Article{
-					{URL: "https://example.com/1", Title: "除外1", Body: "body"},
-					{URL: "https://example.com/2", Title: "除外2", Body: "body"},
+					{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "除外1", Body: "body"},
+					{DedupKey: "https://example.com/2", URL: "https://example.com/2", Title: "除外2", Body: "body"},
 				},
 			},
 		},
@@ -496,7 +496,7 @@ func TestLLMRundowner_Run_AllArticlesExcluded_EmptyCorner(t *testing.T) {
 
 func TestLLMRundowner_Run_FetcherSuccess_BodyReplaced(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"https://example.com/1"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"https://example.com/1"}, SelectionReason: "理由"},
 	}
 	msum := &mockSummarizer{}
 	mf := &mockFetcher{
@@ -512,7 +512,7 @@ func TestLLMRundowner_Run_FetcherSuccess_BodyReplaced(t *testing.T) {
 			{
 				CornerTitle: "テック",
 				Articles: []model.Article{
-					{URL: "https://example.com/1", Title: "記事1", Body: "スニペット"},
+					{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "記事1", Body: "スニペット"},
 				},
 			},
 		},
@@ -533,7 +533,7 @@ func TestLLMRundowner_Run_FetcherSuccess_BodyReplaced(t *testing.T) {
 
 func TestLLMRundowner_Run_FetcherFailure_FallbackToFeedBody(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"https://example.com/1"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"https://example.com/1"}, SelectionReason: "理由"},
 	}
 	msum := &mockSummarizer{}
 	mf := &mockFetcher{err: errors.New("connection refused")}
@@ -545,7 +545,7 @@ func TestLLMRundowner_Run_FetcherFailure_FallbackToFeedBody(t *testing.T) {
 			{
 				CornerTitle: "テック",
 				Articles: []model.Article{
-					{URL: "https://example.com/1", Title: "記事1", Body: "フィードスニペット"},
+					{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "記事1", Body: "フィードスニペット"},
 				},
 			},
 		},
@@ -563,7 +563,7 @@ func TestLLMRundowner_Run_FetcherFailure_FallbackToFeedBody(t *testing.T) {
 
 func TestLLMRundowner_Run_FetcherNil_SkipsFetch(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"https://example.com/1"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"https://example.com/1"}, SelectionReason: "理由"},
 	}
 	msum := &mockSummarizer{}
 	mfd := &mockFlowDesigner{flow: "flow"}
@@ -574,7 +574,7 @@ func TestLLMRundowner_Run_FetcherNil_SkipsFetch(t *testing.T) {
 			{
 				CornerTitle: "テック",
 				Articles: []model.Article{
-					{URL: "https://example.com/1", Title: "記事1", Body: "フィードボディ"},
+					{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "記事1", Body: "フィードボディ"},
 				},
 			},
 		},
@@ -596,7 +596,7 @@ func TestLLMRundowner_WithLogger_ExcludedArticlesLogFormat(t *testing.T) {
 	logger := slog.New(handler)
 
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"https://example.com/2"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"https://example.com/2"}, SelectionReason: "理由"},
 	}
 	mfd := &mockFlowDesigner{flow: "flow"}
 	rd := newRundowner(ms, &mockSummarizer{}, nil, []string{"https://example.com/1"}, mfd, rundown.WithLogger(logger))
@@ -606,8 +606,8 @@ func TestLLMRundowner_WithLogger_ExcludedArticlesLogFormat(t *testing.T) {
 			{
 				CornerTitle: "今日のテックニュース",
 				Articles: []model.Article{
-					{URL: "https://example.com/1", Title: "除外記事", Body: "body"},
-					{URL: "https://example.com/2", Title: "対象記事", Body: "body"},
+					{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "除外記事", Body: "body"},
+					{DedupKey: "https://example.com/2", URL: "https://example.com/2", Title: "対象記事", Body: "body"},
 				},
 			},
 		},
@@ -633,7 +633,7 @@ func TestLLMRundowner_WithLogger_ExcludedArticlesLogFormat(t *testing.T) {
 
 func TestLLMRundowner_Run_FetcherEmptyBody_FallbackToFeedBody(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"https://example.com/1"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"https://example.com/1"}, SelectionReason: "理由"},
 	}
 	msum := &mockSummarizer{}
 	mf := &mockFetcher{
@@ -649,7 +649,7 @@ func TestLLMRundowner_Run_FetcherEmptyBody_FallbackToFeedBody(t *testing.T) {
 			{
 				CornerTitle: "テック",
 				Articles: []model.Article{
-					{URL: "https://example.com/1", Title: "記事1", Body: "フィードスニペット"},
+					{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "記事1", Body: "フィードスニペット"},
 				},
 			},
 		},
@@ -667,7 +667,7 @@ func TestLLMRundowner_Run_FetcherEmptyBody_FallbackToFeedBody(t *testing.T) {
 
 func TestLLMRundowner_Run_FlowDesignerCalledForAllCorners(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"},
 	}
 	mfd := &mockFlowDesigner{flow: "generated flow"}
 	rd := newRundowner(ms, &mockSummarizer{}, nil, nil, mfd)
@@ -675,7 +675,7 @@ func TestLLMRundowner_Run_FlowDesignerCalledForAllCorners(t *testing.T) {
 	cornerTitles := []string{"オープニング", "テックニュース", "エンディング"}
 	cornerArticles := []model.CornerArticles{
 		{CornerTitle: "オープニング", Articles: []model.Article{}},
-		{CornerTitle: "テックニュース", Articles: []model.Article{{URL: "u1", Title: "t", Body: "b"}}},
+		{CornerTitle: "テックニュース", Articles: []model.Article{{DedupKey: "u1", URL: "u1", Title: "t", Body: "b"}}},
 		{CornerTitle: "エンディング", Articles: []model.Article{}},
 	}
 	var corners []config.CornerConfig
@@ -699,7 +699,7 @@ func TestLLMRundowner_Run_FlowDesignerCalledForAllCorners(t *testing.T) {
 
 func TestLLMRundowner_Run_PositionOpeningForFirstCorner(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"},
 	}
 
 	var capturedPositions []flow.Position
@@ -714,7 +714,7 @@ func TestLLMRundowner_Run_PositionOpeningForFirstCorner(t *testing.T) {
 	articles := model.Articles{
 		Corners: []model.CornerArticles{
 			{CornerTitle: "オープニング", Articles: []model.Article{}},
-			{CornerTitle: "テックニュース", Articles: []model.Article{{URL: "u1", Title: "t", Body: "b"}}},
+			{CornerTitle: "テックニュース", Articles: []model.Article{{DedupKey: "u1", URL: "u1", Title: "t", Body: "b"}}},
 			{CornerTitle: "エンディング", Articles: []model.Article{}},
 		},
 	}
@@ -739,7 +739,7 @@ func TestLLMRundowner_Run_PositionOpeningForFirstCorner(t *testing.T) {
 
 func TestLLMRundowner_Run_FlowDesignerReceivesRundownContext(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "選別理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "選別理由"},
 	}
 	msum := &mockSummarizer{
 		byURL: map[string]model.Summary{
@@ -753,7 +753,7 @@ func TestLLMRundowner_Run_FlowDesignerReceivesRundownContext(t *testing.T) {
 	corners := []config.CornerConfig{defaultCorner("テックニュース")}
 	articles := model.Articles{
 		Corners: []model.CornerArticles{
-			{CornerTitle: "テックニュース", Articles: []model.Article{{URL: "u1", Title: "t", Body: "b"}}},
+			{CornerTitle: "テックニュース", Articles: []model.Article{{DedupKey: "u1", URL: "u1", Title: "t", Body: "b"}}},
 		},
 	}
 
@@ -768,7 +768,7 @@ func TestLLMRundowner_Run_FlowDesignerReceivesRundownContext(t *testing.T) {
 
 func TestLLMRundowner_Run_FlowDesignerError(t *testing.T) {
 	ms := &mockSelector{
-		result: sel.SelectResult{SelectedURLs: []string{"u1"}, SelectionReason: "理由"},
+		result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"},
 	}
 	mfd := &mockFlowDesigner{err: errors.New("flow design error")}
 	rd := newRundowner(ms, &mockSummarizer{}, nil, nil, mfd)
@@ -776,7 +776,7 @@ func TestLLMRundowner_Run_FlowDesignerError(t *testing.T) {
 	corners := []config.CornerConfig{defaultCorner("テック")}
 	articles := model.Articles{
 		Corners: []model.CornerArticles{
-			{CornerTitle: "テック", Articles: []model.Article{{URL: "u1", Title: "t", Body: "b"}}},
+			{CornerTitle: "テック", Articles: []model.Article{{DedupKey: "u1", URL: "u1", Title: "t", Body: "b"}}},
 		},
 	}
 
@@ -812,7 +812,7 @@ func TestLLMRundowner_Run_CastsSetInRundown(t *testing.T) {
 func TestLLMRundowner_Run_PropagatesSourceAuthorPublished(t *testing.T) {
 	ms := &mockSelector{
 		result: sel.SelectResult{
-			SelectedURLs:    []string{"https://example.com/meta/1"},
+			SelectedIDs:     []string{"https://example.com/meta/1"},
 			SelectionReason: "出典テスト",
 		},
 	}
@@ -834,6 +834,7 @@ func TestLLMRundowner_Run_PropagatesSourceAuthorPublished(t *testing.T) {
 				CornerTitle: "テック",
 				Articles: []model.Article{
 					{
+						DedupKey:  "https://example.com/meta/1",
 						URL:       "https://example.com/meta/1",
 						Title:     "メタ記事",
 						Body:      "本文",

--- a/internal/rundown/select/select.go
+++ b/internal/rundown/select/select.go
@@ -14,9 +14,9 @@ import (
 
 var selectSchema = json.RawMessage(`{
   "type": "object",
-  "required": ["selected_urls", "selection_reason"],
+  "required": ["selected_ids", "selection_reason"],
   "properties": {
-    "selected_urls": {"type": "array", "items": {"type": "string"}, "minItems": 1},
+    "selected_ids": {"type": "array", "items": {"type": "string"}, "minItems": 1},
     "selection_reason": {"type": "string"}
   },
   "additionalProperties": false
@@ -24,7 +24,7 @@ var selectSchema = json.RawMessage(`{
 
 // SelectResult holds the output of a selection operation.
 type SelectResult struct {
-	SelectedURLs    []string
+	SelectedIDs     []string
 	SelectionReason string
 }
 
@@ -42,12 +42,13 @@ type CornerAppearanceSetter interface {
 
 // articleForPrompt is the subset of article data passed to the LLM (body excluded to save tokens).
 type articleForPrompt struct {
-	URL   string `json:"url"`
+	ID    string `json:"id"`            // DedupKey: 選別結果の id として返却される
+	URL   string `json:"url,omitempty"` // 表示用（空可）
 	Title string `json:"title"`
 }
 
 type selectResponse struct {
-	SelectedURLs    []string `json:"selected_urls"`
+	SelectedIDs     []string `json:"selected_ids"`
 	SelectionReason string   `json:"selection_reason"`
 }
 
@@ -89,7 +90,7 @@ func (s *LLMSelector) Select(ctx context.Context, corner config.CornerConfig, ar
 
 	aps := make([]articleForPrompt, len(articles))
 	for i, a := range articles {
-		aps[i] = articleForPrompt{URL: a.URL, Title: a.Title}
+		aps[i] = articleForPrompt{ID: a.DedupKey, URL: a.URL, Title: a.Title}
 	}
 	articlesJSON, err := json.Marshal(aps)
 	if err != nil {
@@ -121,9 +122,9 @@ func (s *LLMSelector) Select(ctx context.Context, corner config.CornerConfig, ar
 		return SelectResult{}, fmt.Errorf("unmarshal response: %w", err)
 	}
 
-	urls := resp.SelectedURLs
-	if urls == nil {
-		urls = make([]string, 0)
+	ids := resp.SelectedIDs
+	if ids == nil {
+		ids = make([]string, 0)
 	}
-	return SelectResult{SelectedURLs: urls, SelectionReason: resp.SelectionReason}, nil
+	return SelectResult{SelectedIDs: ids, SelectionReason: resp.SelectionReason}, nil
 }

--- a/internal/rundown/select/select_test.go
+++ b/internal/rundown/select/select_test.go
@@ -25,25 +25,25 @@ func (m *mockClient) Complete(_ context.Context, req llm.CompletionRequest) (jso
 
 func TestLLMSelector_Select_Success(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"AIチップ記事が最も関連性が高く、コーナーの趣旨に合致する"}`),
+		response: json.RawMessage(`{"selected_ids":["https://example.com/1"],"selection_reason":"AIチップ記事が最も関連性が高く、コーナーの趣旨に合致する"}`),
 	}
 	s := sel.NewLLMSelector(mc, "コーナー: {{corner}} 記事: {{articles}}", 0)
 
 	corner := config.CornerConfig{Title: "テックニュース", Content: "最新技術を紹介", LengthSec: 60}
 	articles := []model.Article{
-		{URL: "https://example.com/1", Title: "記事1", Body: "本文1"},
-		{URL: "https://example.com/2", Title: "記事2", Body: "本文2"},
+		{DedupKey: "https://example.com/1", URL: "https://example.com/1", Title: "記事1", Body: "本文1"},
+		{DedupKey: "https://example.com/2", URL: "https://example.com/2", Title: "記事2", Body: "本文2"},
 	}
 
 	got, err := s.Select(context.Background(), corner, articles)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(got.SelectedURLs) != 1 {
-		t.Errorf("SelectedURLs: got %d, want 1", len(got.SelectedURLs))
+	if len(got.SelectedIDs) != 1 {
+		t.Errorf("SelectedIDs: got %d, want 1", len(got.SelectedIDs))
 	}
-	if got.SelectedURLs[0] != "https://example.com/1" {
-		t.Errorf("SelectedURLs[0]: got %q, want %q", got.SelectedURLs[0], "https://example.com/1")
+	if got.SelectedIDs[0] != "https://example.com/1" {
+		t.Errorf("SelectedIDs[0]: got %q, want %q", got.SelectedIDs[0], "https://example.com/1")
 	}
 	if got.SelectionReason != "AIチップ記事が最も関連性が高く、コーナーの趣旨に合致する" {
 		t.Errorf("SelectionReason: got %q, want %q", got.SelectionReason, "AIチップ記事が最も関連性が高く、コーナーの趣旨に合致する")
@@ -52,7 +52,7 @@ func TestLLMSelector_Select_Success(t *testing.T) {
 
 func TestLLMSelector_Select_PromptContainsCornerAppearance(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),
+		response: json.RawMessage(`{"selected_ids":["https://example.com/1"],"selection_reason":"理由"}`),
 	}
 	s := sel.NewLLMSelector(mc, "コーナー: {{corner}}", 0)
 	s.SetCornerAppearance(4, 1) // 今回含め4回目・前回は第1回
@@ -74,7 +74,7 @@ func TestLLMSelector_Select_PromptContainsCornerAppearance(t *testing.T) {
 
 func TestLLMSelector_Select_NewCorner_OmitsLastEpisodeNumber(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),
+		response: json.RawMessage(`{"selected_ids":["https://example.com/1"],"selection_reason":"理由"}`),
 	}
 	s := sel.NewLLMSelector(mc, "コーナー: {{corner}}", 0)
 	s.SetCornerAppearance(1, 0) // 新コーナー（今回が初出）
@@ -93,7 +93,7 @@ func TestLLMSelector_Select_NewCorner_OmitsLastEpisodeNumber(t *testing.T) {
 
 func TestLLMSelector_Select_PromptContainsCornerAndArticles(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),
+		response: json.RawMessage(`{"selected_ids":["https://example.com/1"],"selection_reason":"理由"}`),
 	}
 	s := sel.NewLLMSelector(mc, "コーナー: {{corner}} 記事: {{articles}}", 0)
 
@@ -127,7 +127,7 @@ func TestLLMSelector_Select_LLMError(t *testing.T) {
 
 func TestLLMSelector_SetCasts_PromptContainsCastInfo(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),
+		response: json.RawMessage(`{"selected_ids":["https://example.com/1"],"selection_reason":"理由"}`),
 	}
 	s := sel.NewLLMSelector(mc, "キャスト: {{casts}} コーナー: {{corner}} 記事: {{articles}}", 0)
 	s.SetCasts([]model.RundownCast{
@@ -157,7 +157,7 @@ func TestLLMSelector_SetCasts_PromptContainsCastInfo(t *testing.T) {
 func TestLLMSelector_SetCasts_AppearanceCountIsConverted(t *testing.T) {
 	// appearance_count in prompt should be PastAppearanceCount() (new_count - 1), not the raw value
 	mc := &mockClient{
-		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),
+		response: json.RawMessage(`{"selected_ids":["https://example.com/1"],"selection_reason":"理由"}`),
 	}
 	s := sel.NewLLMSelector(mc, "{{casts}}", 0)
 	s.SetCasts([]model.RundownCast{
@@ -178,7 +178,7 @@ func TestLLMSelector_SetCasts_AppearanceCountIsConverted(t *testing.T) {
 
 func TestLLMSelector_NoCasts_PromptHasEmptyArray(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),
+		response: json.RawMessage(`{"selected_ids":["https://example.com/1"],"selection_reason":"理由"}`),
 	}
 	s := sel.NewLLMSelector(mc, "キャスト: {{casts}} コーナー: {{corner}} 記事: {{articles}}", 0)
 	// SetCasts not called
@@ -198,7 +198,7 @@ func TestLLMSelector_NoCasts_PromptHasEmptyArray(t *testing.T) {
 
 func TestLLMSelector_Select_PromptUsesSemanticFieldName(t *testing.T) {
 	mc := &mockClient{
-		response: json.RawMessage(`{"selected_urls":["https://example.com/1"],"selection_reason":"理由"}`),
+		response: json.RawMessage(`{"selected_ids":["https://example.com/1"],"selection_reason":"理由"}`),
 	}
 	s := sel.NewLLMSelector(mc, "コーナー: {{corner}} 記事: {{articles}}", 0)
 

--- a/internal/slack/message.go
+++ b/internal/slack/message.go
@@ -101,8 +101,25 @@ func buildArticlesText(articles []model.ArticleRef, articleTmpl string) string {
 	var parts []string
 	for _, a := range articles {
 		line := articleTmpl
+		if a.URL == "" {
+			// Remove Slack link wrappers "<{url}|...>" → inner text only
+			const open = "<{url}|"
+			for {
+				before, after, found := strings.Cut(line, open)
+				if !found {
+					break
+				}
+				inner, tail, ok := strings.Cut(after, ">")
+				if !ok {
+					break
+				}
+				line = before + inner + tail
+			}
+			line = strings.ReplaceAll(line, "{url}", "")
+		} else {
+			line = strings.ReplaceAll(line, "{url}", a.URL)
+		}
 		line = strings.ReplaceAll(line, "{title}", a.Title)
-		line = strings.ReplaceAll(line, "{url}", a.URL)
 		parts = append(parts, line)
 	}
 	return strings.Join(parts, "\n")

--- a/internal/slack/message_test.go
+++ b/internal/slack/message_test.go
@@ -219,3 +219,34 @@ func TestBuildAudioTitle_WithoutEpisodeTitle(t *testing.T) {
 		t.Errorf("BuildAudioTitle = %q, want title %q", title, manifest.Title)
 	}
 }
+
+func TestBuildThreadBlocks_ArticleEmptyURL_NoSlackLinkSyntax(t *testing.T) {
+	manifest := makeManifest()
+	manifest.Summary = ""
+	manifest.Corners = []model.ManifestCorner{
+		{
+			Title: "テック",
+			Articles: []model.ArticleRef{
+				{Title: "URL無し記事", URL: ""},
+			},
+		},
+	}
+	tmpl := makeTemplate()
+
+	blocks, _ := slack.BuildThreadBlocks(manifest, tmpl)
+
+	if len(blocks) == 0 {
+		t.Fatal("blocks must not be empty")
+	}
+	section, ok := blocks[0].(*slackgo.SectionBlock)
+	if !ok {
+		t.Fatalf("blocks[0] should be SectionBlock, got %T", blocks[0])
+	}
+	text := section.Text.Text
+	if strings.Contains(text, "<|") {
+		t.Errorf("article with empty URL must not produce broken Slack link '<|...>', got: %q", text)
+	}
+	if !strings.Contains(text, "URL無し記事") {
+		t.Errorf("article title should appear in output even when URL is empty, got: %q", text)
+	}
+}


### PR DESCRIPTION
関連タスク: [記事の重複判定をURLから内容ベースの識別キー（DedupKey）へ分離する](https://app.todoist.com/app/task/6gr2QW3J4wPFjXXV)

## Summary

- `model.Article` / `RundownArticle` / `ArticleRef` に `DedupKey` フィールドを追加し、`URL` を表示専用（`omitempty`）に降格
- `internal/collect/dedupkey.go` を新設: `FeedDedupKey`（GUID優先・フォールバック本文ハッシュ）・`HTMLDedupKey`（本文ハッシュ）。`sha256:namespace\x00material` 方式でフィード間 GUID 衝突を回避
- `cache.ArticleEntry.DedupKey` 追加（`omitempty` で旧エントリ後方互換）・`PastDedupKeys` 実装
- `collect` / `rundown` / `pipeline` の除外判定・記事ルックアップを URL→DedupKey ベースへ全移行
- `rundown/select`: `articleForPrompt.URL → ID`（DedupKey）、`selected_urls → selected_ids`
- `prompts/select.md` の出力スキーマを `selected_ids` に更新
- `slack/message.go`: 空 URL 時に Slack リンク構文 `<{url}|text>` を `text` に縮退

## Test plan

- [x] `go test ./...` 全 PASS
- [x] `gofmt -l .` 差分なし
- [x] `golangci-lint run` 0 issues
- [x] `/simplify` 実施・対応済み（FeedDedupKey/HTMLDedupKey 統一・HTMLパース遅延最適化）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)