### PR TITLE
feat: feed の <description> クレジット節見出しを FeedSpec で設定可能にする

### DIFF
--- a/internal/cli/skills/vox-radio/references/feed-spec.md
+++ b/internal/cli/skills/vox-radio/references/feed-spec.md
@@ -17,6 +17,7 @@
 | `feed.explicit` | bool | 任意 | 露骨な表現の有無（itunes:explicit）。デフォルト: false |
 | `feed.cover_image_url` | string | 任意 | カバー画像 URL（itunes:image）。空文字でタグ省略 |
 | `feed.credit` | string | 任意 | 配信者クレジット表記（各 item の itunes:author）。空文字で省略 |
+| `feed.credits_header` | string | 任意 | `<description>` 内クレジット節の見出し文字列。デフォルト: `クレジット` |
 | `output.public` | string | 任意 | `feed.xml` を書き出すディレクトリ。デフォルト: `public` |
 
 必須フィールドの欠落・URL/email 形式・`audio_url_template` のプレースホルダ（`{episode_number}` / `{audio_file}`）は `vox-radio feedgen check` で検証されます。意味検証エラーは全件まとめて報告されます。

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -90,7 +90,7 @@ func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
 		url := audioURL(cfg.Feed.AudioURLTemplate, e.EpisodeNumber, e.AudioFile)
 		item := rssItem{
 			Title:          itemTitle(e),
-			Description:    itemDescription(e),
+			Description:    itemDescription(cfg.Feed, e),
 			GUID:           rssGUID{IsPermaLink: "false", Value: "ep-" + strconv.Itoa(e.EpisodeNumber)},
 			PubDate:        pubDate(e.Datetime),
 			Enclosure:      rssEnclosure{URL: url, Length: e.Bytes, Type: "audio/mpeg"},
@@ -128,11 +128,11 @@ func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
 
 // itemDescription builds the RSS item description by appending a credits section
 // to the episode summary when credits are present.
-func itemDescription(e cache.Entry) string {
+func itemDescription(cfg FeedConfig, e cache.Entry) string {
 	if len(e.Credits) == 0 {
 		return e.Summary
 	}
-	return e.Summary + "\n\nクレジット\n" + strings.Join(e.Credits, "\n")
+	return e.Summary + "\n\n" + cfg.EffectiveCreditsHeader() + "\n" + strings.Join(e.Credits, "\n")
 }
 
 func audioURL(tmpl string, episodeNumber int, audioFile string) string {

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -90,7 +90,7 @@ func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
 		url := audioURL(cfg.Feed.AudioURLTemplate, e.EpisodeNumber, e.AudioFile)
 		item := rssItem{
 			Title:          itemTitle(e),
-			Description:    itemDescription(cfg.Feed, e),
+			Description:    itemDescription(cfg.Feed.EffectiveCreditsHeader(), e),
 			GUID:           rssGUID{IsPermaLink: "false", Value: "ep-" + strconv.Itoa(e.EpisodeNumber)},
 			PubDate:        pubDate(e.Datetime),
 			Enclosure:      rssEnclosure{URL: url, Length: e.Bytes, Type: "audio/mpeg"},
@@ -128,11 +128,11 @@ func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
 
 // itemDescription builds the RSS item description by appending a credits section
 // to the episode summary when credits are present.
-func itemDescription(cfg FeedConfig, e cache.Entry) string {
+func itemDescription(creditsHeader string, e cache.Entry) string {
 	if len(e.Credits) == 0 {
 		return e.Summary
 	}
-	return e.Summary + "\n\n" + cfg.EffectiveCreditsHeader() + "\n" + strings.Join(e.Credits, "\n")
+	return e.Summary + "\n\n" + creditsHeader + "\n" + strings.Join(e.Credits, "\n")
 }
 
 func audioURL(tmpl string, episodeNumber int, audioFile string) string {

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -243,6 +243,40 @@ func TestBuildFeed_CreditsAppendedToDescription(t *testing.T) {
 	}
 }
 
+func TestBuildFeed_CustomCreditsHeader(t *testing.T) {
+	cfg := feed.FeedSpec{
+		Feed: feed.FeedConfig{
+			AudioURLTemplate: "https://host.example/{episode_number}/{audio_file}",
+			CreditsHeader:    "Credits",
+		},
+	}
+	entries := []cache.Entry{
+		{
+			ProgramID:     "radio",
+			Datetime:      "2024-01-01T00:00:00Z",
+			EpisodeNumber: 1,
+			Title:         "タイトル",
+			Summary:       "番組の要約テキスト",
+			AudioFile:     "episode.mp3",
+			Bytes:         1000,
+			DurationSec:   600,
+			Credits:       []string{"OtoLogic / CC BY 4.0"},
+		},
+	}
+
+	got, err := feed.BuildFeed(cfg, entries)
+	if err != nil {
+		t.Fatalf("BuildFeed: %v", err)
+	}
+
+	if !strings.Contains(got, "Credits") {
+		t.Errorf("BuildFeed: expected custom credits header 'Credits' in description\ngot:\n%s", got)
+	}
+	if strings.Contains(got, "クレジット") {
+		t.Errorf("BuildFeed: expected 'クレジット' to be replaced by custom header\ngot:\n%s", got)
+	}
+}
+
 func TestBuildFeed_NoCreditsWhenEmpty(t *testing.T) {
 	cfg := feed.FeedSpec{
 		Feed: feed.FeedConfig{

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -232,7 +232,7 @@ func TestBuildFeed_CreditsAppendedToDescription(t *testing.T) {
 	if !strings.Contains(got, "番組の要約テキスト") {
 		t.Errorf("BuildFeed: expected summary in description\ngot:\n%s", got)
 	}
-	if !strings.Contains(got, "クレジット") {
+	if !strings.Contains(got, feed.DefaultCreditsHeader) {
 		t.Errorf("BuildFeed: expected credit section header in description\ngot:\n%s", got)
 	}
 	if !strings.Contains(got, "OtoLogic / CC BY 4.0") {
@@ -272,8 +272,8 @@ func TestBuildFeed_CustomCreditsHeader(t *testing.T) {
 	if !strings.Contains(got, "Credits") {
 		t.Errorf("BuildFeed: expected custom credits header 'Credits' in description\ngot:\n%s", got)
 	}
-	if strings.Contains(got, "クレジット") {
-		t.Errorf("BuildFeed: expected 'クレジット' to be replaced by custom header\ngot:\n%s", got)
+	if strings.Contains(got, feed.DefaultCreditsHeader) {
+		t.Errorf("BuildFeed: expected %q to be replaced by custom header\ngot:\n%s", feed.DefaultCreditsHeader, got)
 	}
 }
 
@@ -302,7 +302,7 @@ func TestBuildFeed_NoCreditsWhenEmpty(t *testing.T) {
 	}
 
 	// credits が空のとき「クレジット」節が追加されないこと
-	if strings.Contains(got, "クレジット") {
+	if strings.Contains(got, feed.DefaultCreditsHeader) {
 		t.Errorf("BuildFeed: should not contain credit section when credits is empty\ngot:\n%s", got)
 	}
 }

--- a/internal/feed/spec.go
+++ b/internal/feed/spec.go
@@ -10,7 +10,10 @@ import (
 	"github.com/canpok1/vox-radio/internal/fileio"
 )
 
-const DefaultPublicDir = "public"
+const (
+	DefaultPublicDir     = "public"
+	DefaultCreditsHeader = "クレジット"
+)
 
 // FeedConfig holds RSS feed metadata for feed-spec.yaml.
 type FeedConfig struct {
@@ -26,10 +29,10 @@ type FeedConfig struct {
 	CreditsHeader    string `yaml:"credits_header,omitempty"`
 }
 
-// EffectiveCreditsHeader returns the configured credits section header, or "クレジット" if not set.
+// EffectiveCreditsHeader returns the configured credits section header, or DefaultCreditsHeader if not set.
 func (c FeedConfig) EffectiveCreditsHeader() string {
 	if c.CreditsHeader == "" {
-		return "クレジット"
+		return DefaultCreditsHeader
 	}
 	return c.CreditsHeader
 }

--- a/internal/feed/spec.go
+++ b/internal/feed/spec.go
@@ -23,6 +23,15 @@ type FeedConfig struct {
 	SiteURL          string `yaml:"site_url"`
 	AudioURLTemplate string `yaml:"audio_url_template"`
 	Credit           string `yaml:"credit"`
+	CreditsHeader    string `yaml:"credits_header,omitempty"`
+}
+
+// EffectiveCreditsHeader returns the configured credits section header, or "クレジット" if not set.
+func (c FeedConfig) EffectiveCreditsHeader() string {
+	if c.CreditsHeader == "" {
+		return "クレジット"
+	}
+	return c.CreditsHeader
 }
 
 // OutputConfig holds output settings for feed-spec.yaml.

--- a/internal/feed/spec_test.go
+++ b/internal/feed/spec_test.go
@@ -81,6 +81,29 @@ func TestLoadFeedSpec_FileNotExist(t *testing.T) {
 	}
 }
 
+func TestLoadFeedSpec_CreditsHeaderField(t *testing.T) {
+	content := `
+feed:
+  language: ja
+  author: Test Author
+  email: test@example.com
+  site_url: https://example.com/
+  audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"
+  credits_header: Attributions
+output:
+  public: public
+`
+	path := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(content))
+
+	cfg, err := feed.LoadFeedSpec(path)
+	if err != nil {
+		t.Fatalf("LoadFeedSpec: unexpected error: %v", err)
+	}
+	if cfg.Feed.CreditsHeader != "Attributions" {
+		t.Errorf("Feed.CreditsHeader: got %q, want %q", cfg.Feed.CreditsHeader, "Attributions")
+	}
+}
+
 func TestFeedConfig_EffectiveCreditsHeader_DefaultWhenEmpty(t *testing.T) {
 	cfg := feed.FeedConfig{}
 	got := cfg.EffectiveCreditsHeader()

--- a/internal/feed/spec_test.go
+++ b/internal/feed/spec_test.go
@@ -84,8 +84,8 @@ func TestLoadFeedSpec_FileNotExist(t *testing.T) {
 func TestFeedConfig_EffectiveCreditsHeader_DefaultWhenEmpty(t *testing.T) {
 	cfg := feed.FeedConfig{}
 	got := cfg.EffectiveCreditsHeader()
-	if got != "クレジット" {
-		t.Errorf("EffectiveCreditsHeader(): got %q, want %q", got, "クレジット")
+	if got != feed.DefaultCreditsHeader {
+		t.Errorf("EffectiveCreditsHeader(): got %q, want %q", got, feed.DefaultCreditsHeader)
 	}
 }
 

--- a/internal/feed/spec_test.go
+++ b/internal/feed/spec_test.go
@@ -81,6 +81,22 @@ func TestLoadFeedSpec_FileNotExist(t *testing.T) {
 	}
 }
 
+func TestFeedConfig_EffectiveCreditsHeader_DefaultWhenEmpty(t *testing.T) {
+	cfg := feed.FeedConfig{}
+	got := cfg.EffectiveCreditsHeader()
+	if got != "クレジット" {
+		t.Errorf("EffectiveCreditsHeader(): got %q, want %q", got, "クレジット")
+	}
+}
+
+func TestFeedConfig_EffectiveCreditsHeader_Custom(t *testing.T) {
+	cfg := feed.FeedConfig{CreditsHeader: "Credits"}
+	got := cfg.EffectiveCreditsHeader()
+	if got != "Credits" {
+		t.Errorf("EffectiveCreditsHeader(): got %q, want %q", got, "Credits")
+	}
+}
+
 func TestFeedSpec_EffectivePublicDir_Default(t *testing.T) {
 	cfg := feed.FeedSpec{}
 	got := cfg.EffectivePublicDir()


### PR DESCRIPTION
関連タスク: [feed の `<description>` クレジット節見出し「クレジット」を FeedSpec で設定可能にする](https://app.todoist.com/app/task/6grXGpjPp63chXqV)

## Summary

- `FeedConfig` に `credits_header` フィールドを追加し、クレジット節の見出し文字列を設定可能にする
- 空のとき `DefaultCreditsHeader`（`"クレジット"`）をデフォルト値として使用
- `EffectiveCreditsHeader()` メソッドで解決、`itemDescription` は `creditsHeader string` を受け取るシグネチャに変更（FeedConfig 依存を除去）
- `internal/cli/skills/vox-radio/references/feed-spec.md` に `credits_header` フィールドを追記

## Test plan

- [x] `TestFeedConfig_EffectiveCreditsHeader_DefaultWhenEmpty` — 未設定時に `DefaultCreditsHeader` を返す
- [x] `TestFeedConfig_EffectiveCreditsHeader_Custom` — カスタム値を返す
- [x] `TestLoadFeedSpec_CreditsHeaderField` — YAML から `credits_header` が正しくロードされる
- [x] `TestBuildFeed_CustomCreditsHeader` — カスタム見出しが `<description>` に反映される
- [x] 既存テスト全件 pass（`go test ./...`）

---

🤖 Generated with [Claude Code](https://claude.ai/code)