### PR TITLE
refactor(config): ValidateEpisodeSpec* ラッパー関数を削除しテストをメソッド形式へ更新

### DIFF
--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -186,14 +186,14 @@ func TestInitCmd_GeneratedFilesLoadable(t *testing.T) {
 	if cfg.Slack.BotTokenEnv == "" {
 		t.Error("vox-radio.yaml template should have slack.bot_token_env set")
 	}
-	if err := config.ValidateEpisodeSpecProgram(spec); err != nil {
-		t.Fatalf("ValidateEpisodeSpecProgram failed (template must set program.id): %v", err)
+	if err := spec.ValidateProgram(); err != nil {
+		t.Fatalf("ValidateProgram failed (template must set program.id): %v", err)
 	}
-	if err := config.ValidateEpisodeSpecCast(spec); err != nil {
-		t.Fatalf("ValidateEpisodeSpecCast failed: %v", err)
+	if err := spec.ValidateCast(); err != nil {
+		t.Fatalf("ValidateCast failed: %v", err)
 	}
-	if err := config.ValidateEpisodeSpecAssets(spec); err != nil {
-		t.Fatalf("ValidateEpisodeSpecAssets failed: %v", err)
+	if err := spec.ValidateAssets(); err != nil {
+		t.Fatalf("ValidateAssets failed: %v", err)
 	}
 
 	// cache フィールドのアサート
@@ -258,17 +258,17 @@ func TestInitCmd_Sample_Loadable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEpisodeSpecStrict failed on sample: %v", err)
 	}
-	if err := config.ValidateEpisodeSpecAssets(spec); err != nil {
-		t.Fatalf("ValidateEpisodeSpecAssets failed on sample: %v", err)
+	if err := spec.ValidateAssets(); err != nil {
+		t.Fatalf("ValidateAssets failed on sample: %v", err)
 	}
-	if err := config.ValidateEpisodeSpecCast(spec); err != nil {
-		t.Fatalf("ValidateEpisodeSpecCast failed on sample: %v", err)
+	if err := spec.ValidateCast(); err != nil {
+		t.Fatalf("ValidateCast failed on sample: %v", err)
 	}
-	if err := config.ValidateEpisodeSpecCasts(spec, cfg.Characters); err != nil {
-		t.Fatalf("ValidateEpisodeSpecCasts failed on sample: %v", err)
+	if err := spec.ValidateCasts(cfg.Characters); err != nil {
+		t.Fatalf("ValidateCasts failed on sample: %v", err)
 	}
-	if err := config.ValidateEpisodeSpecCorners(spec); err != nil {
-		t.Fatalf("ValidateEpisodeSpecCorners failed on sample: %v", err)
+	if err := spec.ValidateCorners(); err != nil {
+		t.Fatalf("ValidateCorners failed on sample: %v", err)
 	}
 
 	// 毎回の放送コーナーの length_sec 合計が 300 秒（尺不変）であること。

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -258,17 +258,8 @@ func TestInitCmd_Sample_Loadable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEpisodeSpecStrict failed on sample: %v", err)
 	}
-	if err := spec.ValidateAssets(); err != nil {
-		t.Fatalf("ValidateAssets failed on sample: %v", err)
-	}
-	if err := spec.ValidateCast(); err != nil {
-		t.Fatalf("ValidateCast failed on sample: %v", err)
-	}
-	if err := spec.ValidateCasts(cfg.Characters); err != nil {
-		t.Fatalf("ValidateCasts failed on sample: %v", err)
-	}
-	if err := spec.ValidateCorners(); err != nil {
-		t.Fatalf("ValidateCorners failed on sample: %v", err)
+	if err := spec.Validate(cfg.Characters); err != nil {
+		t.Fatalf("Validate failed on sample: %v", err)
 	}
 
 	// 毎回の放送コーナーの length_sec 合計が 300 秒（尺不変）であること。

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -384,9 +384,9 @@ func TestValidateEpisodeSpecAssets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := config.ValidateEpisodeSpecAssets(tt.spec)
+			err := tt.spec.ValidateAssets()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateEpisodeSpecAssets() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("ValidateAssets() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -516,8 +516,8 @@ func TestLoadEpisodeSpec_ValidateEpisodeSpecAssetsIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadEpisodeSpec failed: %v", err)
 	}
-	if err := config.ValidateEpisodeSpecAssets(spec); err != nil {
-		t.Errorf("ValidateEpisodeSpecAssets failed on testdata spec: %v", err)
+	if err := spec.ValidateAssets(); err != nil {
+		t.Errorf("ValidateAssets failed on testdata spec: %v", err)
 	}
 }
 
@@ -745,7 +745,7 @@ func TestValidateEpisodeSpecCast_Valid(t *testing.T) {
 			{Title: "opening", Cast: map[string]string{"zundamon": "ボケ担当"}},
 		},
 	}
-	if err := config.ValidateEpisodeSpecCast(p); err != nil {
+	if err := p.ValidateCast(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -759,7 +759,7 @@ func TestValidateEpisodeSpecCast_UndeclaredCastKey(t *testing.T) {
 			{Title: "opening", Cast: map[string]string{"unknown_char": "司会"}},
 		},
 	}
-	if err := config.ValidateEpisodeSpecCast(p); err == nil {
+	if err := p.ValidateCast(); err == nil {
 		t.Error("expected error for corner cast key not declared in casts")
 	}
 }
@@ -885,7 +885,7 @@ func TestValidateEpisodeCondition_Offset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &config.EpisodeSpec{Casts: tt.casts}
-			err := config.ValidateEpisodeSpecCasts(p, chars)
+			err := p.ValidateCasts(chars)
 			if tt.wantErr && err == nil {
 				t.Errorf("expected error, got nil")
 			} else if !tt.wantErr && err != nil {
@@ -943,7 +943,7 @@ func TestValidateEpisodeSpecCasts_Valid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &config.EpisodeSpec{Casts: tt.casts}
-			if err := config.ValidateEpisodeSpecCasts(p, chars); err != nil {
+			if err := p.ValidateCasts(chars); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
@@ -1004,7 +1004,7 @@ func TestValidateEpisodeSpecCasts_Error(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &config.EpisodeSpec{Casts: tt.casts}
-			if err := config.ValidateEpisodeSpecCasts(p, chars); err == nil {
+			if err := p.ValidateCasts(chars); err == nil {
 				t.Errorf("expected error for %q, got nil", tt.name)
 			}
 		})
@@ -1220,15 +1220,15 @@ func TestLoadEpisodeSpec_ProgramID(t *testing.T) {
 
 func TestValidateEpisodeSpecProgram_EmptyID_Error(t *testing.T) {
 	p := &config.EpisodeSpec{Program: config.ProgramConfig{Title: "t", Description: "d"}}
-	if err := config.ValidateEpisodeSpecProgram(p); err == nil {
-		t.Error("ValidateEpisodeSpecProgram should error when program.id is empty")
+	if err := p.ValidateProgram(); err == nil {
+		t.Error("ValidateProgram should error when program.id is empty")
 	}
 }
 
 func TestValidateEpisodeSpecProgram_WithID_NoError(t *testing.T) {
 	p := &config.EpisodeSpec{Program: config.ProgramConfig{ID: "my-program", Title: "t", Description: "d"}}
-	if err := config.ValidateEpisodeSpecProgram(p); err != nil {
-		t.Errorf("ValidateEpisodeSpecProgram should not error when program.id is set: %v", err)
+	if err := p.ValidateProgram(); err != nil {
+		t.Errorf("ValidateProgram should not error when program.id is set: %v", err)
 	}
 }
 

--- a/internal/config/corners_test.go
+++ b/internal/config/corners_test.go
@@ -236,7 +236,7 @@ func TestValidateEpisodeSpecCorners_Valid(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &EpisodeSpec{Corners: tt.corners}
-			if err := ValidateEpisodeSpecCorners(p); err != nil {
+			if err := p.ValidateCorners(); err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
@@ -303,7 +303,7 @@ func TestValidateEpisodeSpecCorners_Error(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &EpisodeSpec{Corners: tt.corners}
-			if err := ValidateEpisodeSpecCorners(p); err == nil {
+			if err := p.ValidateCorners(); err == nil {
 				t.Errorf("expected error for %q, got nil", tt.name)
 			}
 		})

--- a/internal/config/episode_spec.go
+++ b/internal/config/episode_spec.go
@@ -108,11 +108,6 @@ func (p *EpisodeSpec) ValidateCasts(chars map[string]CharacterConfig) error {
 	return nil
 }
 
-// ValidateEpisodeSpecCasts は ValidateCasts の後方互換ラッパー。
-func ValidateEpisodeSpecCasts(p *EpisodeSpec, chars map[string]CharacterConfig) error {
-	return p.ValidateCasts(chars)
-}
-
 // ValidateCorners は corners の id・出現条件を検証する（キャラ不要・spec 内部整合のみ）。
 // id は必須かつ番組内で一意。title もユーザー向け表示用に重複を禁止する。
 func (p *EpisodeSpec) ValidateCorners() error {
@@ -139,11 +134,6 @@ func (p *EpisodeSpec) ValidateCorners() error {
 	return nil
 }
 
-// ValidateEpisodeSpecCorners は ValidateCorners の後方互換ラッパー。
-func ValidateEpisodeSpecCorners(p *EpisodeSpec) error {
-	return p.ValidateCorners()
-}
-
 // CornerSummaryLength returns the effective summary length (chars) for the corner matching title.
 // Falls back to DefaultCornerSummaryLength when the corner is not found or summary_length is unset.
 func (p *EpisodeSpec) CornerSummaryLength(title string) int {
@@ -164,11 +154,6 @@ func (p *EpisodeSpec) ValidateProgram() error {
 	return nil
 }
 
-// ValidateEpisodeSpecProgram は ValidateProgram の後方互換ラッパー。
-func ValidateEpisodeSpecProgram(p *EpisodeSpec) error {
-	return p.ValidateProgram()
-}
-
 // ValidateCast checks that every character ID in corners[].cast is declared in casts.
 // This ensures corner-only characters are forbidden, preventing rest-state leaks and typos.
 func (p *EpisodeSpec) ValidateCast() error {
@@ -180,11 +165,6 @@ func (p *EpisodeSpec) ValidateCast() error {
 		}
 	}
 	return nil
-}
-
-// ValidateEpisodeSpecCast は ValidateCast の後方互換ラッパー。
-func ValidateEpisodeSpecCast(p *EpisodeSpec) error {
-	return p.ValidateCast()
 }
 
 // ValidateAssets checks that corner-level audio/bgm keys reference existing assets.
@@ -207,11 +187,6 @@ func (p *EpisodeSpec) ValidateAssets() error {
 		}
 	}
 	return nil
-}
-
-// ValidateEpisodeSpecAssets は ValidateAssets の後方互換ラッパー。
-func ValidateEpisodeSpecAssets(p *EpisodeSpec) error {
-	return p.ValidateAssets()
 }
 
 // Validate はすべてのバリデーションを実行する単一エントリポイント。


### PR DESCRIPTION
関連タスク: [`ValidateEpisodeSpec*` ラッパー関数を削除してテストをメソッド形式へ更新する](https://app.todoist.com/app/task/6gr3xv9HJW4V3fQ3)

## Summary

- `episode_spec.go` から後方互換ラッパー関数5本を削除
  - `ValidateEpisodeSpecCasts` / `ValidateEpisodeSpecCorners` / `ValidateEpisodeSpecProgram` / `ValidateEpisodeSpecCast` / `ValidateEpisodeSpecAssets`
- テストの呼び出し箇所を `p.ValidateXxx()` メソッド形式へ更新
  - `internal/config/config_test.go`（10箇所）
  - `internal/config/corners_test.go`（2箇所）
  - `internal/cli/init_test.go`（7箇所 → `spec.Validate()` に集約して4箇所）
- `TestInitCmd_Sample_Loadable` で個別バリデーション4呼び出しを `spec.Validate(cfg.Characters)` に集約（`ValidateProgram` チェックも追加され網羅性が向上）

---
🤖 Generated with [Claude Code](https://claude.ai/code)