### PR TITLE
docs: README の feedgen 出力先と assets preview の前提を明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ vox-radio episodegen manifest --spec episode-spec.yaml --rundown work/02_rundown
 
 ### フィード生成
 
-配信用の RSS フィード（`feed.xml`）を生成します。`feedgen` が番組の履歴キャッシュと `feed-spec.yaml` から出力します（manifest・mp3 は不要）。
+配信用の RSS フィード（`feed.xml`）を生成します。`feedgen` が番組の履歴キャッシュと `feed-spec.yaml` から出力します（manifest・mp3 は不要）。既定では `public/feed.xml` に書き出されます（出力先は `feed-spec.yaml` で変更可）。
 
 ```bash
 vox-radio feedgen --cache .vox-radio/cache/<program.id>.jsonl --spec feed-spec.yaml
@@ -160,7 +160,7 @@ characters:
 
 1. 使う音声ファイルを `assets/` に置く
 2. 各素材を登録する（`assets.yaml`）。音量やフェードのほか、BGM はセリフ中に音量を下げる度合い（ダッキング）なども設定できる
-3. `assets check` で設定を検証し、`assets preview` で素材ごとの鳴り方を確認する
+3. `assets check` で設定を検証し、`assets preview` で素材ごとの鳴り方を確認する（`--id` には手順 2 で登録済みの素材を指定します）
 
    ```bash
    vox-radio assets check assets/assets.yaml


### PR DESCRIPTION
## 概要

README.md 記載の手順を作業ディレクトリ上で実際に試して検証し、利用者がそのままなぞると迷う・失敗しうる2点を明記しました。

## 背景（検証結果）

インストール → クイックスタート（`init --sample` → `episodegen`）→ 個別6ステップ → `feedgen` → `init`/`install --skills`、および `slackpost` の `check`/`--dry-run` まで一通り実行し、出力先・キャッシュ・ログともREADME記載と一致することを確認しました。致命的な不備はなく、以下の軽微な2点のみ補足しています。

## 変更内容

- **フィード生成節**: `feedgen` は既定で `public/feed.xml` に書き出される旨を追記（出力先は `feed-spec.yaml` で変更可）。READMEだけ読むとカレントに `feed.xml` が無く戸惑うため。
- **アセット設定 手順3**: `assets preview` の `--id` には手順2で登録済みの素材を指定する旨を追記。サンプルはアセットがコメントアウト済みのため、例をそのまま実行すると失敗するため。

## 確認

- `doc-structure-checker`: ADR-0062 の利用者向け/開発者向け分離方針に照らし崩れなし
- `user-doc-reviewer`: 冗長性の指摘を反映し feedgen 追記を一文に圧縮

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeozqgE3Ft7WLUiXEEhesE)_