### PR TITLE
refactor: nil-to-empty-slice ガードを model.NonNil ジェネリックヘルパーに集約

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -91,10 +91,7 @@ func (m *Manager) Load() ([]Entry, error) {
 	if err := scanner.Err(); err != nil {
 		return nil, fmt.Errorf("scan cache: %w", err)
 	}
-	if entries == nil {
-		return make([]Entry, 0), nil
-	}
-	return entries, nil
+	return model.NonNil(entries), nil
 }
 
 // Append loads existing entries, adds the new entry, compacts if needed, and writes back.
@@ -216,17 +213,10 @@ func BuildEntryFromManifest(programID string, m model.Manifest, rd model.Rundown
 			}
 			articles[j] = ae
 		}
-		points := mc.Points
-		if points == nil {
-			points = make([]string, 0)
-		}
-		corners[i] = CornerEntry{ID: mc.ID, Title: mc.Title, Summary: mc.Summary, Points: points, Articles: articles}
+		corners[i] = CornerEntry{ID: mc.ID, Title: mc.Title, Summary: mc.Summary, Points: model.NonNil(mc.Points), Articles: articles}
 	}
 
-	notes := m.ConversationNotes
-	if notes == nil {
-		notes = make([]model.ConversationNote, 0)
-	}
+	notes := model.NonNil(m.ConversationNotes)
 
 	casts := make([]CastEntry, len(m.Casts))
 	for i, c := range m.Casts {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -207,9 +207,7 @@ func BuildEntryFromManifest(programID string, m model.Manifest, rd model.Rundown
 			}
 			if rda, ok := rdArticleByDedupKey[ar.DedupKey]; ok {
 				ae.Summary = rda.Summary
-				if rda.Points != nil {
-					ae.Points = rda.Points
-				}
+				ae.Points = model.NonNil(rda.Points)
 			}
 			articles[j] = ae
 		}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -35,10 +35,7 @@ func Build(p BuildParams) model.Manifest {
 			refs = append(refs, model.ArticleRef{Title: a.Title, URL: a.URL})
 		}
 		cs := p.CornerSummaries[c.Title]
-		points := cs.Points
-		if points == nil {
-			points = make([]string, 0)
-		}
+		points := model.NonNil(cs.Points)
 		manifestCorners = append(manifestCorners, model.ManifestCorner{
 			ID:       c.ID,
 			Title:    c.Title,
@@ -47,15 +44,8 @@ func Build(p BuildParams) model.Manifest {
 			Articles: refs,
 		})
 	}
-	notes := p.ConversationNotes
-	if notes == nil {
-		notes = make([]model.ConversationNote, 0)
-	}
-
-	casts := p.Rundown.Casts
-	if casts == nil {
-		casts = make([]model.RundownCast, 0)
-	}
+	notes := model.NonNil(p.ConversationNotes)
+	casts := model.NonNil(p.Rundown.Casts)
 
 	return model.Manifest{
 		Title:             p.Program.Title,

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -43,9 +43,6 @@ func Build(p BuildParams) model.Manifest {
 			Articles: refs,
 		})
 	}
-	notes := model.NonNil(p.ConversationNotes)
-	casts := model.NonNil(p.Rundown.Casts)
-
 	return model.Manifest{
 		Title:             p.Program.Title,
 		EpisodeNumber:     p.EpisodeNumber,
@@ -55,7 +52,7 @@ func Build(p BuildParams) model.Manifest {
 		Datetime:          p.GeneratedAt.UTC().Format(time.RFC3339),
 		AudioFile:         p.AudioFile,
 		Corners:           manifestCorners,
-		ConversationNotes: notes,
-		Casts:             casts,
+		ConversationNotes: model.NonNil(p.ConversationNotes),
+		Casts:             model.NonNil(p.Rundown.Casts),
 	}
 }

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -35,12 +35,11 @@ func Build(p BuildParams) model.Manifest {
 			refs = append(refs, model.ArticleRef{Title: a.Title, URL: a.URL})
 		}
 		cs := p.CornerSummaries[c.Title]
