### PR TITLE
refactor(config): EpisodeSpec の validate 群をメソッド化し Validate() を追加

### DIFF
--- a/internal/cli/collect.go
+++ b/internal/cli/collect.go
@@ -41,7 +41,7 @@ source フィールドのないコーナーはスキップされます。
 				return fmt.Errorf("load spec: %w", err)
 			}
 
-			if err := config.ValidateEpisodeSpecCorners(p); err != nil {
+			if err := p.ValidateCorners(); err != nil {
 				return fmt.Errorf("spec validation: %w", err)
 			}
 

--- a/internal/cli/episodegen_check.go
+++ b/internal/cli/episodegen_check.go
@@ -32,28 +32,12 @@ func newEpisodegenCheckCmd() *cobra.Command {
 				return err
 			}
 
-			if err := config.ValidateEpisodeSpecProgram(p); err != nil {
-				return err
-			}
-
-			if err := config.ValidateEpisodeSpecAssets(p); err != nil {
-				return err
-			}
-
 			cfg, err := config.LoadConfig(configPath(cmd))
 			if err != nil {
 				return fmt.Errorf("load config for cast validation: %w", err)
 			}
 
-			if err := config.ValidateEpisodeSpecCast(p); err != nil {
-				return err
-			}
-
-			if err := config.ValidateEpisodeSpecCasts(p, cfg.Characters); err != nil {
-				return err
-			}
-
-			if err := config.ValidateEpisodeSpecCorners(p); err != nil {
+			if err := p.Validate(cfg.Characters); err != nil {
 				return err
 			}
 

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -212,19 +212,7 @@ func loadConfigAndSpec(cfgPath, specPath string) (*config.Config, *config.Episod
 	if err != nil {
 		return nil, nil, fmt.Errorf("load spec: %w", err)
 	}
-	if err := config.ValidateEpisodeSpecProgram(p); err != nil {
-		return nil, nil, fmt.Errorf("spec validation: %w", err)
-	}
-	if err := config.ValidateEpisodeSpecCast(p); err != nil {
-		return nil, nil, fmt.Errorf("spec validation: %w", err)
-	}
-	if err := config.ValidateEpisodeSpecAssets(p); err != nil {
-		return nil, nil, fmt.Errorf("spec validation: %w", err)
-	}
-	if err := config.ValidateEpisodeSpecCasts(p, cfg.Characters); err != nil {
-		return nil, nil, fmt.Errorf("spec validation: %w", err)
-	}
-	if err := config.ValidateEpisodeSpecCorners(p); err != nil {
+	if err := p.Validate(cfg.Characters); err != nil {
 		return nil, nil, fmt.Errorf("spec validation: %w", err)
 	}
 	return cfg, p, nil

--- a/internal/config/episode_spec.go
+++ b/internal/config/episode_spec.go
@@ -86,9 +86,9 @@ func validateEpisodeCondition(cond EpisodeCondition, prefix string) error {
 	return nil
 }
 
-// ValidateEpisodeSpecCasts checks that every cast character ID exists in chars,
+// ValidateCasts checks that every cast character ID exists in chars,
 // that type is valid, and that condition is set correctly (guest requires condition).
-func ValidateEpisodeSpecCasts(p *EpisodeSpec, chars map[string]CharacterConfig) error {
+func (p *EpisodeSpec) ValidateCasts(chars map[string]CharacterConfig) error {
 	for charID, c := range p.Casts {
 		if _, ok := chars[charID]; !ok {
 			return fmt.Errorf("casts[%q]: character not found in characters catalog", charID)
@@ -108,9 +108,14 @@ func ValidateEpisodeSpecCasts(p *EpisodeSpec, chars map[string]CharacterConfig) 
 	return nil
 }
 
-// ValidateEpisodeSpecCorners は corners の id・出現条件を検証する（キャラ不要・spec 内部整合のみ）。
+// ValidateEpisodeSpecCasts は ValidateCasts の後方互換ラッパー。
+func ValidateEpisodeSpecCasts(p *EpisodeSpec, chars map[string]CharacterConfig) error {
+	return p.ValidateCasts(chars)
+}
+
+// ValidateCorners は corners の id・出現条件を検証する（キャラ不要・spec 内部整合のみ）。
 // id は必須かつ番組内で一意。title もユーザー向け表示用に重複を禁止する。
-func ValidateEpisodeSpecCorners(p *EpisodeSpec) error {
+func (p *EpisodeSpec) ValidateCorners() error {
 	seenID := make(map[string]bool, len(p.Corners))
 	seenTitle := make(map[string]bool, len(p.Corners))
 	for i, c := range p.Corners {
@@ -134,6 +139,11 @@ func ValidateEpisodeSpecCorners(p *EpisodeSpec) error {
 	return nil
 }
 
+// ValidateEpisodeSpecCorners は ValidateCorners の後方互換ラッパー。
+func ValidateEpisodeSpecCorners(p *EpisodeSpec) error {
+	return p.ValidateCorners()
+}
+
 // CornerSummaryLength returns the effective summary length (chars) for the corner matching title.
 // Falls back to DefaultCornerSummaryLength when the corner is not found or summary_length is unset.
 func (p *EpisodeSpec) CornerSummaryLength(title string) int {
@@ -145,18 +155,23 @@ func (p *EpisodeSpec) CornerSummaryLength(title string) int {
 	return DefaultCornerSummaryLength
 }
 
-// ValidateEpisodeSpecProgram checks that program.id is set.
+// ValidateProgram checks that program.id is set.
 // program.id is the cache key (episodes are stored per program.id), so it is required.
-func ValidateEpisodeSpecProgram(p *EpisodeSpec) error {
+func (p *EpisodeSpec) ValidateProgram() error {
 	if p.Program.ID == "" {
 		return fmt.Errorf("program.id is required (it is the cache key for episode history)")
 	}
 	return nil
 }
 
-// ValidateEpisodeSpecCast checks that every character ID in corners[].cast is declared in casts.
+// ValidateEpisodeSpecProgram は ValidateProgram の後方互換ラッパー。
+func ValidateEpisodeSpecProgram(p *EpisodeSpec) error {
+	return p.ValidateProgram()
+}
+
+// ValidateCast checks that every character ID in corners[].cast is declared in casts.
 // This ensures corner-only characters are forbidden, preventing rest-state leaks and typos.
-func ValidateEpisodeSpecCast(p *EpisodeSpec) error {
+func (p *EpisodeSpec) ValidateCast() error {
 	for _, corner := range p.Corners {
 		for charID := range corner.Cast {
 			if _, ok := p.Casts[charID]; !ok {
@@ -167,8 +182,13 @@ func ValidateEpisodeSpecCast(p *EpisodeSpec) error {
 	return nil
 }
 
-// ValidateEpisodeSpecAssets checks that corner-level audio/bgm keys reference existing assets.
-func ValidateEpisodeSpecAssets(p *EpisodeSpec) error {
+// ValidateEpisodeSpecCast は ValidateCast の後方互換ラッパー。
+func ValidateEpisodeSpecCast(p *EpisodeSpec) error {
+	return p.ValidateCast()
+}
+
+// ValidateAssets checks that corner-level audio/bgm keys reference existing assets.
+func (p *EpisodeSpec) ValidateAssets() error {
 	for _, corner := range p.Corners {
 		if corner.StartAudio != nil {
 			if err := validateAudioRef(corner.Title, "start_audio", corner.StartAudio, &p.Assets); err != nil {
@@ -187,6 +207,29 @@ func ValidateEpisodeSpecAssets(p *EpisodeSpec) error {
 		}
 	}
 	return nil
+}
+
+// ValidateEpisodeSpecAssets は ValidateAssets の後方互換ラッパー。
+func ValidateEpisodeSpecAssets(p *EpisodeSpec) error {
+	return p.ValidateAssets()
+}
+
+// Validate はすべてのバリデーションを実行する単一エントリポイント。
+// Program・Corners・Cast・Assets・Casts の順に検証し、最初のエラーを返す。
+func (p *EpisodeSpec) Validate(chars map[string]CharacterConfig) error {
+	if err := p.ValidateProgram(); err != nil {
+		return err
+	}
+	if err := p.ValidateCorners(); err != nil {
+		return err
+	}
+	if err := p.ValidateCast(); err != nil {
+		return err
+	}
+	if err := p.ValidateAssets(); err != nil {
+		return err
+	}
+	return p.ValidateCasts(chars)
 }
 
 func validateAudioRef(cornerTitle, field string, ref *AudioRef, assets *AssetsConfig) error {

--- a/internal/config/episode_spec_test.go
+++ b/internal/config/episode_spec_test.go
@@ -257,6 +257,17 @@ func TestEpisodeSpec_Validate_ErrorCases(t *testing.T) {
 				Assets: config.AssetsConfig{Jingle: map[string]config.JingleEntry{}, BGM: map[string]config.BGMEntry{}},
 			},
 		},
+		{
+			name: "存在しないアセットを参照するとき Validate はエラーを返す",
+			spec: &config.EpisodeSpec{
+				Program: config.ProgramConfig{ID: "prog"},
+				Corners: []config.CornerConfig{
+					{ID: "c1", Title: "opening", StartAudio: &config.AudioRef{Type: "jingle", ID: "nonexistent"}},
+				},
+				Casts:  map[string]config.CastConfig{},
+				Assets: config.AssetsConfig{Jingle: map[string]config.JingleEntry{}, BGM: map[string]config.BGMEntry{}},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/episode_spec_test.go
+++ b/internal/config/episode_spec_test.go
@@ -1,0 +1,268 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+)
+
+func TestEpisodeSpec_ValidateProgram(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *config.EpisodeSpec
+		wantErr bool
+	}{
+		{
+			name:    "program.id が設定されている場合はエラーなし",
+			spec:    &config.EpisodeSpec{Program: config.ProgramConfig{ID: "my-program"}},
+			wantErr: false,
+		},
+		{
+			name:    "program.id が空の場合はエラー",
+			spec:    &config.EpisodeSpec{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.ValidateProgram()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateProgram() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEpisodeSpec_ValidateCorners(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *config.EpisodeSpec
+		wantErr bool
+	}{
+		{
+			name: "有効な corners はエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{ID: "c1", Title: "Corner 1"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "id が空のコーナーはエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{Title: "Corner 1"}},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.ValidateCorners()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCorners() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEpisodeSpec_ValidateCast(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *config.EpisodeSpec
+		wantErr bool
+	}{
+		{
+			name: "コーナーのキャストが casts に宣言済みの場合はエラーなし",
+			spec: &config.EpisodeSpec{
+				Casts: map[string]config.CastConfig{
+					"zundamon": {Type: config.CastTypeRegular, Role: "司会"},
+				},
+				Corners: []config.CornerConfig{
+					{Title: "opening", Cast: map[string]string{"zundamon": "ボケ担当"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "コーナーのキャストが casts に未宣言の場合はエラー",
+			spec: &config.EpisodeSpec{
+				Casts: map[string]config.CastConfig{},
+				Corners: []config.CornerConfig{
+					{Title: "opening", Cast: map[string]string{"unknown": "司会"}},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.ValidateCast()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCast() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEpisodeSpec_ValidateAssets(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *config.EpisodeSpec
+		wantErr bool
+	}{
+		{
+			name: "有効なアセット参照はエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{
+					{Title: "C1", StartAudio: &config.AudioRef{Type: "jingle", ID: "opening"}},
+				},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{"opening": {File: "opening.mp3"}},
+					BGM:    map[string]config.BGMEntry{},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "存在しない jingle キーはエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{
+					{Title: "C1", StartAudio: &config.AudioRef{Type: "jingle", ID: "nonexistent"}},
+				},
+				Assets: config.AssetsConfig{
+					Jingle: map[string]config.JingleEntry{},
+					BGM:    map[string]config.BGMEntry{},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.ValidateAssets()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateAssets() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEpisodeSpec_ValidateCasts(t *testing.T) {
+	chars := map[string]config.CharacterConfig{
+		"zundamon": {},
+	}
+	tests := []struct {
+		name    string
+		spec    *config.EpisodeSpec
+		wantErr bool
+	}{
+		{
+			name: "casts のキャラが characters に存在する場合はエラーなし",
+			spec: &config.EpisodeSpec{
+				Casts: map[string]config.CastConfig{
+					"zundamon": {Type: config.CastTypeRegular, Role: "司会"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "casts のキャラが characters に存在しない場合はエラー",
+			spec: &config.EpisodeSpec{
+				Casts: map[string]config.CastConfig{
+					"unknown_char": {Type: config.CastTypeRegular, Role: "司会"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.ValidateCasts(chars)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateCasts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestEpisodeSpec_Validate_CallsAllValidations は Validate が全検証を通過することを確認する。
+func TestEpisodeSpec_Validate_CallsAllValidations(t *testing.T) {
+	chars := map[string]config.CharacterConfig{
+		"zundamon": {},
+	}
+	validSpec := &config.EpisodeSpec{
+		Program: config.ProgramConfig{ID: "my-program"},
+		Corners: []config.CornerConfig{
+			{
+				ID:    "c1",
+				Title: "opening",
+				Cast:  map[string]string{"zundamon": "司会"},
+			},
+		},
+		Casts: map[string]config.CastConfig{
+			"zundamon": {Type: config.CastTypeRegular, Role: "司会"},
+		},
+		Assets: config.AssetsConfig{
+			Jingle: map[string]config.JingleEntry{},
+			BGM:    map[string]config.BGMEntry{},
+		},
+	}
+	if err := validSpec.Validate(chars); err != nil {
+		t.Errorf("Validate() unexpected error = %v", err)
+	}
+}
+
+// TestEpisodeSpec_Validate_ErrorCases は各バリデーションのエラーが Validate から伝播することを確認する。
+func TestEpisodeSpec_Validate_ErrorCases(t *testing.T) {
+	chars := map[string]config.CharacterConfig{
+		"zundamon": {},
+	}
+	tests := []struct {
+		name string
+		spec *config.EpisodeSpec
+	}{
+		{
+			name: "program.id が空のとき Validate はエラーを返す",
+			spec: &config.EpisodeSpec{
+				Program: config.ProgramConfig{},
+				Assets:  config.AssetsConfig{Jingle: map[string]config.JingleEntry{}, BGM: map[string]config.BGMEntry{}},
+			},
+		},
+		{
+			name: "corner の id が空のとき Validate はエラーを返す",
+			spec: &config.EpisodeSpec{
+				Program: config.ProgramConfig{ID: "prog"},
+				Corners: []config.CornerConfig{{Title: "opening"}},
+				Assets:  config.AssetsConfig{Jingle: map[string]config.JingleEntry{}, BGM: map[string]config.BGMEntry{}},
+			},
+		},
+		{
+			name: "corner cast が未宣言のとき Validate はエラーを返す",
+			spec: &config.EpisodeSpec{
+				Program: config.ProgramConfig{ID: "prog"},
+				Corners: []config.CornerConfig{
+					{ID: "c1", Title: "opening", Cast: map[string]string{"ghost": "司会"}},
+				},
+				Casts:  map[string]config.CastConfig{},
+				Assets: config.AssetsConfig{Jingle: map[string]config.JingleEntry{}, BGM: map[string]config.BGMEntry{}},
+			},
+		},
+		{
+			name: "casts のキャラが characters に存在しないとき Validate はエラーを返す",
+			spec: &config.EpisodeSpec{
+				Program: config.ProgramConfig{ID: "prog"},
+				Corners: []config.CornerConfig{{ID: "c1", Title: "opening"}},
+				Casts: map[string]config.CastConfig{
+					"unknown": {Type: config.CastTypeRegular, Role: "司会"},
+				},
+				Assets: config.AssetsConfig{Jingle: map[string]config.JingleEntry{}, BGM: map[string]config.BGMEntry{}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.spec.Validate(chars); err == nil {
+				t.Error("Validate() expected error but got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
関連タスク: [`EpisodeSpec` の validate 群（5関数）をメソッド化してエントリポイントを統一する](https://app.todoist.com/app/task/6gr2CWxQgpMg8HxV)

## Summary

- `EpisodeSpec` の5つのバリデーション package-level 関数を `*EpisodeSpec` のメソッドとして実装
  - `ValidateProgram()` / `ValidateCorners()` / `ValidateCast()` / `ValidateAssets()` / `ValidateCasts(chars)`
- すべての検証を一括実行する単一エントリポイント `Validate(chars) error` を追加
- 既存の `ValidateEpisodeSpecXxx` 関数は後方互換ラッパーとして維持（テスト変更なし）
- CLI 層の呼び出し側を簡潔化
  - `util.go` / `episodegen_check.go`: 5回の個別呼び出し → `p.Validate(cfg.Characters)` 1回
  - `collect.go`: `config.ValidateEpisodeSpecCorners(p)` → `p.ValidateCorners()`

## Test plan

- [x] `go test ./...` がすべて green
- [x] `golangci-lint run` の指摘なし
- [x] 新規メソッド（`ValidateProgram` / `ValidateCorners` / `ValidateCast` / `ValidateAssets` / `ValidateCasts` / `Validate`）の直接ユニットテストを追加
- [x] `Validate()` の各バリデーション（Program / Corners / Cast / Assets / Casts）エラー伝播テストを追加

## Note

`/simplify` 指摘のうち、後方互換ラッパー削除（テスト側を新メソッド形式に更新）はスコープ外としてスキップ。後続タスク `ValidateEpisodeSpec*` ラッパー関数を削除してテストをメソッド形式へ更新する（ID: 6gr3xv9HJW4V3fQ3）で追跡。

---
🤖 Generated with [Claude Code](https://claude.ai/code)