### PR TITLE
fix(release): install.sh を dist 外で生成しリリース公開失敗を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ go.work.sum
 
 # GoReleaser
 /dist/
+/.extra-files/
 
 # 一時ファイル
 .tmp/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,8 +3,10 @@ version: 2
 
 before:
   hooks:
-    - mkdir -p dist
-    - sed 's/__VERSION__/{{ .Tag }}/g' scripts/install.sh > dist/install.sh
+    # GoReleaser の before hook はシェルを介さず実行されるためリダイレクトが効かない。
+    # また dist 配下は hook 後の空チェックに引っかかるため、dist の外へ出力する。
+    - mkdir -p .extra-files
+    - sh -c "sed 's/__VERSION__/{{ .Tag }}/g' scripts/install.sh > .extra-files/install.sh"
 
 builds:
   - id: vox-radio
@@ -43,7 +45,7 @@ changelog:
 
 release:
   extra_files:
-    - glob: dist/install.sh
+    - glob: .extra-files/install.sh
   footer: >-
 
     ---


### PR DESCRIPTION
## 概要

v0.0.16 のリリースCI（`version-tagging` → `goreleaser`）が publish 段階で失敗していた問題を修正します。

```
⨯ release failed: scm releases: failed to publish artifacts:
  globbing failed for pattern dist/install.sh:
  matching "./dist/install.sh": file does not exist
```

## 原因

`.goreleaser.yaml` の `before.hooks` で `dist/install.sh` を生成する想定だったが、以下2点により機能していなかった。

1. **GoReleaser の before hook はシェルを介さず実行される** → `sed ... > dist/install.sh` の `>` がリダイレクトされず（`sed` の引数として渡され）、`install.sh` が生成されない。エラーも出ないまま publish に進み、`extra_files` の glob が "file does not exist" で失敗していた。
2. 仮に `sh -c` でリダイレクトを有効化しても、**`dist/` 配下は before hook 後の「dist が空」チェックに引っかかり** `dist is not empty` で失敗する。

※ 直前の v0.0.15 はこの仕組み（PR #402）が無かったため成功していた。

## 修正内容

- before hook を `sh -c` でラップしてリダイレクトを有効化
- 生成先を `dist/` の外（`.extra-files/`）へ変更し、空チェックを回避
- `extra_files` の glob も `.extra-files/install.sh` に追従
- `.gitignore` に `/.extra-files/` を追加

## 検証

実機 goreleaser v2.16.0 で、本ブランチの設定そのままを使い `release --clean --skip=publish,sign` を実行し、`release succeeded` を確認。`.extra-files/install.sh` が `VERSION="v0.0.16"` 置換済みで生成され、`dist is not empty` / `file does not exist` ともに発生しないことを確認済み。

## マージ後の運用対応（別途必要）

- [ ] 失敗時に残ったドラフトリリース `untagged-5802e869b8fcd6333495` の削除
- [ ] タグ `v0.0.16` の再リリース（`goreleaser` 再実行）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDwb6wz2s2MtAMGCPkfoNN)_