-		points := model.NonNil(cs.Points)
 		manifestCorners = append(manifestCorners, model.ManifestCorner{
 			ID:       c.ID,
 			Title:    c.Title,
 			Summary:  cs.Summary,
-			Points:   points,
+			Points:   model.NonNil(cs.Points),
 			Articles: refs,
 		})
 	}

--- a/internal/model/slice.go
+++ b/internal/model/slice.go
@@ -1,0 +1,10 @@
+package model
+
+// NonNil returns s if s is non-nil, otherwise returns an empty non-nil slice.
+// Prevents JSON marshaling from producing null instead of [].
+func NonNil[S ~[]E, E any](s S) S {
+	if s == nil {
+		return make(S, 0)
+	}
+	return s
+}

--- a/internal/model/slice_test.go
+++ b/internal/model/slice_test.go
@@ -53,17 +53,6 @@ func TestNonNil(t *testing.T) {
 	}
 }
 
-func TestNonNil_int_slice(t *testing.T) {
-	var s []int
-	got := model.NonNil(s)
-	if got == nil {
-		t.Error("NonNil(nil []int) should not return nil")
-	}
-	if len(got) != 0 {
-		t.Errorf("NonNil(nil []int) len = %d, want 0", len(got))
-	}
-}
-
 func TestNonNil_nil_marshals_as_empty_array(t *testing.T) {
 	type wrapper struct {
 		Items []string `json:"items"`

--- a/internal/model/slice_test.go
+++ b/internal/model/slice_test.go
@@ -1,0 +1,80 @@
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+func TestNonNil(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		wantNil   bool
+		wantLen   int
+		wantItems []string
+	}{
+		{
+			name:    "nil slice returns non-nil empty slice",
+			input:   nil,
+			wantNil: false,
+			wantLen: 0,
+		},
+		{
+			name:    "non-nil empty slice returns non-nil empty slice",
+			input:   make([]string, 0),
+			wantNil: false,
+			wantLen: 0,
+		},
+		{
+			name:      "non-empty slice returns same content",
+			input:     []string{"a", "b", "c"},
+			wantNil:   false,
+			wantLen:   3,
+			wantItems: []string{"a", "b", "c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := model.NonNil(tt.input)
+			if (got == nil) != tt.wantNil {
+				t.Errorf("NonNil() nil = %v, want %v", got == nil, tt.wantNil)
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("NonNil() len = %d, want %d", len(got), tt.wantLen)
+			}
+			for i, item := range tt.wantItems {
+				if got[i] != item {
+					t.Errorf("NonNil()[%d] = %q, want %q", i, got[i], item)
+				}
+			}
+		})
+	}
+}
+
+func TestNonNil_int_slice(t *testing.T) {
+	var s []int
+	got := model.NonNil(s)
+	if got == nil {
+		t.Error("NonNil(nil []int) should not return nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("NonNil(nil []int) len = %d, want 0", len(got))
+	}
+}
+
+func TestNonNil_nil_marshals_as_empty_array(t *testing.T) {
+	type wrapper struct {
+		Items []string `json:"items"`
+	}
+	var s []string
+	w := wrapper{Items: model.NonNil(s)}
+	data, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if string(data) != `{"items":[]}` {
+		t.Errorf("NonNil nil result: got %s, want {\"items\":[]}", string(data))
+	}
+}

--- a/internal/rundown/rundown.go
+++ b/internal/rundown/rundown.go
@@ -144,16 +144,12 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 			if err != nil {
 				return model.Rundown{}, fmt.Errorf("summarize %q: %w", id, err)
 			}
-			points := sum.Points
-			if points == nil {
-				points = make([]string, 0)
-			}
 			rdArticles = append(rdArticles, model.RundownArticle{
 				DedupKey:  a.DedupKey,
 				URL:       a.URL,
 				Title:     a.Title,
 				Summary:   sum.Summary,
-				Points:    points,
+				Points:    model.NonNil(sum.Points),
 				Source:    a.Source,
 				Author:    a.Author,
 				Published: a.Published,
@@ -171,9 +167,7 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 	}
 
 	// キャストをセット
-	if casts == nil {
-		casts = make([]model.RundownCast, 0)
-	}
+	casts = model.NonNil(casts)
 	rd := model.Rundown{
 		Corners: rundownCorners,
 		Casts:   casts,

--- a/internal/rundown/select/select.go
+++ b/internal/rundown/select/select.go
@@ -122,9 +122,5 @@ func (s *LLMSelector) Select(ctx context.Context, corner config.CornerConfig, ar
 		return SelectResult{}, fmt.Errorf("unmarshal response: %w", err)
 	}
 
-	ids := resp.SelectedIDs
-	if ids == nil {
-		ids = make([]string, 0)
-	}
-	return SelectResult{SelectedIDs: ids, SelectionReason: resp.SelectionReason}, nil
+	return SelectResult{SelectedIDs: model.NonNil(resp.SelectedIDs), SelectionReason: resp.SelectionReason}, nil
 }

--- a/internal/script/summary/corner_summary.go
+++ b/internal/script/summary/corner_summary.go
@@ -89,10 +89,5 @@ func (s *LLMCornerSummarizer) SummarizeCorner(ctx context.Context, corner model.
 		return model.CornerSummary{}, fmt.Errorf("unmarshal response: %w", err)
 	}
 
-	points := resp.Points
-	if points == nil {
-		points = make([]string, 0)
-	}
-
-	return model.CornerSummary{Summary: resp.Summary, Points: points}, nil
+	return model.CornerSummary{Summary: resp.Summary, Points: model.NonNil(resp.Points)}, nil
 }

--- a/internal/script/summary/summary.go
+++ b/internal/script/summary/summary.go
@@ -133,13 +133,9 @@ func (s *LLMProgramSummarizer) Summarize(ctx context.Context, lines model.Script
 	}
 
 	// Normalize nil slices to empty slices so JSON marshals as [] not null.
-	if result.ConversationNotes == nil {
-		result.ConversationNotes = make([]model.ConversationNote, 0)
-	}
+	result.ConversationNotes = model.NonNil(result.ConversationNotes)
 	for i := range result.ConversationNotes {
-		if result.ConversationNotes[i].CharacterIDs == nil {
-			result.ConversationNotes[i].CharacterIDs = make([]string, 0)
-		}
+		result.ConversationNotes[i].CharacterIDs = model.NonNil(result.ConversationNotes[i].CharacterIDs)
 	}
 
 	return result, nil


### PR DESCRIPTION
関連タスク: [`nil-to-empty-slice` ガードを `nonNil[T]` ジェネリックヘルパーに集約](https://app.todoist.com/app/task/6gr2HcHvgJx9hG23)

## Summary

- `internal/model/slice.go` に `func NonNil[S ~[]E, E any](s S) S` を追加。nil スライスを空の非 nil スライスに変換し、JSON marshaling で `null` でなく `[]` が出力されることを保証する。
- `internal/manifest`, `internal/rundown`, `internal/cache`, `internal/script/summary` に散在していた `if x == nil { x = make([]T, 0) }` パターンを `model.NonNil()` 呼び出しに一本化。
- `internal/rundown/select` の同一パターンも同様に統一。

## Test plan

- [x] `go test ./internal/model/...` — `TestNonNil*` すべて通過
- [x] `go test ./internal/manifest/... ./internal/rundown/... ./internal/cache/... ./internal/script/summary/...` — 全パッケージ通過
- [x] `golangci-lint run ./internal/...` — 0 issues
- [x] `gofmt -l .` — 差分なし

---
🤖 Generated with [Claude Code](https://claude.ai/code)