### PR TITLE
refactor(model): RundownArticle / ManifestCorner の Points 非 nil 保証をコンストラクタに移動する

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -207,11 +207,11 @@ func BuildEntryFromManifest(programID string, m model.Manifest, rd model.Rundown
 			}
 			if rda, ok := rdArticleByDedupKey[ar.DedupKey]; ok {
 				ae.Summary = rda.Summary
-				ae.Points = model.NonNil(rda.Points)
+				ae.Points = rda.Points
 			}
 			articles[j] = ae
 		}
-		corners[i] = CornerEntry{ID: mc.ID, Title: mc.Title, Summary: mc.Summary, Points: model.NonNil(mc.Points), Articles: articles}
+		corners[i] = CornerEntry{ID: mc.ID, Title: mc.Title, Summary: mc.Summary, Points: mc.Points, Articles: articles}
 	}
 
 	casts := make([]CastEntry, len(m.Casts))

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -449,7 +449,7 @@ func TestBuildEntryFromManifest_CornerPointsNeverNil(t *testing.T) {
 		Title:    "エピソード",
 		Datetime: "2026-06-01T00:00:00Z",
 		Corners: []model.ManifestCorner{
-			{Title: "コーナーA"},
+			model.NewManifestCorner("", "コーナーA", "", nil, nil),
 		},
 	}
 	rd := model.Rundown{}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -35,13 +35,9 @@ func Build(p BuildParams) model.Manifest {
 			refs = append(refs, model.ArticleRef{Title: a.Title, URL: a.URL})
 		}
 		cs := p.CornerSummaries[c.Title]
