### PR TITLE
feat: 生成MP3の音質を program.audio_quality プリセットで設定可能にする

### DIFF
--- a/internal/assemble/filter.go
+++ b/internal/assemble/filter.go
@@ -193,7 +193,7 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 	// Peak limiter: prevents clipping after loudnorm.
 	b.addFilter(fmt.Sprintf("[norm_out]alimiter=limit=%.3f:level=0[out]", outputLimiterLimit))
 
-	outputArgs := []string{"-map", "[out]", "-c:a", "libmp3lame", "-q:a", "2"}
+	outputArgs := append([]string{"-map", "[out]", "-c:a", "libmp3lame"}, audioQualityArgs(bctx.Program.EffectiveAudioQuality())...)
 	if metaArgs := buildMetadataArgs(bctx); len(metaArgs) > 0 {
 		outputArgs = append(outputArgs, "-id3v2_version", "3")
 		outputArgs = append(outputArgs, metaArgs...)
@@ -205,6 +205,20 @@ func BuildFFmpegArgs(bctx BuildContext) (*FFmpegArgs, error) {
 		OutputArgs:    outputArgs,
 		OutputPath:    bctx.OutPath,
 	}, nil
+}
+
+// audioQualityArgs returns the ffmpeg VBR quality arguments for the given preset.
+// preset must be one of "high", "standard", "low" (values from config.DefaultAudioQuality etc.).
+// Unknown values fall back to "standard" (-q:a 2).
+func audioQualityArgs(preset string) []string {
+	switch preset {
+	case "high":
+		return []string{"-q:a", "0"}
+	case "low":
+		return []string{"-q:a", "5"}
+	default:
+		return []string{"-q:a", "2"}
+	}
 }
 
 // buildMetadataArgs constructs ffmpeg -metadata key=value pairs for ID3 tagging.

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -2171,3 +2171,64 @@ func TestBuildFFmpegArgs_MetadataArgs_DateUsesTimezone(t *testing.T) {
 		t.Errorf("OutputArgs: date should be 2026-06-15 (JST), got: %v", args.OutputArgs)
 	}
 }
+
+func TestAudioQualityArgs(t *testing.T) {
+	tests := []struct {
+		preset string
+		wantQA string // expected -q:a value
+	}{
+		{"high", "0"},
+		{"standard", "2"},
+		{"low", "5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.preset, func(t *testing.T) {
+			got := audioQualityArgs(tt.preset)
+			found := false
+			for i, a := range got {
+				if a == "-q:a" && i+1 < len(got) && got[i+1] == tt.wantQA {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("audioQualityArgs(%q) = %v, want -q:a %s", tt.preset, got, tt.wantQA)
+			}
+		})
+	}
+}
+
+func TestBuildFFmpegArgs_AudioQuality(t *testing.T) {
+	tests := []struct {
+		name         string
+		audioQuality string
+		wantQA       string // expected -q:a value in OutputArgs
+	}{
+		{"未設定はstandard(-q:a 2)", "", "2"},
+		{"high は -q:a 0", "high", "0"},
+		{"standard は -q:a 2", "standard", "2"},
+		{"low は -q:a 5", "low", "5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newMinimalContext()
+			ctx.Program = config.ProgramConfig{AudioQuality: tt.audioQuality}
+
+			args, err := BuildFFmpegArgs(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			found := false
+			for i, a := range args.OutputArgs {
+				if a == "-q:a" && i+1 < len(args.OutputArgs) && args.OutputArgs[i+1] == tt.wantQA {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("OutputArgs: want -q:a %s, got %v", tt.wantQA, args.OutputArgs)
+			}
+		})
+	}
+}

--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -2184,15 +2184,8 @@ func TestAudioQualityArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.preset, func(t *testing.T) {
 			got := audioQualityArgs(tt.preset)
-			found := false
-			for i, a := range got {
-				if a == "-q:a" && i+1 < len(got) && got[i+1] == tt.wantQA {
-					found = true
-					break
-				}
-			}
-			if !found {
-				t.Errorf("audioQualityArgs(%q) = %v, want -q:a %s", tt.preset, got, tt.wantQA)
+			if len(got) != 2 || got[0] != "-q:a" || got[1] != tt.wantQA {
+				t.Errorf("audioQualityArgs(%q) = %v, want [\"-q:a\", %q]", tt.preset, got, tt.wantQA)
 			}
 		})
 	}

--- a/internal/cli/skills/vox-radio/references/episode-spec.md
+++ b/internal/cli/skills/vox-radio/references/episode-spec.md
@@ -18,6 +18,7 @@
 | `script_note` | string | 任意 | 番組全体の台本指示（write ステップのみに渡る）。非公開フィールド。manifest・feed・Slack には露出しない。コーナーを問わず全台本に適用したいルールや注意事項を記述する |
 | `summary_length` | int | 任意 | 番組全体サマリーの目安文字数。未指定時はデフォルト 200 文字 |
 | `chars_per_minute` | int | 任意 | 台本の文字数換算に使用する1分あたりの目安文字数。台本生成時の `length_sec` → 目標文字数換算に使用。未指定時はデフォルト 420（= 7文字/秒×60） |
