### PR TITLE
refactor(script): Generate の proofread 結果を戻り値に移し暗黙的 I/O を除去

### DIFF
--- a/internal/cli/episodegen.go
+++ b/internal/cli/episodegen.go
@@ -76,7 +76,6 @@ func newEpisodegenCmd() *cobra.Command {
 			}
 
 			assetCatalog := buildAssetCatalog(p.Assets)
-			intermediateDir := fileio.IntermediateDir(outDir)
 
 			selector := sel.NewLLMSelector(llmClient, prompts["select"], stepTemp(cfg.LLM, "select"))
 			flowDesigner := flow.NewLLMDesigner(llmClient, prompts["flow"], stepTemp(cfg.LLM, "flow"))
@@ -114,7 +113,6 @@ func newEpisodegenCmd() *cobra.Command {
 					direct.WithProofread(prompts["proofread"], stepTemp(cfg.LLM, "proofread")),
 				),
 				assetCatalog,
-				intermediateDir,
 				script.WithLogger(logger),
 			)
 

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -130,7 +130,7 @@ func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, c
 	}
 
 	if pr != nil {
-		if err := writeJSON(fileio.ProofreadPath(workDir), pr); err != nil {
+		if err := writeJSON(filepath.Join(workDir, fileio.FileProofread), pr); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -116,11 +116,10 @@ func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, c
 			direct.WithProofread(prompts["proofread"], stepTemp(cfg.LLM, "proofread")),
 		),
 		assetCatalog,
-		workDir,
 		script.WithLogger(logger),
 	)
 
-	scr, lines, err := gen.Generate(ctx, p.Program, rd, corners, cfg.Characters)
+	scr, lines, pr, err := gen.Generate(ctx, p.Program, rd, corners, cfg.Characters)
 	if err != nil {
 		return fmt.Errorf("generate: %w", err)
 	}
@@ -128,6 +127,12 @@ func runScriptFull(ctx context.Context, in, out, workDir string, c llm.Client, c
 	linesPath := filepath.Join(workDir, fileio.FileLines)
 	if err := writeJSON(linesPath, lines); err != nil {
 		return err
+	}
+
+	if pr != nil {
+		if err := writeJSON(fileio.ProofreadPath(workDir), pr); err != nil {
+			return err
+		}
 	}
 
 	return writeJSON(out, scr)

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -33,7 +33,7 @@ type Rundowner interface {
 
 // Scripter generates a radio script from a rundown.
 type Scripter interface {
-	Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, error)
+	Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, *model.ProofreadResult, error)
 }
 
 // Synther synthesizes voice clips from a script.
@@ -97,7 +97,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		chars = r.Config.Characters
 	}
 
-	scr, scriptLines, err := r.Scripter.Generate(ctx, r.Spec.Program, rundown, r.Spec.Corners, chars)
+	scr, scriptLines, pr, err := r.Scripter.Generate(ctx, r.Spec.Program, rundown, r.Spec.Corners, chars)
 	if err != nil {
 		return fmt.Errorf("script: %w", err)
 	}