-		manifestCorners = append(manifestCorners, model.ManifestCorner{
-			ID:       c.ID,
-			Title:    c.Title,
-			Summary:  cs.Summary,
-			Points:   model.NonNil(cs.Points),
-			Articles: refs,
-		})
+		manifestCorners = append(manifestCorners, model.NewManifestCorner(
+			c.ID, c.Title, cs.Summary, cs.Points, refs,
+		))
 	}
 	return model.Manifest{
 		Title:             p.Program.Title,

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -60,6 +60,26 @@ func (p *ProgramSummary) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// NewManifestCorner creates a ManifestCorner with Points guaranteed non-nil.
+func NewManifestCorner(id, title, summary string, points []string, articles []ArticleRef) ManifestCorner {
+	return ManifestCorner{
+		ID: id, Title: title, Summary: summary,
+		Points: NonNil(points), Articles: articles,
+	}
+}
+
+// UnmarshalJSON implements json.Unmarshaler to normalize Points to a non-nil empty slice.
+func (c *ManifestCorner) UnmarshalJSON(data []byte) error {
+	type alias ManifestCorner
+	var raw alias
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*c = ManifestCorner(raw)
+	c.Points = NonNil(c.Points)
+	return nil
+}
+
 // ManifestCorner represents a corner in the manifest with its articles.
 type ManifestCorner struct {
 	ID       string       `json:"id"`

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -60,6 +60,15 @@ func (p *ProgramSummary) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// ManifestCorner represents a corner in the manifest with its articles.
+type ManifestCorner struct {
+	ID       string       `json:"id"`
+	Title    string       `json:"title"`
+	Summary  string       `json:"summary"`
+	Points   []string     `json:"points"`
+	Articles []ArticleRef `json:"articles"`
+}
+
 // NewManifestCorner creates a ManifestCorner with Points guaranteed non-nil.
 func NewManifestCorner(id, title, summary string, points []string, articles []ArticleRef) ManifestCorner {
 	return ManifestCorner{
@@ -78,15 +87,6 @@ func (c *ManifestCorner) UnmarshalJSON(data []byte) error {
 	*c = ManifestCorner(raw)
 	c.Points = NonNil(c.Points)
 	return nil
-}
-
-// ManifestCorner represents a corner in the manifest with its articles.
-type ManifestCorner struct {
-	ID       string       `json:"id"`
-	Title    string       `json:"title"`
-	Summary  string       `json:"summary"`
-	Points   []string     `json:"points"`
-	Articles []ArticleRef `json:"articles"`
 }
 
 // Manifest is the content manifest output alongside an mp3 episode.

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -940,6 +940,62 @@ func TestProgramSummary_UnmarshalJSON_NoteCharacterIDsNormalized(t *testing.T) {
 	}
 }
 
+func TestNewRundownArticle_NilPointsNormalized(t *testing.T) {
+	a := model.NewRundownArticle("k", "u", "t", "s", nil, "src", "au", "pub")
+	if a.Points == nil {
+		t.Error("Points should be non-nil after NewRundownArticle with nil")
+	}
+	if len(a.Points) != 0 {
+		t.Errorf("Points should be empty, got %v", a.Points)
+	}
+}
+
+func TestNewRundownArticle_NonNilPointsPreserved(t *testing.T) {
+	a := model.NewRundownArticle("k", "u", "t", "s", []string{"p1", "p2"}, "src", "au", "pub")
+	if len(a.Points) != 2 || a.Points[0] != "p1" {
+		t.Errorf("Points: got %v, want [p1 p2]", a.Points)
+	}
+}
+
+func TestRundownArticle_UnmarshalJSON_NilPointsNormalized(t *testing.T) {
+	data := []byte(`{"dedup_key":"k","title":"t","summary":"s","points":null}`)
+	var a model.RundownArticle
+	if err := json.Unmarshal(data, &a); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if a.Points == nil {
+		t.Error("Points should be non-nil after unmarshal with null")
+	}
+}
+
+func TestNewManifestCorner_NilPointsNormalized(t *testing.T) {
+	c := model.NewManifestCorner("id", "title", "summary", nil, nil)
+	if c.Points == nil {
+		t.Error("Points should be non-nil after NewManifestCorner with nil")
+	}
+	if len(c.Points) != 0 {
+		t.Errorf("Points should be empty, got %v", c.Points)
+	}
+}
+
+func TestNewManifestCorner_NonNilPointsPreserved(t *testing.T) {
+	c := model.NewManifestCorner("id", "title", "s", []string{"p1"}, nil)
+	if len(c.Points) != 1 || c.Points[0] != "p1" {
+		t.Errorf("Points: got %v, want [p1]", c.Points)
+	}
+}
+
+func TestManifestCorner_UnmarshalJSON_NilPointsNormalized(t *testing.T) {
+	data := []byte(`{"id":"id","title":"t","summary":"s","points":null,"articles":[]}`)
+	var c model.ManifestCorner
+	if err := json.Unmarshal(data, &c); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if c.Points == nil {
+		t.Error("Points should be non-nil after unmarshal with null")
+	}
+}
+
 func TestNewCornerSummary_NilPointsNormalized(t *testing.T) {
 	cs := model.NewCornerSummary("summary text", nil)
 	if cs.Points == nil {

--- a/internal/model/rundown.go
+++ b/internal/model/rundown.go
@@ -2,6 +2,17 @@ package model
 
 import "encoding/json"
 
+type RundownArticle struct {
+	DedupKey  string   `json:"dedup_key"`     // 重複判定キー（sha256:hex）
+	URL       string   `json:"url,omitempty"` // 表示用リンク（空可）
+	Title     string   `json:"title"`
+	Summary   string   `json:"summary"`
+	Points    []string `json:"points"`
+	Source    string   `json:"source,omitempty"`    // 媒体名
+	Author    string   `json:"author,omitempty"`    // 著者名
+	Published string   `json:"published,omitempty"` // 配信日時（RFC3339）
+}
+
 // NewRundownArticle creates a RundownArticle with Points guaranteed non-nil.
 func NewRundownArticle(dedupKey, url, title, summary string, points []string, source, author, published string) RundownArticle {
 	return RundownArticle{
@@ -20,17 +31,6 @@ func (a *RundownArticle) UnmarshalJSON(data []byte) error {
 	*a = RundownArticle(raw)
 	a.Points = NonNil(a.Points)
 	return nil
-}
-
-type RundownArticle struct {
-	DedupKey  string   `json:"dedup_key"`     // 重複判定キー（sha256:hex）
-	URL       string   `json:"url,omitempty"` // 表示用リンク（空可）
-	Title     string   `json:"title"`
-	Summary   string   `json:"summary"`
-	Points    []string `json:"points"`
-	Source    string   `json:"source,omitempty"`    // 媒体名
-	Author    string   `json:"author,omitempty"`    // 著者名
-	Published string   `json:"published,omitempty"` // 配信日時（RFC3339）
 }
 
 type RundownCorner struct {

--- a/internal/model/rundown.go
+++ b/internal/model/rundown.go
@@ -1,5 +1,27 @@
 package model
 
+import "encoding/json"
+
+// NewRundownArticle creates a RundownArticle with Points guaranteed non-nil.
+func NewRundownArticle(dedupKey, url, title, summary string, points []string, source, author, published string) RundownArticle {
+	return RundownArticle{
+		DedupKey: dedupKey, URL: url, Title: title, Summary: summary,
+		Points: NonNil(points), Source: source, Author: author, Published: published,
+	}
+}
+
+// UnmarshalJSON implements json.Unmarshaler to normalize Points to a non-nil empty slice.
+func (a *RundownArticle) UnmarshalJSON(data []byte) error {
+	type alias RundownArticle
+	var raw alias
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	*a = RundownArticle(raw)
+	a.Points = NonNil(a.Points)
+	return nil
+}
+
 type RundownArticle struct {
 	DedupKey  string   `json:"dedup_key"`     // 重複判定キー（sha256:hex）
 	URL       string   `json:"url,omitempty"` // 表示用リンク（空可）

--- a/internal/rundown/rundown.go
+++ b/internal/rundown/rundown.go
@@ -144,16 +144,10 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 			if err != nil {
 				return model.Rundown{}, fmt.Errorf("summarize %q: %w", id, err)
 			}
-			rdArticles = append(rdArticles, model.RundownArticle{
-				DedupKey:  a.DedupKey,
-				URL:       a.URL,
-				Title:     a.Title,
-				Summary:   sum.Summary,
-				Points:    model.NonNil(sum.Points),
-				Source:    a.Source,
-				Author:    a.Author,
-				Published: a.Published,
-			})
+			rdArticles = append(rdArticles, model.NewRundownArticle(
+				a.DedupKey, a.URL, a.Title, sum.Summary, sum.Points,
+				a.Source, a.Author, a.Published,
+			))
 		}
 
 		rundownCorners = append(rundownCorners, model.RundownCorner{


### PR DESCRIPTION
関連タスク: [RundownArticle / ManifestCorner の Points 非 nil 保証をコンストラクタに移動する](https://app.todoist.com/app/task/6gr5727X9p64G6j3)

## Summary

- `model.RundownArticle` に `NewRundownArticle` コンストラクタと `UnmarshalJSON` を追加し、`Points` の非 nil 保証を型が持つようにした
- `model.ManifestCorner` に `NewManifestCorner` コンストラクタと `UnmarshalJSON` を追加し、同様に `Points` の非 nil 保証を型が持つようにした
- 消費側（`rundown.go` / `manifest.go` / `cache.go`）の `model.NonNil` ガードを除去した
- `CornerSummary` / `ConversationNote` / `ProgramSummary` と同じパターンに統一

---
🤖 Generated with [Claude Code](https://claude.ai/code)