### PR TITLE
refactor(collect): フィード関連の警告ログでURLの代わりにフィード名を表示

### DIFF
--- a/internal/collect/collect_test.go
+++ b/internal/collect/collect_test.go
@@ -249,6 +249,38 @@ func TestCollector_Run_WarnOnEmptyFeed(t *testing.T) {
 	}
 }
 
+func TestCollector_Run_WarnFallsBackToURLWhenFeedTitleEmpty(t *testing.T) {
+	// フィード名（title）が空のフィードでは、ログにURLをフォールバック表示する
+	noTitleFeed := `<?xml version="1.0"?><rss version="2.0"><channel></channel></rss>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(noTitleFeed))
+	}))
+	defer server.Close()
+
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	feedURL := server.URL + "/no-title.xml"
+	cfg := config.FeedsConfig{
+		Feeds: []config.FeedEntry{
+			{URL: feedURL, MaxItems: 5},
+		},
+	}
+
+	c := collect.New(server.Client(), collect.WithLogger(logger))
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("expected no error for no-title feed, got: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("articles count: got %d, want 0", len(result))
+	}
+	if !strings.Contains(buf.String(), feedURL) {
+		t.Errorf("expected URL fallback in log when feed title is empty, got: %q", buf.String())
+	}
+}
+
 func TestCollector_Run_ExcludesURLsAndFillsFromLater(t *testing.T) {
 	// feed.xml has 3 articles: article/1, article/2, article/3
 	// Exclude article/1 by DedupKey; with maxItems=2 should return article/2 and article/3

--- a/internal/collect/collect_test.go
+++ b/internal/collect/collect_test.go
@@ -318,6 +318,13 @@ func TestCollector_Run_WarnWhenInsufficientNonExcludedArticles(t *testing.T) {
 	if !strings.Contains(buf.String(), "WARN") {
 		t.Errorf("expected WARN log for insufficient articles, got: %q", buf.String())
 	}
+	// ログにはURLではなくフィード名を表示する（feed.xml のチャンネルタイトル）
+	if !strings.Contains(buf.String(), "テストフィード") {
+		t.Errorf("expected feed name in log, got: %q", buf.String())
+	}
+	if strings.Contains(buf.String(), feedURL) {
+		t.Errorf("expected feed name instead of URL in log, but URL was present: %q", buf.String())
+	}
 }
 
 func TestCollector_Run_UnlimitedWithExcludedDedupKeys(t *testing.T) {

--- a/internal/collect/collect_test.go
+++ b/internal/collect/collect_test.go
@@ -240,6 +240,13 @@ func TestCollector_Run_WarnOnEmptyFeed(t *testing.T) {
 	if !strings.Contains(buf.String(), "WARN") {
 		t.Errorf("expected WARN log for empty feed, got: %q", buf.String())
 	}
+	// ログにはURLではなくフィード名を表示する（emptyFeed のチャンネルタイトル）
+	if !strings.Contains(buf.String(), "Empty") {
+		t.Errorf("expected feed name in log, got: %q", buf.String())
+	}
+	if strings.Contains(buf.String(), cfg.Feeds[0].URL) {
+		t.Errorf("expected feed name instead of URL in log, but URL was present: %q", buf.String())
+	}
 }
 
 func TestCollector_Run_ExcludesURLsAndFillsFromLater(t *testing.T) {

--- a/internal/collect/rss.go
+++ b/internal/collect/rss.go
@@ -22,6 +22,13 @@ func (c *Collector) fetchFeed(ctx context.Context, url string, maxItems int, exc
 
 	source := feed.Title
 
+	// ログ表示用のフィード識別子。どのフィードか分かりやすいよう、URLではなく
+	// フィード名を表示する。フィード名が空のフィードもあるためURLにフォールバックする。
+	feedName := source
+	if feedName == "" {
+		feedName = url
+	}
+
 	articles := make([]model.Article, 0, len(feed.Items))
 	for _, item := range feed.Items {
 		body := item.Content
@@ -59,17 +66,11 @@ func (c *Collector) fetchFeed(ctx context.Context, url string, maxItems int, exc
 	}
 
 	if len(articles) == 0 {
-		c.logger.Warn("feed returned 0 items", "url", url)
+		c.logger.Warn("feed returned 0 items", "feed", feedName)
 		return articles, nil
 	}
 
 	if maxItems > 0 && len(articles) < maxItems {
-		// どのフィードか分かりやすいよう、URLではなくフィード名を表示する。
-		// フィード名が空のフィードもあるため、その場合はURLにフォールバックする。
-		feedName := source
-		if feedName == "" {
-			feedName = url
-		}
 		c.logger.Warn("フィードの未使用記事が不足", "feed", feedName, "got", len(articles), "want", maxItems)
 	}
 

--- a/internal/collect/rss.go
+++ b/internal/collect/rss.go
@@ -64,7 +64,13 @@ func (c *Collector) fetchFeed(ctx context.Context, url string, maxItems int, exc
 	}
 
 	if maxItems > 0 && len(articles) < maxItems {
-		c.logger.Warn("フィードの未使用記事が不足", "url", url, "got", len(articles), "want", maxItems)
+		// どのフィードか分かりやすいよう、URLではなくフィード名を表示する。
+		// フィード名が空のフィードもあるため、その場合はURLにフォールバックする。
+		feedName := source
+		if feedName == "" {
+			feedName = url
+		}
+		c.logger.Warn("フィードの未使用記事が不足", "feed", feedName, "got", len(articles), "want", maxItems)
 	}
 
 	return articles, nil


### PR DESCRIPTION
## Summary

`internal/collect/rss.go` のフィード関連の警告ログで、`url`（URL）ではなく**フィード名**（`feed.Title`）を表示するようにしました。ログを見たときにどのフィードかぱっと見で分かりやすくなります。

対象ログ:
- `フィードの未使用記事が不足`
- `feed returned 0 items`（0件フィード）

```
変更前: msg=フィードの未使用記事が不足 url=http://.../feed.xml got=1 want=3
変更後: msg=フィードの未使用記事が不足 feed=テストフィード got=1 want=3
```

## 実装メモ

- フィード名フォールバック（フィード名が空のフィードでは `url` にフォールバック）のロジックを `fetchFeed` 冒頭に抽出し、2つのログで共用しています。
- フィード名が空のときに `url` がフォールバック表示されることをテストで固定しています。

## テスト

- `go test ./internal/collect/` グリーン
- `gofmt -l` 出力なし / `go vet` クリーン
- 既存の警告ログ検証テスト2件に「フィード名が出力されURLが出力されない」アサーションを追加
- 空タイトルフィードのフォールバック検証テストを追加

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ER4PN8tR6C8z2isfFksogh)_