### PR TITLE
fix(manifest): ArticleRef に DedupKey を転記する

### DIFF
--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -32,7 +32,7 @@ func Build(p BuildParams) model.Manifest {
 		rc := cornerMap[c.ID]
 		refs := make([]model.ArticleRef, 0, len(rc.Articles))
 		for _, a := range rc.Articles {
-			refs = append(refs, model.ArticleRef{Title: a.Title, URL: a.URL})
+			refs = append(refs, model.ArticleRef{DedupKey: a.DedupKey, Title: a.Title, URL: a.URL})
 		}
 		cs := p.CornerSummaries[c.Title]
 		manifestCorners = append(manifestCorners, model.NewManifestCorner(

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -355,23 +355,18 @@ func TestBuild_EpisodeNumberAndTitle(t *testing.T) {
 }
 
 func TestBuild_DedupKeyCopiedToArticleRef(t *testing.T) {
-	corners := []config.CornerConfig{
+	p := newMinimalBuildParams()
+	p.Corners = []config.CornerConfig{
 		{ID: "opening", Title: "オープニング"},
 		{ID: "tech", Title: "今日のテックニュース"},
 	}
-	p := manifest.BuildParams{
-		Program:     config.ProgramConfig{Title: "テスト番組", Description: "説明"},
-		Corners:     corners,
-		AudioFile:   "episode.mp3",
-		GeneratedAt: fixedTime,
-		Rundown: model.Rundown{
-			Corners: []model.RundownCorner{
-				{
-					ID:    "tech",
-					Title: "今日のテックニュース",
-					Articles: []model.RundownArticle{
-						{DedupKey: "sha256:abc123", URL: "https://example.com/1", Title: "記事1", Points: []string{}},
-					},
+	p.Rundown = model.Rundown{
+		Corners: []model.RundownCorner{
+			{
+				ID:    "tech",
+				Title: "今日のテックニュース",
+				Articles: []model.RundownArticle{
+					{DedupKey: "sha256:abc123", URL: "https://example.com/1", Title: "記事1", Points: []string{}},
 				},
 			},
 		},

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -239,6 +239,7 @@ func TestBuild(t *testing.T) {
 			t.Errorf("ConversationNotes: got %d, want 0", len(got.ConversationNotes))
 		}
 	})
+
 }
 
 func TestBuild_CastsCopiedFromRundown(t *testing.T) {
@@ -351,4 +352,36 @@ func TestBuild_EpisodeNumberAndTitle(t *testing.T) {
 			t.Errorf("Title = %q, want テスト番組", got.Title)
 		}
 	})
+}
+
+func TestBuild_DedupKeyCopiedToArticleRef(t *testing.T) {
+	corners := []config.CornerConfig{
+		{ID: "opening", Title: "オープニング"},
+		{ID: "tech", Title: "今日のテックニュース"},
+	}
+	p := manifest.BuildParams{
+		Program:     config.ProgramConfig{Title: "テスト番組", Description: "説明"},
+		Corners:     corners,
+		AudioFile:   "episode.mp3",
+		GeneratedAt: fixedTime,
+		Rundown: model.Rundown{
+			Corners: []model.RundownCorner{
+				{
+					ID:    "tech",
+					Title: "今日のテックニュース",
+					Articles: []model.RundownArticle{
+						{DedupKey: "sha256:abc123", URL: "https://example.com/1", Title: "記事1", Points: []string{}},
+					},
+				},
+			},
+		},
+	}
+	got := manifest.Build(p)
+	techCorner := got.Corners[1]
+	if len(techCorner.Articles) != 1 {
+		t.Fatalf("Articles count = %d, want 1", len(techCorner.Articles))
+	}
+	if techCorner.Articles[0].DedupKey != "sha256:abc123" {
+		t.Errorf("Articles[0].DedupKey = %q, want %q", techCorner.Articles[0].DedupKey, "sha256:abc123")
+	}
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -239,7 +239,6 @@ func TestBuild(t *testing.T) {
 			t.Errorf("ConversationNotes: got %d, want 0", len(got.ConversationNotes))
 		}
 	})
-
 }
 
 func TestBuild_CastsCopiedFromRundown(t *testing.T) {


### PR DESCRIPTION
関連タスク: [manifest.Build で ArticleRef.DedupKey が転記されず空になるバグを修正](https://app.todoist.com/app/task/6gr779wXm2M7fxh3)

## Summary

- `internal/manifest/manifest.go` の `Build` 関数で `ArticleRef` を組み立てる際、`RundownArticle.DedupKey` がコピーされておらず、マニフェストの `articles[].dedup_key` が常に空文字になっていたバグを修正
- 過去記事の重複除外（`cache.PastDedupKeys`）とキャッシュへの Summary/Points 転記が連鎖的に機能しなくなる問題を解消
- `TestBuild_DedupKeyCopiedToArticleRef` テストを TDD（RED → GREEN）で追加

## Test plan

- [x] `TestBuild_DedupKeyCopiedToArticleRef`: DedupKey が ArticleRef に転記されることを直接検証
- [x] 既存の manifest テスト全件 PASS
- [x] `gofmt -l .` → 出力なし
- [x] `golangci-lint run ./internal/manifest/...` → 0 issues

---
🤖 Generated with [Claude Code](https://claude.ai/code)