### PR TITLE
fix: フルパイプライン episodegen の manifest に credits が転記されないバグを修正

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -172,6 +172,13 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		ConversationNotes: programSummary.ConversationNotes,
 		EpisodeNumber:     opts.EpisodeNumber,
 		EpisodeTitle:      programSummary.EpisodeTitle,
+		Credits: manifest.CollectCredits(manifest.CreditParams{
+			Assets:     r.Spec.Assets,
+			Characters: chars,
+			Lines:      &scriptLines,
+			Script:     &scr,
+			Casts:      rundown.Casts,
+		}),
 	})
 	if err := fileio.WriteJSON(fileio.ManifestPath(outDir), m); err != nil {
 		return fmt.Errorf("write manifest: %w", err)

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -562,6 +562,60 @@ func TestRunner_Run_SummaryBeforeAssemble(t *testing.T) {
 	}
 }
 
+func TestRunner_Run_ManifestIncludesAssetCredits(t *testing.T) {
+	outDir := t.TempDir()
+	s := defaultStubs()
+	s.scr.lines = model.ScriptLines{
+		Corners: []model.CornerLines{
+			{Title: "コーナー1", BGM: "bgm1", Lines: []model.Line{{Text: "テスト"}}},
+		},
+	}
+
+	r := newRunner(s)
+	r.Spec.Assets = config.AssetsConfig{
+		BGM: map[string]config.BGMEntry{"bgm1": {Credit: "OtoLogic / CC BY 4.0"}},
+	}
+
+	if err := r.Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(fileio.ManifestPath(outDir))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if !strings.Contains(string(data), "OtoLogic / CC BY 4.0") {
+		t.Errorf("manifest should contain asset credit, got: %s", data)
+	}
+}
+
+func TestRunner_Run_ManifestIncludesCharacterCredits(t *testing.T) {
+	outDir := t.TempDir()
+	s := defaultStubs()
+	casts := []model.RundownCast{
+		{CharacterID: "zundamon", Role: "MC", Type: "mc"},
+	}
+
+	r := newRunner(s)
+	r.Config = &config.Config{
+		Characters: map[string]config.CharacterConfig{
+			"zundamon": {Credit: "VOICEVOX:ずんだもん"},
+		},
+	}
+
+	if err := r.Run(context.Background(), pipeline.Options{OutDir: outDir, Casts: casts}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(fileio.ManifestPath(outDir))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if !strings.Contains(string(data), "VOICEVOX:ずんだもん") {
+		t.Errorf("manifest should contain character credit, got: %s", data)
+	}
+}
+
 func TestRunner_Run_EpisodeMetaPassedToAssembler(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -115,6 +115,15 @@ func (s *stubCornerSummarizer) SummarizeCorner(_ context.Context, _ model.Corner
 
 // --- helpers ---
 
+func mustReadManifest(t *testing.T, outDir string) string {
+	t.Helper()
+	data, err := os.ReadFile(fileio.ManifestPath(outDir))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	return string(data)
+}
+
 type stubs struct {
 	col  *stubCollector
 	rnd  *stubRundowner
@@ -335,13 +344,9 @@ func TestRunner_Run_ManifestIncludesSummary(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	manifestPath := fileio.ManifestPath(outDir)
-	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("read manifest: %v", err)
-	}
-	if !strings.Contains(string(data), wantSummary) {
-		t.Errorf("manifest should contain summary %q, got: %s", wantSummary, data)
+	got := mustReadManifest(t, outDir)
+	if !strings.Contains(got, wantSummary) {
+		t.Errorf("manifest should contain summary %q, got: %s", wantSummary, got)
 	}
 }
 
@@ -408,12 +413,9 @@ func TestRunner_Run_ManifestIncludesCornerSummary(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, err := os.ReadFile(fileio.ManifestPath(outDir))
-	if err != nil {
-		t.Fatalf("read manifest: %v", err)
-	}
-	if !strings.Contains(string(data), "コーナー要約テスト") {
-		t.Errorf("manifest should contain corner summary, got: %s", data)
+	got := mustReadManifest(t, outDir)
+	if !strings.Contains(got, "コーナー要約テスト") {
+		t.Errorf("manifest should contain corner summary, got: %s", got)
 	}
 }
 
@@ -502,16 +504,12 @@ func TestRunner_Run_ManifestIncludesConversationNotes(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	manifestPath := fileio.ManifestPath(outDir)
-	data, err := os.ReadFile(manifestPath)
-	if err != nil {
-		t.Fatalf("read manifest: %v", err)
+	got := mustReadManifest(t, outDir)
+	if !strings.Contains(got, "カフェにハマっている") {
+		t.Errorf("manifest should contain conversation note, got: %s", got)
 	}
-	if !strings.Contains(string(data), "カフェにハマっている") {
-		t.Errorf("manifest should contain conversation note, got: %s", string(data))
-	}
-	if !strings.Contains(string(data), `"conversation_notes"`) {
-		t.Errorf("manifest should contain conversation_notes field, got: %s", string(data))
+	if !strings.Contains(got, `"conversation_notes"`) {
+		t.Errorf("manifest should contain conversation_notes field, got: %s", got)
 	}
 }
 
@@ -580,12 +578,9 @@ func TestRunner_Run_ManifestIncludesAssetCredits(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, err := os.ReadFile(fileio.ManifestPath(outDir))
-	if err != nil {
-		t.Fatalf("read manifest: %v", err)
-	}
-	if !strings.Contains(string(data), "OtoLogic / CC BY 4.0") {
-		t.Errorf("manifest should contain asset credit, got: %s", data)
+	got := mustReadManifest(t, outDir)
+	if !strings.Contains(got, "OtoLogic / CC BY 4.0") {
+		t.Errorf("manifest should contain asset credit, got: %s", got)
 	}
 }
 
@@ -607,12 +602,9 @@ func TestRunner_Run_ManifestIncludesCharacterCredits(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	data, err := os.ReadFile(fileio.ManifestPath(outDir))
-	if err != nil {
-		t.Fatalf("read manifest: %v", err)
-	}
-	if !strings.Contains(string(data), "VOICEVOX:ずんだもん") {
-		t.Errorf("manifest should contain character credit, got: %s", data)
+	got := mustReadManifest(t, outDir)
+	if !strings.Contains(got, "VOICEVOX:ずんだもん") {
+		t.Errorf("manifest should contain character credit, got: %s", got)
 	}
 }
 


### PR DESCRIPTION
関連タスク: [フルパイプライン episodegen の manifest に credits が転記されないバグを修正](https://app.todoist.com/app/task/6grcHVJcR4PjpWxV)

## Summary

- `internal/pipeline/pipeline.go` の `manifest.Build` 呼び出しに `Credits` フィールドが未設定だったため、フル実行時の `manifest.json` の `credits` が常に空配列 `[]` になっていた
- `manifest.CollectCredits` を呼び出してアセットクレジット（BGM/Jingle/SE）・キャラクタークレジットを正しく転記するよう修正
- テスト2件追加（アセットクレジット・キャラクタークレジットの転記確認）
- `/simplify` 指摘対応: テスト内の manifest 読み込みボイラープレートを `mustReadManifest` ヘルパーに集約

## Test plan

- [ ] `go test ./internal/pipeline/...` で全テスト GREEN を確認
- [ ] `TestRunner_Run_ManifestIncludesAssetCredits` — BGM クレジットが manifest に含まれること
- [ ] `TestRunner_Run_ManifestIncludesCharacterCredits` — キャラクタークレジットが manifest に含まれること

---
🤖 Generated with [Claude Code](https://claude.ai/code)