### PR TITLE
refactor(config): FeedsConfig と SourceConfig の重複型を統一

### DIFF
--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -126,10 +126,7 @@ func (c *Collector) RunAll(ctx context.Context, corners []config.CornerConfig, e
 	for i, corner := range filtered {
 		logger.Info(fmt.Sprintf("コーナー「%s」を収集中 (%d/%d)", corner.Title, i+1, len(filtered)))
 
-		articles, err := c.Run(ctx, config.FeedsConfig{
-			Feeds:    corner.Source.Feeds,
-			Articles: corner.Source.Articles,
-		}, excluded)
+		articles, err := c.Run(ctx, *corner.Source, excluded)
 		if err != nil {
 			return model.Articles{}, fmt.Errorf("collect corner %q: %w", corner.Title, err)
 		}

--- a/internal/config/program.go
+++ b/internal/config/program.go
@@ -32,10 +32,8 @@ type FeedsConfig struct {
 }
 
 // SourceConfig defines the data sources for a corner (feeds and individual article URLs).
-type SourceConfig struct {
-	Feeds    []FeedEntry `yaml:"feeds"`
-	Articles []string    `yaml:"articles"`
-}
+// It is an alias for FeedsConfig, ensuring the two remain in sync.
+type SourceConfig = FeedsConfig
 
 // AudioRef references a jingle or SE asset by type and asset ID.
 type AudioRef struct {


### PR DESCRIPTION
関連タスク: [`FeedsConfig` と `SourceConfig` の重複型を統一する](https://app.todoist.com/app/task/6gr2CWx7pQhv5GGV)

## Summary

- `internal/config/program.go`: `SourceConfig` の独立した struct 定義を `type SourceConfig = FeedsConfig` 型エイリアスに変更し、同一フィールド構成の重複型を一本化
- `internal/collect/collect.go`: `RunAll` 内で手動で行っていた `FeedsConfig{Feeds: ..., Articles: ...}` への変換を `*corner.Source` の直接参照に簡化

型エイリアスにより両型のフィールドが常に同期され、将来フィールド追加時の片方取り残しリスクを排除する。

---
🤖 Generated with [Claude Code](https://claude.ai/code)