### PR TITLE
docs(README): bashコメントから「Claude Code 向け」の限定表現を除去

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ characters:
 設定方法で説明した編集は、コーディングエージェントに任せることもできます。`vox-radio install --skills` は、エージェントスキル（`SKILL.md` ＋ フィールド定義 `references/*.md`）をインストールします。
 
 ```bash
-# Claude Code 向け（既定: .claude/skills/vox-radio/）
+# 既定: .claude/skills/vox-radio/
 vox-radio install --skills
 
 # 別のエージェントのスキルディレクトリへ展開する場合


### PR DESCRIPTION
関連タスク: [README「応用的な設定方法」のコメント文言を修正する](https://app.todoist.com/app/task/6grJjw6gJ4hPXM43)

## Summary

- `vox-radio install --skills` の bash コメント `# Claude Code 向け（既定: .claude/skills/vox-radio/）` から「Claude Code 向け」の限定表現を除去
- `--skills-dir` フラグで任意のエージェントに使えるにもかかわらず Claude Code 限定と誤解させる表現だったため修正
- 修正後: `# 既定: .claude/skills/vox-radio/`

---
🤖 Generated with [Claude Code](https://claude.ai/code)