### PR TITLE
feat(install): インストールスクリプトをリリース埋め込みバージョン方式に変更

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,11 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 
+before:
+  hooks:
+    - mkdir -p dist
+    - sed 's/__VERSION__/{{ .Tag }}/g' scripts/install.sh > dist/install.sh
+
 builds:
   - id: vox-radio
     main: ./cmd/vox-radio
@@ -37,6 +42,8 @@ changelog:
       - "^test:"
 
 release:
+  extra_files:
+    - glob: dist/install.sh
   footer: >-
 
     ---

--- a/README.md
+++ b/README.md
@@ -86,18 +86,17 @@ make release-check
 
 ### バイナリインストール（リリース版）
 
-GitHub Releases のバイナリを `curl` のワンライナーで導入できます。
+[GitHub Releases](https://github.com/canpok1/vox-radio/releases) からインストールスクリプトを取得して実行します。
 
 ```bash
-# 最新版をインストール
-curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | bash
+# リリースページから install.sh をダウンロードして実行（例: v0.0.1 の場合）
+curl -fsSL https://github.com/canpok1/vox-radio/releases/download/v0.0.1/install.sh | bash
 
-# バージョンを指定してインストール（引数で渡す）
-curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | bash -s -- v0.0.1
-
-# 設置先を変更（環境変数）
-curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | INSTALL_DIR=$HOME/.local/bin bash -s -- v0.0.1
+# 設置先を変更する場合は環境変数 INSTALL_DIR を指定
+curl -fsSL https://github.com/canpok1/vox-radio/releases/download/v0.0.1/install.sh | INSTALL_DIR=$HOME/.local/bin bash
 ```
+
+`v0.0.1` の部分はインストールしたいリリースタグに置き換えてください。
 
 デフォルトの設置先は `/usr/local/bin` です。書き込み権限がない場合は自動で `sudo` にフォールバックします。
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -115,12 +115,9 @@ INSTALLED_VERSION=""
 if command -v vox-radio >/dev/null 2>&1; then
   raw_ver="$(vox-radio --version 2>/dev/null || true)"
   # cobra デフォルト形式: "vox-radio version 0.0.1" → "v0.0.1" に正規化
-  ver_num="$(echo "$raw_ver" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
-  if [[ -n "$ver_num" ]]; then
-    INSTALLED_VERSION="v${ver_num}"
-  else
-    INSTALLED_VERSION="$raw_ver"
-  fi
+  INSTALLED_VERSION="$(printf '%s' "$raw_ver" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  INSTALLED_VERSION="${INSTALLED_VERSION:+v${INSTALLED_VERSION}}"
+  INSTALLED_VERSION="${INSTALLED_VERSION:-$raw_ver}"
 fi
 
 if [[ -n "$INSTALLED_VERSION" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 # vox-radio バイナリを GitHub Releases から取得して INSTALL_DIR に配置する。
 #
-# 使い方:
-#   bash install-vox-radio.sh [VERSION]
-#   curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/canpok1/vox-radio/main/scripts/install-vox-radio.sh | bash -s -- v0.0.1
+# このスクリプトはリリースアセットとして配布される専用スクリプトです。
+# リリースページから直接ダウンロードして実行してください。
 #
-# 引数:
-#   VERSION  取得するリリースタグ (例: v0.0.1)。省略時は最新版を自動解決。
+# 使い方:
+#   bash install.sh
+#   bash install.sh --help
 #
 # 環境変数:
 #   INSTALL_DIR  バイナリ設置先ディレクトリ (デフォルト: /usr/local/bin)
@@ -16,26 +15,30 @@ set -euo pipefail
 REPO="canpok1/vox-radio"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
+# リリース時に置換されるバージョンプレースホルダ
+VERSION="__VERSION__"
+
 usage() {
-  echo "Usage: $0 [VERSION]" >&2
-  echo "  VERSION: release tag (e.g. v0.0.1). Omit to install the latest." >&2
+  echo "Usage: $0" >&2
+  echo "" >&2
+  echo "このスクリプトはリリースアセットとして配布されます。" >&2
+  echo "リリースページから install.sh をダウンロードして実行してください。" >&2
   echo "" >&2
   echo "Environment variables:" >&2
   echo "  INSTALL_DIR  Installation directory (default: /usr/local/bin)" >&2
 }
 
-# ---- 引数パース ----
-if [[ $# -gt 1 ]]; then
-  usage
-  exit 1
-fi
-
-if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0
 fi
 
-VERSION="${1:-}"
+# ---- プレースホルダ未置換チェック ----
+if [[ ! "$VERSION" =~ ^v[0-9] ]]; then
+  echo "ERROR: バージョンが埋め込まれていません。" >&2
+  echo "       リリースページから install.sh をダウンロードして実行してください。" >&2
+  exit 1
+fi
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -98,28 +101,6 @@ download() {
   fi
 }
 
-download_stdout() {
-  local url="$1"
-  if [[ "$DOWNLOADER" == "curl" ]]; then
-    curl -fsSL "$url"
-  else
-    wget -qO- "$url"
-  fi
-}
-
-# ---- latest 解決 ----
-if [[ -z "$VERSION" ]]; then
-  echo "最新バージョンを GitHub API から解決しています..."
-  VERSION="$(download_stdout "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name"' \
-    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
-  if [[ -z "$VERSION" ]]; then
-    echo "ERROR: latest バージョンの解決に失敗しました" >&2
-    exit 1
-  fi
-  echo "最新バージョン: $VERSION"
-fi
-
 # VERSION から先頭 "v" を除いたもの（checksums ファイル名用）
 VERSION_NUM="${VERSION#v}"
 
@@ -129,29 +110,61 @@ BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
 TARBALL_URL="${BASE_URL}/${ASSET_NAME}"
 CHECKSUMS_URL="${BASE_URL}/${CHECKSUMS_NAME}"
 
+# ---- インストール済みバージョン確認・分岐 ----
+INSTALLED_VERSION=""
+if command -v vox-radio >/dev/null 2>&1; then
+  raw_ver="$(vox-radio --version 2>/dev/null || true)"
+  # cobra デフォルト形式: "vox-radio version 0.0.1" → "v0.0.1" に正規化
+  ver_num="$(echo "$raw_ver" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+  if [[ -n "$ver_num" ]]; then
+    INSTALLED_VERSION="v${ver_num}"
+  else
+    INSTALLED_VERSION="$raw_ver"
+  fi
+fi
+
+if [[ -n "$INSTALLED_VERSION" ]]; then
+  if [[ ! "$INSTALLED_VERSION" =~ ^v[0-9] ]]; then
+    echo "警告: インストール済みバージョン ($INSTALLED_VERSION) が semver 形式ではありません。上書きインストールします。"
+  elif [[ "$INSTALLED_VERSION" == "$VERSION" ]]; then
+    echo "$VERSION は既にインストール済みです。スキップします。"
+    exit 0
+  else
+    LOWER="$(printf '%s\n%s\n' "$VERSION" "$INSTALLED_VERSION" | sort -V | head -1)"
+    if [[ "$LOWER" == "$VERSION" ]]; then
+      echo "警告: より新しいバージョン ($INSTALLED_VERSION) がインストール済みです。インストールをスキップします。"
+      exit 0
+    else
+      echo "古いバージョン ($INSTALLED_VERSION) から $VERSION へ更新します。"
+    fi
+  fi
+else
+  echo "$VERSION を新規インストールします。"
+fi
+
 # ---- 一時ディレクトリ（EXIT 時に自動削除） ----
-TMPDIR_WORK="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_WORK"' EXIT
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
 
 # ---- ダウンロード ----
 echo "ダウンロード中: $TARBALL_URL"
-download "$TARBALL_URL" "$TMPDIR_WORK/$ASSET_NAME"
+download "$TARBALL_URL" "$WORK_DIR/$ASSET_NAME"
 
 echo "ダウンロード中: $CHECKSUMS_URL"
-download "$CHECKSUMS_URL" "$TMPDIR_WORK/$CHECKSUMS_NAME"
+download "$CHECKSUMS_URL" "$WORK_DIR/$CHECKSUMS_NAME"
 
 # ---- sha256 検証 ----
 echo "チェックサムを検証しています..."
-checksum_line="$(grep "$ASSET_NAME" "$TMPDIR_WORK/$CHECKSUMS_NAME" || true)"
+checksum_line="$(grep "$ASSET_NAME" "$WORK_DIR/$CHECKSUMS_NAME" || true)"
 if [[ -z "$checksum_line" ]]; then
   echo "ERROR: checksums.txt に $ASSET_NAME のエントリが見つかりません" >&2
   exit 1
 fi
-echo "$checksum_line" | (cd "$TMPDIR_WORK" && $SHA256CMD --check -)
+echo "$checksum_line" | (cd "$WORK_DIR" && $SHA256CMD --check -)
 echo "チェックサム OK"
 
 # ---- 展開 ----
-tar -xzf "$TMPDIR_WORK/$ASSET_NAME" -C "$TMPDIR_WORK" vox-radio
+tar -xzf "$WORK_DIR/$ASSET_NAME" -C "$WORK_DIR" vox-radio
 
 # ---- インストール ----
 if [[ ! -d "$INSTALL_DIR" ]]; then
@@ -160,10 +173,10 @@ if [[ ! -d "$INSTALL_DIR" ]]; then
 fi
 
 if [[ -w "$INSTALL_DIR" ]]; then
-  install -m 0755 "$TMPDIR_WORK/vox-radio" "$INSTALL_DIR/vox-radio"
+  install -m 0755 "$WORK_DIR/vox-radio" "$INSTALL_DIR/vox-radio"
 else
   echo "書き込み権限がないため sudo でインストールします..."
-  sudo install -m 0755 "$TMPDIR_WORK/vox-radio" "$INSTALL_DIR/vox-radio"
+  sudo install -m 0755 "$WORK_DIR/vox-radio" "$INSTALL_DIR/vox-radio"
 fi
 
 echo ""


### PR DESCRIPTION
関連タスク: [インストールスクリプトを引数指定廃止＋リリース埋め込みバージョン方式に変更する](https://app.todoist.com/app/task/6gr3XvPWMqqPHQP3)

## Summary

- `scripts/install-vox-radio.sh` を `scripts/install.sh` にリネーム
- バージョン引数指定・latest 自動解決を廃止し、`VERSION="__VERSION__"` プレースホルダ方式に変更
  - プレースホルダ未置換時はエラー終了（リリースアセット専用であることを明示）
- インストール済みバージョンとの比較ロジックを追加（新規/更新/同一スキップ/新しい版警告の4分岐）
- `.goreleaser.yaml` の `before.hooks` で `__VERSION__` を `{{ .Tag }}` に sed 置換して `dist/install.sh` を生成、`release.extra_files` でリリースアセットとして添付
- README から curl ワンライナー（main raw 取得）を廃止し、リリースアセット取得手順に更新

## Test plan

- [ ] shellcheck scripts/install.sh が通ること
- [ ] goreleaser check が通ること
- [ ] VERSION が `__VERSION__` のままのスクリプトを実行するとエラーになること
- [ ] 各バージョン分岐（新規/更新/同一/新しい版）の動作確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)