+| `audio_quality` | string | 任意 | 生成 MP3 の音質プリセット。`high`（約245kbps）/ `standard`（約190kbps、**既定**）/ `low`（約130kbps）。未指定または空は `standard` として扱われる |
 
 ## `corners` セクション
 

--- a/internal/cli/templates-sample/episode-spec.yaml
+++ b/internal/cli/templates-sample/episode-spec.yaml
@@ -27,6 +27,9 @@ program:
   # timezone: "Asia/Tokyo"
   # 台本生成時の1分あたり目安文字数。話速や BGM で実再生時間が前後する場合に調整する。省略時は 420（= 7文字/秒）。
   # chars_per_minute: 420
+  # 生成 MP3 の音質プリセット。省略時は standard（約190kbps VBR V2）。
+  #   high → 約245kbps / standard → 約190kbps（既定）/ low → 約130kbps
+  # audio_quality: "standard"
 
 # 出演者の一覧。ここに書いた人だけが番組に登場します。
 casts:

--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -20,6 +20,11 @@ program:
   # script_note: "記事を紹介する場合は記事タイトルを正確に伝えること。"
   # 番組まとめ文のおおよその文字数（省略すると 200 文字）。
   # summary_length: 200
+  # 生成 MP3 の音質プリセット（省略すると standard）。
+  #   high     → 約245kbps (VBR V0)
+  #   standard → 約190kbps (VBR V2) ※既定
+  #   low      → 約130kbps (VBR V5)
+  # audio_quality: "standard"
 
 # 出演者の一覧（番組に登場するキャラクターをここで宣言します）。
 # キーは vox-radio.yaml の characters のキーと合わせてください。

