### PR TITLE
fix(install): install.sh を sudo 不要にする（既定設置先を $HOME/.local/bin に変更）

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install
 
 ## 設置先（INSTALL_DIR）
 
-既定の設置先は `$HOME/.local/bin` です。ユーザー権限のみで完結し、`sudo` は不要です。ディレクトリが無い場合は自動で作成します。別の場所（書き込み権限のあるディレクトリ）に入れる場合は環境変数 `INSTALL_DIR` を指定します。指定先に書き込み権限が無い場合はエラーで停止し、別ディレクトリの指定を促します。
+既定の設置先は `$HOME/.local/bin` です。ディレクトリが無い場合は自動で作成します。別の場所（書き込み権限のあるディレクトリ）に入れる場合は環境変数 `INSTALL_DIR` を指定します。指定先に書き込み権限が無い場合はエラーで停止し、別ディレクトリの指定を促します。
 
 ```bash
 curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | INSTALL_DIR=$HOME/bin bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,10 +12,16 @@ curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install
 
 ## 設置先（INSTALL_DIR）
 
-既定の設置先は `/usr/local/bin` です。書き込み権限がない場合は自動で `sudo` にフォールバックします。別の場所に入れる場合は環境変数 `INSTALL_DIR` を指定します。
+既定の設置先は `$HOME/.local/bin` です。ユーザー権限のみで完結し、`sudo` は不要です。ディレクトリが無い場合は自動で作成します。別の場所（書き込み権限のあるディレクトリ）に入れる場合は環境変数 `INSTALL_DIR` を指定します。指定先に書き込み権限が無い場合はエラーで停止し、別ディレクトリの指定を促します。
 
 ```bash
-curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | INSTALL_DIR=$HOME/.local/bin bash
+curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | INSTALL_DIR=$HOME/bin bash
+```
+
+`$HOME/.local/bin` が `PATH` に含まれていない場合は、インストール後に表示される案内に従い、shell の設定ファイル（例: `~/.bashrc`, `~/.zshrc`）へ次の行を追記してください。
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
 ## バージョンの指定

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,13 +164,11 @@ echo "チェックサム OK"
 tar -xzf "$WORK_DIR/$ASSET_NAME" -C "$WORK_DIR" vox-radio
 
 # ---- インストール ----
-# 設置先が存在しなければ作成する（$HOME/.local/bin はデフォルトでは無いことが多い）
-if [[ ! -d "$INSTALL_DIR" ]]; then
-  if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
-    echo "ERROR: INSTALL_DIR を作成できません: $INSTALL_DIR" >&2
-    echo "       書き込み可能なディレクトリを INSTALL_DIR で指定してください。" >&2
-    exit 1
-  fi
+# 設置先を作成する（既存なら何もしない。$HOME/.local/bin はデフォルトでは無いことが多い）
+if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+  echo "ERROR: INSTALL_DIR を作成できません: $INSTALL_DIR" >&2
+  echo "       書き込み可能なディレクトリを INSTALL_DIR で指定してください。" >&2
+  exit 1
 fi
 
 if [[ ! -w "$INSTALL_DIR" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,11 +9,11 @@
 #   bash install.sh --help
 #
 # 環境変数:
-#   INSTALL_DIR  バイナリ設置先ディレクトリ (デフォルト: /usr/local/bin)
+#   INSTALL_DIR  バイナリ設置先ディレクトリ (デフォルト: $HOME/.local/bin)
 set -euo pipefail
 
 REPO="canpok1/vox-radio"
-INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
 
 # リリース時に置換されるバージョンプレースホルダ
 VERSION="__VERSION__"
@@ -25,7 +25,7 @@ usage() {
   echo "リリースページから install.sh をダウンロードして実行してください。" >&2
   echo "" >&2
   echo "Environment variables:" >&2
-  echo "  INSTALL_DIR  Installation directory (default: /usr/local/bin)" >&2
+  echo "  INSTALL_DIR  Installation directory (default: \$HOME/.local/bin)" >&2
 }
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
@@ -164,18 +164,38 @@ echo "チェックサム OK"
 tar -xzf "$WORK_DIR/$ASSET_NAME" -C "$WORK_DIR" vox-radio
 
 # ---- インストール ----
+# 設置先が存在しなければ作成する（$HOME/.local/bin はデフォルトでは無いことが多い）
 if [[ ! -d "$INSTALL_DIR" ]]; then
-  echo "ERROR: INSTALL_DIR が存在しません: $INSTALL_DIR" >&2
+  if ! mkdir -p "$INSTALL_DIR" 2>/dev/null; then
+    echo "ERROR: INSTALL_DIR を作成できません: $INSTALL_DIR" >&2
+    echo "       書き込み可能なディレクトリを INSTALL_DIR で指定してください。" >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -w "$INSTALL_DIR" ]]; then
+  echo "ERROR: INSTALL_DIR に書き込み権限がありません: $INSTALL_DIR" >&2
+  echo "       書き込み可能なディレクトリを INSTALL_DIR で指定してください。" >&2
+  echo "       例: curl -fsSL <URL> | INSTALL_DIR=\$HOME/.local/bin bash" >&2
   exit 1
 fi
 
-if [[ -w "$INSTALL_DIR" ]]; then
-  install -m 0755 "$WORK_DIR/vox-radio" "$INSTALL_DIR/vox-radio"
-else
-  echo "書き込み権限がないため sudo でインストールします..."
-  sudo install -m 0755 "$WORK_DIR/vox-radio" "$INSTALL_DIR/vox-radio"
-fi
+install -m 0755 "$WORK_DIR/vox-radio" "$INSTALL_DIR/vox-radio"
 
 echo ""
 echo "インストール完了: $INSTALL_DIR/vox-radio"
 "$INSTALL_DIR/vox-radio" --version
+
+# ---- PATH 案内 ----
+# INSTALL_DIR が PATH に含まれていなければ追加方法を案内する（設定ファイルは書き換えない）
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*)
+    ;;
+  *)
+    echo ""
+    echo "注意: $INSTALL_DIR は PATH に含まれていません。"
+    echo "      vox-radio コマンドを使うには、以下を shell の設定ファイル（例: ~/.bashrc, ~/.zshrc）に追記してください。"
+    echo ""
+    echo "      export PATH=\"$INSTALL_DIR:\$PATH\""
+    ;;
+esac


### PR DESCRIPTION
## 概要

`install.sh` が sudo 権限を必要とする問題を解消します。これまで既定の設置先が `/usr/local/bin`（root 所有のシステム領域）だったため、書き込み権限が無い場合に `sudo` へフォールバックしていました。sudo 権限を持たないユーザーはインストールできませんでした。

Claude Code の install スクリプトと同様に、ホームディレクトリ配下へ設置することで sudo を不要にします。

## 変更内容

### `scripts/install.sh`
- 既定 `INSTALL_DIR` を `/usr/local/bin` → `$HOME/.local/bin` に変更
- sudo フォールバックを廃止。書き込み不可時はエラーで `INSTALL_DIR` 指定を促す
- 設置先ディレクトリを `mkdir -p` で作成（既存なら何もしない）
- PATH 未登録時に `export PATH=...` の追記方法を案内（設定ファイルは書き換えない）

### `docs/installation.md`
- 既定設置先・PATH 案内を実挙動に合わせて更新

## 確認

- `shellcheck` / `bash -n` パス
- sudo なしで `~/.local/bin` への配置・ディレクトリ自動作成・PATH 案内が動作することを確認

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019B49ZRJPtwKV4tmWUicH1V)_