@@ -106,6 +106,11 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 	}
 	if err := fileio.WriteJSON(fileio.LinesPath(outDir), scriptLines); err != nil {
 		return err
+	}
+	if pr != nil {
+		if err := fileio.WriteJSON(fileio.ProofreadPath(outDir), pr); err != nil {
+			return err
+		}
 	}
 
 	clips, err := r.Synther.Run(ctx, scr, fileio.ClipsDir(outDir))

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -45,6 +45,7 @@ func (s *stubRundowner) Run(_ context.Context, _ []config.CornerConfig, _ model.
 type stubScripter struct {
 	script     model.Script
 	lines      model.ScriptLines
+	proofread  *model.ProofreadResult
 	err        error
 	called     bool
 	gotRundown model.Rundown
@@ -53,7 +54,7 @@ type stubScripter struct {
 func (s *stubScripter) Generate(_ context.Context, _ config.ProgramConfig, rundown model.Rundown, _ []config.CornerConfig, _ map[string]config.CharacterConfig) (model.Script, model.ScriptLines, *model.ProofreadResult, error) {
 	s.called = true
 	s.gotRundown = rundown
-	return s.script, s.lines, nil, s.err
+	return s.script, s.lines, s.proofread, s.err
 }
 
 type stubSynther struct {
@@ -505,5 +506,37 @@ func TestRunner_Run_ManifestIncludesConversationNotes(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"conversation_notes"`) {
 		t.Errorf("manifest should contain conversation_notes field, got: %s", string(data))
+	}
+}
+
+func TestRunner_Run_WritesProofreadFile_WhenProofreadResultIsNotNil(t *testing.T) {
+	outDir := t.TempDir()
+	s := defaultStubs()
+	s.scr.proofread = &model.ProofreadResult{
+		Corrections: []model.ProofreadCorrection{
+			{CornerIndex: 0, LineIndex: 0, Before: "誤字", After: "正字"},
+		},
+	}
+
+	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(fileio.ProofreadPath(outDir)); err != nil {
+		t.Errorf("expected proofread file %q to exist: %v", fileio.ProofreadPath(outDir), err)
+	}
+}
+
+func TestRunner_Run_SkipsProofreadFile_WhenProofreadResultIsNil(t *testing.T) {
+	outDir := t.TempDir()
+	s := defaultStubs()
+	// s.scr.proofread is nil by default
+
+	if err := newRunner(s).Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(fileio.ProofreadPath(outDir)); err == nil {
+		t.Errorf("proofread file should not exist when ProofreadResult is nil, but found %q", fileio.ProofreadPath(outDir))
 	}
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -50,10 +50,10 @@ type stubScripter struct {
 	gotRundown model.Rundown
 }
 
-func (s *stubScripter) Generate(_ context.Context, _ config.ProgramConfig, rundown model.Rundown, _ []config.CornerConfig, _ map[string]config.CharacterConfig) (model.Script, model.ScriptLines, error) {
+func (s *stubScripter) Generate(_ context.Context, _ config.ProgramConfig, rundown model.Rundown, _ []config.CornerConfig, _ map[string]config.CharacterConfig) (model.Script, model.ScriptLines, *model.ProofreadResult, error) {
 	s.called = true
 	s.gotRundown = rundown
-	return s.script, s.lines, s.err
+	return s.script, s.lines, nil, s.err
 }
 
 type stubSynther struct {

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -2,16 +2,12 @@ package script
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"time"
 	"unicode/utf8"
 
 	"github.com/canpok1/vox-radio/internal/config"
-	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script/direct"
 	"github.com/canpok1/vox-radio/internal/script/write"
@@ -20,14 +16,13 @@ import (
 const regenThreshold = 0.20
 
 type ScriptGenerator interface {
-	Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, error)
+	Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, *model.ProofreadResult, error)
 }
 
 type LLMScriptGenerator struct {
 	writer       write.Writer
 	director     direct.Director
 	assetCatalog model.AssetCatalog
-	workDir      string
 	logger       *slog.Logger
 }
 
@@ -43,14 +38,12 @@ func NewLLMScriptGenerator(
 	w write.Writer,
 	d direct.Director,
 	assetCatalog model.AssetCatalog,
-	workDir string,
 	opts ...GeneratorOption,
 ) *LLMScriptGenerator {
 	g := &LLMScriptGenerator{
 		writer:       w,
 		director:     d,
 		assetCatalog: assetCatalog,
-		workDir:      workDir,
 		logger:       slog.Default(),
 	}
 	for _, opt := range opts {
@@ -59,7 +52,7 @@ func NewLLMScriptGenerator(
 	return g
 }
 
-func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, error) {
+func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, *model.ProofreadResult, error) {
 	start := time.Now()
 
 	cornerMap := rundown.CornerMap()
@@ -73,7 +66,7 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	g.logger.With("step", "script/write").Info("開始")
 	cornerLines, err := WriteAll(ctx, g.writer, program, corners, allAssignments, cornerMap, chars)
 	if err != nil {
-		return model.Script{}, model.ScriptLines{}, err
+		return model.Script{}, model.ScriptLines{}, nil, err
 	}
 	cornerLines = g.regenIfNeeded(ctx, program, cornerLines, corners, allAssignments, cornerMap, chars)
 	scriptLines := model.ScriptLines{Direction: program.Direction, Corners: BuildScriptLines(corners, cornerLines)}
@@ -81,19 +74,16 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	g.logger.With("step", "script/direct").Info("開始")
 	scr, pr, err := g.director.Direct(ctx, scriptLines.Corners, g.assetCatalog, program.Direction)
 	if err != nil {
-		return model.Script{}, model.ScriptLines{}, fmt.Errorf("direct: %w", err)
+		return model.Script{}, model.ScriptLines{}, nil, fmt.Errorf("direct: %w", err)
 	}
 
 	if pr != nil {
-		if err := g.saveIntermediate(fileio.FileProofread, pr); err != nil {
-			return model.Script{}, model.ScriptLines{}, err
-		}
 		g.logger.With("step", "script/direct").Info("校正完了", "count", len(pr.Corrections))
 	}
 
 	g.logger.With("step", "script").Info(fmt.Sprintf("完了 (%dセグメント, %.1fs)", len(scr.Segments), time.Since(start).Seconds()))
 
-	return scr, scriptLines, nil
+	return scr, scriptLines, pr, nil
 }
 
 // WriteAll writes lines for each corner in order, passing previously generated corners as context.
@@ -193,21 +183,6 @@ func (g *LLMScriptGenerator) regenIfNeeded(ctx context.Context, program config.P
 		cornerLines[worstIdx] = newLines
 	}
 	return cornerLines
-}
-
-func (g *LLMScriptGenerator) saveIntermediate(filename string, v any) error {
-	if g.workDir == "" {
-		return nil
-	}
-	data, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return fmt.Errorf("marshal %s: %w", filename, err)
-	}
-	path := filepath.Join(g.workDir, filename)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", filename, err)
-	}
-	return nil
 }
 
 // BuildScriptLines converts per-corner config and line slices into a []model.CornerLines.

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -2,15 +2,11 @@ package script_test
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/canpok1/vox-radio/internal/config"
-	"github.com/canpok1/vox-radio/internal/fileio"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script"
 	"github.com/canpok1/vox-radio/internal/script/write"
@@ -107,10 +103,9 @@ func TestLLMScriptGenerator_Generate_HappyPath(t *testing.T) {
 		&mockWriter{lines: lines},
 		&mockDirector{},
 		model.AssetCatalog{SE: []model.AssetCatalogEntry{{Name: "chime"}}},
-		"",
 	)
 
-	got, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, testCorners, testChars)
+	got, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, testCorners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -124,10 +119,9 @@ func TestLLMScriptGenerator_Generate_WriteError(t *testing.T) {
 		&mockWriter{err: context.Canceled},
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, corneredRundown("AIコーナー", model.RundownArticle{URL: "u"}), testCorners, testChars)
+	_, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, corneredRundown("AIコーナー", model.RundownArticle{URL: "u"}), testCorners, testChars)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -151,10 +145,9 @@ func TestLLMScriptGenerator_Generate_CharCountRegen(t *testing.T) {
 		mw,
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,10 +169,9 @@ func TestLLMScriptGenerator_Generate_NoRegenWhenWithinThreshold(t *testing.T) {
 		mw,
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -193,10 +185,9 @@ func TestLLMScriptGenerator_Generate_EmptyRundown(t *testing.T) {
 		&mockWriter{lines: []model.Line{{SpeakerRole: "zundamon", Text: "テスト"}}},
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	got, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, model.Rundown{Casts: make([]model.RundownCast, 0)}, testCorners, testChars)
+	got, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, model.Rundown{Casts: make([]model.RundownCast, 0)}, testCorners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -210,10 +201,9 @@ func TestLLMScriptGenerator_Generate_EmptyCorners(t *testing.T) {
 		&mockWriter{},
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	got, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, corneredRundown("AIコーナー", model.RundownArticle{URL: "u"}), []config.CornerConfig{}, testChars)
+	got, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, corneredRundown("AIコーナー", model.RundownArticle{URL: "u"}), []config.CornerConfig{}, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -234,10 +224,9 @@ func TestLLMScriptGenerator_Generate_NoRegenWhenAllCornersHaveZeroTarget(t *test
 		mw,
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -267,9 +256,9 @@ func TestLLMScriptGenerator_Generate_LogsProgress(t *testing.T) {
 	var buf strings.Builder
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	gen := script.NewLLMScriptGenerator(mw, md, model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)}, "", script.WithLogger(logger))
+	gen := script.NewLLMScriptGenerator(mw, md, model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)}, script.WithLogger(logger))
 
-	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -290,10 +279,9 @@ func TestLLMScriptGenerator_Generate_ReturnsScriptLines(t *testing.T) {
 		&mockWriter{lines: lines},
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	_, sl, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, testCorners, testChars)
+	_, sl, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, testCorners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,10 +337,9 @@ func TestLLMScriptGenerator_Generate_ReturnsCornerStructureInLines(t *testing.T)
 		&mockWriter{lines: lines},
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	_, sl, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, sl, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -437,10 +424,9 @@ func TestLLMScriptGenerator_Generate_PassesPreviousCornersAccumulated(t *testing
 		mw,
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
-	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -625,7 +611,7 @@ func TestMergeCornerCast_AbsentCastExcluded(t *testing.T) {
 func TestGenerate_UsesEpisodeCastsForAssignments(t *testing.T) {
 	mw := &mockWriter{lines: []model.Line{{SpeakerRole: "zundamon", Text: "こんにちは"}}}
 	md := &mockDirector{}
-	gen := script.NewLLMScriptGenerator(mw, md, model.AssetCatalog{}, "")
+	gen := script.NewLLMScriptGenerator(mw, md, model.AssetCatalog{})
 
 	rundown := model.Rundown{
 		Corners: []model.RundownCorner{{Title: "AIコーナー", Flow: "フロー"}},
@@ -637,7 +623,7 @@ func TestGenerate_UsesEpisodeCastsForAssignments(t *testing.T) {
 		{Title: "AIコーナー", Cast: map[string]string{"guest_char": "特別ゲスト役"}, LengthSec: 15},
 	}
 
-	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -666,7 +652,7 @@ func TestGenerate_UsesEpisodeCastsForAssignments(t *testing.T) {
 func TestGenerate_AbsentCastNotInAssignments(t *testing.T) {
 	mw := &mockWriter{lines: []model.Line{{SpeakerRole: "zundamon", Text: "こんにちは"}}}
 	md := &mockDirector{}
-	gen := script.NewLLMScriptGenerator(mw, md, model.AssetCatalog{}, "")
+	gen := script.NewLLMScriptGenerator(mw, md, model.AssetCatalog{})
 
 	// absent_char は casts に含まれないが corner.Cast に書かれている
 	rundown := model.Rundown{
@@ -677,7 +663,7 @@ func TestGenerate_AbsentCastNotInAssignments(t *testing.T) {
 		{Title: "AIコーナー", Cast: map[string]string{"absent_char": "休演中"}, LengthSec: 15},
 	}
 
-	_, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	_, _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -705,11 +691,10 @@ func TestLLMScriptGenerator_Generate_ProgramDirectionInReturnedLines(t *testing.
 		&mockWriter{lines: lines},
 		&mockDirector{},
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		"",
 	)
 
 	program := config.ProgramConfig{Direction: "番組全体の演出方針テスト"}
-	_, sl, err := gen.Generate(context.Background(), program, rundown, corners, testChars)
+	_, sl, _, err := gen.Generate(context.Background(), program, rundown, corners, testChars)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -718,8 +703,7 @@ func TestLLMScriptGenerator_Generate_ProgramDirectionInReturnedLines(t *testing.
 	}
 }
 
-func TestGenerate_SavesProofreadIntermediate_WhenProofreadSucceeds(t *testing.T) {
-	workDir := t.TempDir()
+func TestGenerate_ReturnsProofreadResult_WhenProofreadSucceeds(t *testing.T) {
 	rundown := corneredRundown("AIコーナー",
 		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
 	)
@@ -738,22 +722,15 @@ func TestGenerate_SavesProofreadIntermediate_WhenProofreadSucceeds(t *testing.T)
 		&mockWriter{lines: lines},
 		md,
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		workDir,
 	)
 
-	if _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+	_, _, got, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	path := filepath.Join(workDir, fileio.FileProofread)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("expected %s to exist: %v", fileio.FileProofread, err)
-	}
-
-	var got model.ProofreadResult
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("%s must be valid ProofreadResult JSON: %v", fileio.FileProofread, err)
+	if got == nil {
+		t.Fatal("expected non-nil ProofreadResult, got nil")
 	}
 	if len(got.Corrections) != 1 {
 		t.Fatalf("Corrections: got %d, want 1", len(got.Corrections))
@@ -766,8 +743,7 @@ func TestGenerate_SavesProofreadIntermediate_WhenProofreadSucceeds(t *testing.T)
 	}
 }
 
-func TestGenerate_DoesNotSaveProofreadIntermediate_WhenProofreadDisabled(t *testing.T) {
-	workDir := t.TempDir()
+func TestGenerate_ReturnsNilProofreadResult_WhenProofreadDisabled(t *testing.T) {
 	rundown := corneredRundown("AIコーナー",
 		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
 	)
@@ -776,27 +752,24 @@ func TestGenerate_DoesNotSaveProofreadIntermediate_WhenProofreadDisabled(t *test
 		{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
 	}
 
-	// proofreadResult is nil (proofread not set or failed)
 	md := &mockDirector{proofreadResult: nil}
 	gen := script.NewLLMScriptGenerator(
 		&mockWriter{lines: lines},
 		md,
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		workDir,
 	)
 
-	if _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+	_, _, got, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	path := filepath.Join(workDir, fileio.FileProofread)
-	if _, err := os.Stat(path); err == nil {
-		t.Errorf("%s should NOT exist when proofread is disabled, but it does", fileio.FileProofread)
+	if got != nil {
+		t.Errorf("expected nil ProofreadResult when proofread disabled, got %+v", got)
 	}
 }
 
-func TestGenerate_SavesProofreadIntermediate_EmptyCorrections(t *testing.T) {
-	workDir := t.TempDir()
+func TestGenerate_ReturnsEmptyCorrections_WhenProofreadFoundNone(t *testing.T) {
 	rundown := corneredRundown("AIコーナー",
 		model.RundownArticle{URL: "https://example.com/1", Title: "AI", Summary: "要約", Points: []string{"p1"}},
 	)
@@ -805,32 +778,24 @@ func TestGenerate_SavesProofreadIntermediate_EmptyCorrections(t *testing.T) {
 		{Title: "AIコーナー", Content: "AI紹介", Cast: map[string]string{"zundamon": "司会"}, LengthSec: 15},
 	}
 
-	// proofread ran but found 0 corrections
 	pr := &model.ProofreadResult{Corrections: make([]model.ProofreadCorrection, 0)}
 	md := &mockDirector{proofreadResult: pr}
 	gen := script.NewLLMScriptGenerator(
 		&mockWriter{lines: lines},
 		md,
 		model.AssetCatalog{SE: make([]model.AssetCatalogEntry, 0)},
-		workDir,
 	)
 
-	if _, _, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars); err != nil {
+	_, _, got, err := gen.Generate(context.Background(), config.ProgramConfig{}, rundown, corners, testChars)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	path := filepath.Join(workDir, fileio.FileProofread)
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("expected %s to exist even with 0 corrections: %v", fileio.FileProofread, err)
-	}
-
-	var got model.ProofreadResult
-	if err := json.Unmarshal(data, &got); err != nil {
-		t.Fatalf("%s must be valid ProofreadResult JSON: %v", fileio.FileProofread, err)
+	if got == nil {
+		t.Fatal("expected non-nil ProofreadResult even with 0 corrections")
 	}
 	if got.Corrections == nil {
-		t.Error("Corrections should be [] not null in JSON output")
+		t.Error("Corrections should be [] not nil")
 	}
 	if len(got.Corrections) != 0 {
 		t.Errorf("Corrections: got %d, want 0", len(got.Corrections))


### PR DESCRIPTION
関連タスク: [LLMScriptGenerator.Generate の proofread 結果を戻り値に移動](https://app.todoist.com/app/task/6gr242RGVvwpGvXV)

## Summary

- `ScriptGenerator.Generate` / `Scripter.Generate` インターフェースに `*model.ProofreadResult` を第3戻り値として追加
- `LLMScriptGenerator` から `workDir` フィールドと `saveIntermediate` メソッドを除去（アーキテクチャ §4 違反解消）
- proofread ファイル書き出しを呼び出し側（`pipeline.Runner.Run` / `cli/script.go runScriptFull`）で明示的に実施
- `pipeline_test.go` の `stubScripter` に `proofread` フィールドを追加し、`if pr != nil` 両分岐のテストカバレッジを確保

## Test plan

- [x] `go test ./...` — 全件 PASS
- [x] `golangci-lint run` — 指摘なし
- [x] `TestRunner_Run_WritesProofreadFile_WhenProofreadResultIsNotNil` — non-nil 時のファイル書き出しを確認
- [x] `TestRunner_Run_SkipsProofreadFile_WhenProofreadResultIsNil` — nil 時にファイルが生成されないことを確認
- [x] proofread パス計算: CLI（`filepath.Join(workDir, fileio.FileProofread)`）と pipeline（`fileio.ProofreadPath(outDir)`）で二重ネストが起きないことを確認済み

---
🤖 Generated with [Claude Code](https://claude.ai/code)