--- a/internal/config/episode_spec.go
+++ b/internal/config/episode_spec.go
@@ -151,7 +151,7 @@ func (p *EpisodeSpec) ValidateProgram() error {
 	if p.Program.ID == "" {
 		return fmt.Errorf("program.id is required (it is the cache key for episode history)")
 	}
-	if q := p.Program.EffectiveAudioQuality(); !slices.Contains([]string{"high", "standard", "low"}, q) {
+	if q := p.Program.EffectiveAudioQuality(); !slices.Contains(ValidAudioQualityPresets, q) {
 		return fmt.Errorf("program.audio_quality: invalid preset %q (must be high, standard, or low)", p.Program.AudioQuality)
 	}
 	return nil

--- a/internal/config/episode_spec.go
+++ b/internal/config/episode_spec.go
@@ -145,11 +145,14 @@ func (p *EpisodeSpec) CornerSummaryLength(title string) int {
 	return DefaultCornerSummaryLength
 }
 
-// ValidateProgram checks that program.id is set.
+// ValidateProgram checks that program.id is set and audio_quality (if set) is a valid preset.
 // program.id is the cache key (episodes are stored per program.id), so it is required.
 func (p *EpisodeSpec) ValidateProgram() error {
 	if p.Program.ID == "" {
 		return fmt.Errorf("program.id is required (it is the cache key for episode history)")
+	}
+	if q := p.Program.EffectiveAudioQuality(); !slices.Contains([]string{"high", "standard", "low"}, q) {
+		return fmt.Errorf("program.audio_quality: invalid preset %q (must be high, standard, or low)", p.Program.AudioQuality)
 	}
 	return nil
 }

--- a/internal/config/episode_spec_test.go
+++ b/internal/config/episode_spec_test.go
@@ -22,6 +22,36 @@ func TestEpisodeSpec_ValidateProgram(t *testing.T) {
 			spec:    &config.EpisodeSpec{},
 			wantErr: true,
 		},
+		{
+			name:    "audio_quality が未設定の場合はエラーなし",
+			spec:    &config.EpisodeSpec{Program: config.ProgramConfig{ID: "p", AudioQuality: ""}},
+			wantErr: false,
+		},
+		{
+			name:    "audio_quality=high はエラーなし",
+			spec:    &config.EpisodeSpec{Program: config.ProgramConfig{ID: "p", AudioQuality: "high"}},
+			wantErr: false,
+		},
+		{
+			name:    "audio_quality=standard はエラーなし",
+			spec:    &config.EpisodeSpec{Program: config.ProgramConfig{ID: "p", AudioQuality: "standard"}},
+			wantErr: false,
+		},
+		{
+			name:    "audio_quality=low はエラーなし",
+			spec:    &config.EpisodeSpec{Program: config.ProgramConfig{ID: "p", AudioQuality: "low"}},
+			wantErr: false,
+		},
+		{
+			name:    "audio_quality が不正値の場合はエラー",
+			spec:    &config.EpisodeSpec{Program: config.ProgramConfig{ID: "p", AudioQuality: "ultra"}},
+			wantErr: true,
+		},
+		{
+			name:    "audio_quality が大文字でもエラーなし（正規化後に判定）",
+			spec:    &config.EpisodeSpec{Program: config.ProgramConfig{ID: "p", AudioQuality: "HIGH"}},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/program.go
+++ b/internal/config/program.go
@@ -1,6 +1,9 @@
 package config
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 const (
 	// DefaultCharsPerMinute is the default number of characters spoken per minute (= 7文字/秒×60),
@@ -12,6 +15,8 @@ const (
 	DefaultProgramTimezone = "Asia/Tokyo"
 	// DefaultCornerSummaryLength is the default summary length (chars) for per-corner summaries.
 	DefaultCornerSummaryLength = 100
+	// DefaultAudioQuality is the default audio quality preset ("standard" = VBR V2, ~190kbps).
+	DefaultAudioQuality = "standard"
 )
 
 // DurationSecToTargetChars converts a duration in seconds to an approximate target character count.
@@ -80,6 +85,7 @@ type ProgramConfig struct {
 	SummaryLength  int    `yaml:"summary_length,omitempty"`
 	Timezone       string `yaml:"timezone,omitempty"`         // IANA tz名。未設定時は DefaultProgramTimezone
 	CharsPerMinute int    `yaml:"chars_per_minute,omitempty"` // 台本の文字数換算に使用する1分あたりの文字数。未設定時は DefaultCharsPerMinute
+	AudioQuality   string `yaml:"audio_quality,omitempty"`    // 音質プリセット: "high" / "standard" / "low"。未設定時は DefaultAudioQuality
 }
 
 // EffectiveSummaryLength returns the configured SummaryLength, falling back to DefaultProgramSummaryLength.
@@ -96,6 +102,14 @@ func (p ProgramConfig) EffectiveCharsPerMinute() int {
 		return DefaultCharsPerMinute
 	}
 	return p.CharsPerMinute
+}
+
+// EffectiveAudioQuality returns the lowercased AudioQuality, falling back to DefaultAudioQuality.
+func (p ProgramConfig) EffectiveAudioQuality() string {
+	if p.AudioQuality == "" {
+		return DefaultAudioQuality
+	}
+	return strings.ToLower(p.AudioQuality)
 }
 
 // EffectiveTimezone returns Timezone, falling back to DefaultProgramTimezone.

--- a/internal/config/program.go
+++ b/internal/config/program.go
@@ -19,6 +19,9 @@ const (
 	DefaultAudioQuality = "standard"
 )
 
+// ValidAudioQualityPresets lists all accepted values for program.audio_quality (lowercased).
+var ValidAudioQualityPresets = []string{"high", "standard", "low"}
+
 // DurationSecToTargetChars converts a duration in seconds to an approximate target character count.
 func DurationSecToTargetChars(sec, charsPerMinute int) int {
 	return sec * charsPerMinute / 60

--- a/internal/config/program_test.go
+++ b/internal/config/program_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/canpok1/vox-radio/internal/config"
 )
 
+func TestProgramConfig_EffectiveAudioQuality(t *testing.T) {
+	tests := []struct {
+		name         string
+		audioQuality string
+		want         string
+	}{
+		{"未設定はstandardになる", "", config.DefaultAudioQuality},
+		{"high", "high", "high"},
+		{"standard", "standard", "standard"},
+		{"low", "low", "low"},
+		{"大文字は小文字正規化", "HIGH", "high"},
+		{"混在も小文字正規化", "Standard", "standard"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := config.ProgramConfig{AudioQuality: tt.audioQuality}
+			got := p.EffectiveAudioQuality()
+			if got != tt.want {
+				t.Errorf("EffectiveAudioQuality() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestProgramConfig_Author(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
関連タスク: [生成MP3の音質を program.audio_quality プリセットで設定可能にする](https://todoist.com/showTask?id=6grXMM29Hcv2RfW3)

## Summary

- `ProgramConfig` に `audio_quality` フィールドを追加（`high` / `standard` / `low` プリセット）
- `ValidateProgram()` で不正値をエラーにするバリデーション追加
- `audioQualityArgs()` でプリセット → ffmpeg `-q:a` 引数にマッピング
- `BuildFFmpegArgs()` のハードコード `-q:a 2` をプリセット由来の値に置換
- テンプレ・サンプルテンプレ・リファレンスに `audio_quality` フィールドをコメント付きで追記

## Mappings

| プリセット | ffmpeg 引数 | 目安ビットレート |
|---|---|---|
| `high` | `-q:a 0` | 約 245 kbps (VBR V0) |
| `standard` (既定) | `-q:a 2` | 約 190 kbps (VBR V2) |
| `low` | `-q:a 5` | 約 130 kbps (VBR V5) |

---
🤖 Generated with [Claude Code](https://claude.ai/code)