### PR TITLE
feat(config+collect): file:// プロトコルで手動DLした feed.xml をローカル読み込み可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ collect → rundown → script → synth → assemble → manifest
 | `init` | カレントディレクトリに `vox-radio.yaml`・`episode-spec.yaml`・`feed-spec.yaml`・`slack-spec.yaml`・`assets/assets.yaml` のテンプレートを生成する（初回セットアップ用）。`--sample` を付けると、ずんだもん・めたんMCのお天気番組（気象庁の防災情報XMLを利用）の「すぐ動くサンプル設定一式」を `sample/` に生成する |
 | `install --skills` | LLM エージェント向けスキルファイル（SKILL.md + references/*.md）を `.claude/skills/vox-radio/` にインストールする |
 | `episodegen` | collect → rundown → script → synth → assemble → manifest の全パイプラインを一括実行し 1 本のエピソードを生成する |
-| `episodegen collect` | `corners[].source` に定義したフィード・URL からコーナーごとに記事を収集し `01_articles.json` を生成する |
+| `episodegen collect` | `corners[].source` に定義したフィード・URL からコーナーごとに記事を収集し `01_articles.json` を生成する。`https://` のほか `file://` でローカル XML ファイルも指定可能（アクセス制限がある場合に手動 DL した feed.xml をローカルから読み込む運用に対応） |
 | `episodegen rundown` | LLM が収集記事を選別し、コーナーごとの話の流れと要約を含む `02_rundown.json` を生成する（番組設計図） |
 | `episodegen script` | rundown を LLM に渡して台本 `04_script.json` を生成する（write → direct の多段パイプライン） |
 | `episodegen synth` | `04_script.json` をもとに VOICEVOX で音声クリップを合成する |

--- a/internal/cli/skills/vox-radio/references/episode-spec.md
+++ b/internal/cli/skills/vox-radio/references/episode-spec.md
@@ -120,14 +120,40 @@ corners:
 | フィールド | 型 | 必須/任意 | 説明 |
 |---|---|---|---|
 | `feeds` | []FeedEntry | 任意 | RSS/Atom フィードのリスト |
-| `articles` | []string | 任意 | 個別記事 URL のリスト |
+| `articles` | []string | 任意 | 個別記事 URL のリスト。`https://` のほか `file://` によるローカルファイル指定も可能（後述） |
 
 ### `corners[].source.feeds[]` サブフィールド
 
 | フィールド | 型 | 必須/任意 | 説明 |
 |---|---|---|---|
-| `url` | string | 必須 | フィードの URL |
+| `url` | string | 必須 | フィードの URL。`https://` のほか `file://` によるローカルファイル指定も可能（後述） |
 | `max_items` | int | 任意 | 過去使用URLを除外したうえで確保する最大記事数。デフォルト: 0（実質無制限）。除外で減った分はフィード内の後続記事で補う。 |
+
+### `file://` プロトコルによるローカルフィード・記事の読み込み
+
+アクセス制限などで RSS/Atom フィードに直接アクセスできない場合、手動ダウンロードした XML ファイルをローカルから読み込めます。`feeds[].url` および `articles[]` に `file://` プロトコルを使ったパスを指定します。
+
+**絶対パス指定**（そのまま使用）:
+
+```yaml
+source:
+  feeds:
+    - url: "file:///home/user/downloads/feed.xml"
+```
+
+**相対パス指定**（spec ファイルのディレクトリを基準に解決）:
+
+```yaml
+# /home/user/myshow/episode-spec.yaml に記述した場合、
+# /home/user/myshow/feeds/feed.xml を読み込む
+source:
+  feeds:
+    - url: "file://feeds/feed.xml"
+  articles:
+    - "file://articles/article.html"
+```
+
+> **注意**: ファイルが存在しない場合は `episodegen collect` 実行時にエラーになります。
 
 ## `casts` セクション（出演者名簿）
 

--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -40,10 +40,13 @@ func WithSanitizePolicy(p config.PromptInjectionConfig) Option {
 }
 
 // New creates a Collector. If client is nil, a client with retry-enabled
-// transport (exponential backoff on 5xx/429) is used.
+// transport (exponential backoff on 5xx/429) is used. The default client
+// also supports file:// URLs for loading locally saved feed/article files.
 func New(client *http.Client, opts ...Option) *Collector {
 	if client == nil {
-		client = httpretry.NewClient(0)
+		base := http.DefaultTransport.(*http.Transport).Clone()
+		base.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+		client = &http.Client{Transport: httpretry.NewTransport(base)}
 	}
 	c := &Collector{
 		client: client,

--- a/internal/collect/collect_test.go
+++ b/internal/collect/collect_test.go
@@ -853,3 +853,89 @@ func TestCollector_Run_RSS_OnDetectError_ReturnsError(t *testing.T) {
 		t.Error("on_detect=error should return error when injection detected")
 	}
 }
+
+func TestNew_DefaultClient_FileProtocol_Feed(t *testing.T) {
+	feedData := loadTestdata(t, "feed.xml")
+	tmp, err := os.CreateTemp("", "test-feed-*.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(feedData); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	cfg := config.FeedsConfig{
+		Feeds: []config.FeedEntry{{URL: "file://" + tmp.Name(), MaxItems: 1}},
+	}
+
+	c := collect.New(nil)
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error reading feed via file://: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected at least 1 article from local file feed")
+	}
+}
+
+func TestNew_DefaultClient_FileProtocol_Article(t *testing.T) {
+	htmlData := loadTestdata(t, "article.html")
+	tmp, err := os.CreateTemp("", "test-article-*.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(htmlData); err != nil {
+		t.Fatal(err)
+	}
+	tmp.Close()
+
+	cfg := config.FeedsConfig{
+		Articles: []string{"file://" + tmp.Name()},
+	}
+
+	c := collect.New(nil)
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error reading article via file://: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected 1 article from local HTML file")
+	}
+}
+
+func TestNew_DefaultClient_FileProtocol_MissingFile(t *testing.T) {
+	cfg := config.FeedsConfig{
+		Feeds: []config.FeedEntry{{URL: "file:///nonexistent/path/feed.xml", MaxItems: 1}},
+	}
+
+	c := collect.New(nil)
+	_, err := c.Run(context.Background(), cfg, nil)
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestNew_DefaultClient_HTTPS_StillWorks(t *testing.T) {
+	rssData := loadTestdata(t, "feed.xml")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write(rssData)
+	}))
+	defer server.Close()
+
+	cfg := config.FeedsConfig{
+		Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 1}},
+	}
+
+	c := collect.New(server.Client())
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("http:// feed should still work after file transport registration: %v", err)
+	}
+	if len(result) == 0 {
+		t.Error("expected at least 1 article from http feed")
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1948,3 +1948,63 @@ func TestLoadConfig_ValidationError_FieldPathPresent(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadEpisodeSpec_FileURLResolution(t *testing.T) {
+	spec, err := config.LoadEpisodeSpec("testdata/episode_spec_file_url.yaml")
+	if err != nil {
+		t.Fatalf("LoadEpisodeSpec failed: %v", err)
+	}
+
+	var sourceCorner *config.CornerConfig
+	for i := range spec.Corners {
+		if spec.Corners[i].Source != nil {
+			sourceCorner = &spec.Corners[i]
+			break
+		}
+	}
+	if sourceCorner == nil {
+		t.Fatal("no corner with source found")
+	}
+
+	absTestdata, err := filepath.Abs("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	feeds := sourceCorner.Source.Feeds
+	if len(feeds) < 3 {
+		t.Fatalf("expected 3 feeds, got %d", len(feeds))
+	}
+
+	// relative file:// URL resolved to specDir-based absolute
+	wantRelFeed := "file://" + filepath.Join(absTestdata, "feeds/feed.xml")
+	if feeds[0].URL != wantRelFeed {
+		t.Errorf("feeds[0].URL (relative file://): got %q, want %q", feeds[0].URL, wantRelFeed)
+	}
+
+	// absolute file:// URL stays as-is
+	if feeds[1].URL != "file:///abs/feed.xml" {
+		t.Errorf("feeds[1].URL (absolute file://): got %q, want %q", feeds[1].URL, "file:///abs/feed.xml")
+	}
+
+	// https:// passthrough
+	if feeds[2].URL != "https://example.com/rss.xml" {
+		t.Errorf("feeds[2].URL (https://): got %q, want %q", feeds[2].URL, "https://example.com/rss.xml")
+	}
+
+	articles := sourceCorner.Source.Articles
+	if len(articles) < 2 {
+		t.Fatalf("expected 2 articles, got %d", len(articles))
+	}
+
+	// relative file:// article URL resolved
+	wantRelArticle := "file://" + filepath.Join(absTestdata, "articles/article.html")
+	if articles[0] != wantRelArticle {
+		t.Errorf("articles[0] (relative file://): got %q, want %q", articles[0], wantRelArticle)
+	}
+
+	// https:// article passthrough
+	if articles[1] != "https://example.com/articles/1" {
+		t.Errorf("articles[1] (https://): got %q, want %q", articles[1], "https://example.com/articles/1")
+	}
+}

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -42,7 +42,8 @@ func LoadConfigStrict(path string) (*Config, error) {
 }
 
 // LoadEpisodeSpec loads episode-specific settings from the given YAML file path.
-// Relative asset file paths are resolved relative to the spec file's directory.
+// Relative asset file paths and file:// URLs in corners[].source are resolved
+// relative to the spec file's directory.
 func LoadEpisodeSpec(path string) (*EpisodeSpec, error) {
 	return loadEpisodeSpecWith(path, false)
 }
@@ -86,7 +87,8 @@ func loadEpisodeSpecWith(path string, strict bool) (*EpisodeSpec, error) {
 
 // LoadEpisodeSpecStrict loads episode-specific settings from the given YAML file path with strict parsing.
 // Unknown keys in the YAML will cause an error (detects typos).
-// Relative asset file paths are resolved relative to the spec file's directory.
+// Relative asset file paths and file:// URLs in corners[].source are resolved
+// relative to the spec file's directory.
 func LoadEpisodeSpecStrict(path string) (*EpisodeSpec, error) {
 	return loadEpisodeSpecWith(path, true)
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -61,6 +61,26 @@ func loadEpisodeSpecWith(path string, strict bool) (*EpisodeSpec, error) {
 		}
 		mergeAssets(&p.Assets, &assets)
 	}
+	for i := range p.Corners {
+		corner := &p.Corners[i]
+		if corner.Source == nil {
+			continue
+		}
+		for j := range corner.Source.Feeds {
+			resolved, err := resolveFileURL(specDir, corner.Source.Feeds[j].URL)
+			if err != nil {
+				return nil, err
+			}
+			corner.Source.Feeds[j].URL = resolved
+		}
+		for j, article := range corner.Source.Articles {
+			resolved, err := resolveFileURL(specDir, article)
+			if err != nil {
+				return nil, err
+			}
+			corner.Source.Articles[j] = resolved
+		}
+	}
 	return p, nil
 }
 

--- a/internal/config/source_url.go
+++ b/internal/config/source_url.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+)
+
+// resolveFileURL normalizes a file:// URL to an absolute file:// URL.
+// Relative paths within file:// URLs are resolved relative to specDir.
+// Non-file scheme URLs are returned as-is.
+func resolveFileURL(specDir, raw string) (string, error) {
+	if raw == "" {
+		return raw, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse URL %q: %w", raw, err)
+	}
+	if u.Scheme != "file" {
+		return raw, nil
+	}
+
+	// For file://host/path, u.Host + u.Path reconstructs the local path.
+	// For file:///abs/path, u.Host is empty and u.Path is the absolute path.
+	localPath := u.Host + u.Path
+
+	resolved := resolveFile(specDir, localPath)
+
+	absPath, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolve file URL %q: %w", raw, err)
+	}
+
+	return "file://" + absPath, nil
+}

--- a/internal/config/source_url_test.go
+++ b/internal/config/source_url_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestResolveFileURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		specDir string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "https URL passthrough",
+			specDir: "/cfg",
+			raw:     "https://example.com/feed.xml",
+			want:    "https://example.com/feed.xml",
+		},
+		{
+			name:    "http URL passthrough",
+			specDir: "/cfg",
+			raw:     "http://example.com/feed.xml",
+			want:    "http://example.com/feed.xml",
+		},
+		{
+			name:    "absolute file URL stays as-is",
+			specDir: "/cfg",
+			raw:     "file:///abs/x.xml",
+			want:    "file:///abs/x.xml",
+		},
+		{
+			name:    "relative file URL resolved against specDir",
+			specDir: "/cfg",
+			raw:     "file://feeds/x.xml",
+			want:    "file:///cfg/feeds/x.xml",
+		},
+		{
+			name:    "relative file URL with deeper path",
+			specDir: "/home/user/spec",
+			raw:     "file://subdir/feed.xml",
+			want:    "file:///home/user/spec/subdir/feed.xml",
+		},
+		{
+			name:    "empty string passthrough",
+			specDir: "/cfg",
+			raw:     "",
+			want:    "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveFileURL(tt.specDir, tt.raw)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resolveFileURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("resolveFileURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/testdata/episode_spec_file_url.yaml
+++ b/internal/config/testdata/episode_spec_file_url.yaml
@@ -1,0 +1,26 @@
+program:
+  id: "test-program-file"
+
+casts:
+  zundamon:
+    type: regular
+    role: "MC"
+
+corners:
+  - id: "news"
+    title: "ニュースコーナー"
+    content: "テック記事を紹介"
+    cast:
+      zundamon: "司会"
+    length_sec: 30
+    source:
+      feeds:
+        - url: "file://feeds/feed.xml"
+          max_items: 3
+        - url: "file:///abs/feed.xml"
+          max_items: 3
+        - url: "https://example.com/rss.xml"
+          max_items: 3
+      articles:
+        - "file://articles/article.html"
+        - "https://example.com/articles/1"


### PR DESCRIPTION
関連タスク: [入力feed/記事URLで file:// プロトコルをサポート（手動DLしたfeed.xmlをローカル読み込み）](https://app.todoist.com/app/task/6grC9j755JhRQP3V)

## Summary

- `internal/config/source_url.go`（新規）: `resolveFileURL` ヘルパーを追加。`file://` 相対パスを spec ファイルのディレクトリ基準の絶対 `file://` URL に正規化（`https://` 等は素通し）
- `internal/config/load.go`: `loadEpisodeSpecWith` で `corners[].source` の `Feeds[].URL` / `Articles[]` を `file://` 絶対化
- `internal/collect/collect.go`: `New(nil)` 時のデフォルト client に `file://` 対応 Transport を追加（`DefaultTransport.Clone` + `RegisterProtocol("file", ...)` + httpretry ラップ）
- docs: README と `episode-spec.md` references に `file://` 運用（絶対パス・spec ファイル基準の相対パス）を追記

## 設計のポイント

- **相対→絶対変換は spec ローダで行う**。`file://feeds/x.xml`（Host="feeds"）を `spec ファイルのディレクトリ / feeds/x.xml` として解決し、collector には常に絶対 `file://` URL が渡る
- **collector は file スキームを読める Transport を持つだけ**。`fetchFeed` / `fetchArticle` の変更不要
- `http.DefaultTransport` はグローバルなので `.Clone()` してから `RegisterProtocol` する（グローバル破壊なし）

---

🤖 Generated with [Claude Code](https://claude.ai/code)