### PR TITLE
feat(slackpost): メッセージ整形を text/template ベースの2テンプレ構成へ刷新

### DIFF
--- a/docs/cli/vox-radio_slackpost_check.md
+++ b/docs/cli/vox-radio_slackpost_check.md
@@ -8,6 +8,7 @@ slack-spec.yaml を strict モードでフル検証する
 
   (a) strict パース: 未知キー（typo）をエラー化
   (b) 必須フィールド: slack.channel の存在チェック
+  (c) テンプレートファイル: slack.message.{parent,thread,fallback} 指定時にファイルの存在・読み込み・構文を検証
 
 成功時は標準出力に OK メッセージを出力し、ゼロで終了します。
 失敗時は非ゼロで終了します（CI での自動検知に使用できます）。

--- a/e2e/fixtures/slack-spec.yaml
+++ b/e2e/fixtures/slack-spec.yaml
@@ -1,9 +1,4 @@
 # e2e テスト用の Slack 投稿設定。channel は e2e/fake_slack.go の slackTestChannel と合わせること。
+# message フィールドを省略すると組み込みのデフォルトテンプレートを使います。
 slack:
   channel: "C0123456789"
-  message:
-    header: "🎙️ {title} 第{episode_number}回「{episode_title}」"
-    fallback: "{title} 第{episode_number}回 を配信しました"
-    summary: "*今回のまとめ*\n{summary}"
-    corner: "*{corner_title}*\n{corner_summary}\n{articles}"
-    article: " • <{url}|{title}>"

--- a/internal/cli/skills/vox-radio/references/slack-spec.md
+++ b/internal/cli/skills/vox-radio/references/slack-spec.md
@@ -38,27 +38,149 @@ vox-radio slackpost --manifest output/manifest.json --spec config/slack-spec.yam
 | フィールド | 型 | 必須/任意 | 説明 |
 |---|---|---|---|
 | `slack.channel` | string | 必須 | 投稿先チャンネル ID（`C` で始まる Slack のチャンネル ID） |
-| `slack.message.header` | string | 任意 | 親メッセージ（mp3 アップロード時の初期コメント）のテンプレート |
-| `slack.message.fallback` | string | 任意 | スレッド返信の通知用プレーンテキストのテンプレート |
-| `slack.message.summary` | string | 任意 | スレッド返信の要約 Section テンプレート（空のとき省略） |
-| `slack.message.corner` | string | 任意 | コーナー Section テンプレート |
-| `slack.message.article` | string | 任意 | 記事 1 件のテンプレート |
+| `slack.message.parent` | string | 任意 | 親メッセージ（mp3 アップロード初期コメント）のテンプレートファイルパス |
+| `slack.message.thread` | string | 任意 | スレッド返信本文のテンプレートファイルパス（3000 文字超は自動分割） |
+| `slack.message.fallback` | string | 任意 | スレッド通知用プレーンテキストのテンプレートファイルパス |
 
-`message.*` を省略した場合はコード側のデフォルトテンプレートが適用されます。
+`message.*` を省略した場合は組み込みのデフォルトテンプレートが使われます。
 
-## 利用可能なプレースホルダ
+## テンプレートファイルのパス指定
 
-| スコープ | プレースホルダ | manifest フィールド |
-|---------|----------------|---------------------|
-| 全体（header/summary/fallback） | `{title}` `{episode_number}` `{episode_title}` `{description}` `{summary}` `{datetime}` `{audio_file}` | `Manifest` の各 json タグ |
-| 全体（header/summary/fallback） | `{credit}` | `Manifest.Credits` を改行結合した文字列。credits が空のとき空文字列に置換される |
-| コーナー（`corner`） | `{corner_title}` `{corner_summary}` `{articles}` | `ManifestCorner.Title` / `.Summary` / 記事展開 |
-| 記事（`article`） | `{title}` `{url}` | `ArticleRef.Title` / `.URL` |
+- **相対パス**: `slack-spec.yaml` のあるディレクトリ基準で解決されます
+- **絶対パス**: そのまま使用されます
+
+```yaml
+slack:
+  channel: "C0123456789"
+  message:
+    parent: "slack-parent.tmpl"          # 相対パス（slack-spec.yaml と同じディレクトリ）
+    thread: "/abs/path/slack-thread.tmpl" # 絶対パス
+```
+
+`vox-radio init` を実行すると `slack-spec.yaml`・`slack-parent.tmpl`・`slack-thread.tmpl` が同時に生成されます。
+
+## テンプレートの書き方（Go text/template）
+
+テンプレートは Go 標準の [`text/template`](https://pkg.go.dev/text/template) 記法を使います。
+
+### データ文脈
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `.Title` | string | 番組タイトル |
+| `.EpisodeNumber` | int | 回番号（0 で偽扱い） |
+| `.EpisodeTitle` | string | サブタイトル |
+| `.Description` | string | 番組説明 |
+| `.Summary` | string | 全体要約 |
+| `.Datetime` | string | 配信日時 |
+| `.AudioFile` | string | 音声ファイル名 |
+| `.Credits` | []string | クレジット一覧 |
+| `.Corners` | []ManifestCorner | コーナー一覧（下記参照） |
+
+`ManifestCorner` のフィールド:
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `.ID` | string | コーナー ID |
+| `.Title` | string | コーナータイトル |
+| `.Summary` | string | コーナー要約 |
+| `.Points` | []string | 要点リスト |
+| `.Articles` | []ArticleRef | 記事一覧（下記参照） |
+
+`ArticleRef` のフィールド:
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `.Title` | string | 記事タイトル |
+| `.URL` | string | 記事 URL（空の場合がある） |
+
+### 利用可能なテンプレート関数
+
+| 関数 | 説明 |
+|---|---|
+| `corner "<id>"` | 指定 ID のコーナーを `*ManifestCorner` で返す（見つからない場合は `nil`） |
+| `hasLinks <corner>` | コーナーに URL 付き記事が 1 件以上あれば `true` |
+
+Go 標準の `eq` / `ne` / `if` / `range` / `with` 等もすべて使えます。
+
+### レシピ集
+
+#### 回番号・サブタイトルの条件付き表示
+
+```
+{{- /* EpisodeNumber が 0 のとき「第N回」を省略、EpisodeTitle が空のとき「」を省略 */}}
+🎙️ {{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}}{{if .EpisodeTitle}}「{{.EpisodeTitle}}」{{end}}
+```
+
+#### URL なし記事のスキップ
+
+```
+{{range .Corners}}
+*{{.Title}}*
+{{.Summary}}
+{{range .Articles}}{{if .URL}} • <{{.URL}}|{{.Title}}>
+{{end}}{{end}}{{end}}
+```
+
+#### 特定コーナーを ID で取り出す
+
+```
+{{with corner "news"}}
+*{{.Title}}*
+{{.Summary}}
+{{end}}
+```
+
+#### 特定コーナーだけ別表記（`eq`/`ne`）
+
+```
+{{range .Corners}}
+{{if eq .ID "oheri"}}お便り: {{.Summary}}
+{{else}}*{{.Title}}*
+{{.Summary}}
+{{range .Articles}}{{if .URL}} • <{{.URL}}|{{.Title}}>{{end}}{{end}}
+{{end}}
+{{end}}
+```
+
+#### URL 付き記事があるコーナーだけ見出しを出す（`hasLinks`）
+
+```
+{{range .Corners}}{{if hasLinks .}}
+*{{.Title}}*
+{{range .Articles}}{{if .URL}} • <{{.URL}}|{{.Title}}>
+{{end}}{{end}}
+{{end}}{{end}}
+```
+
+#### クレジット表示
+
+```
+{{range .Credits}} • {{.}}
+{{end}}
+```
+
+### スレッドの 3000 文字自動分割
+
+`thread` テンプレートのレンダリング結果が 3000 文字（Rune）を超える場合、`vox-radio` は改行境界で自動的に複数の Section ブロックに分割します。テンプレート側での分割指定は不要です。
 
 ## 投稿フロー
 
 1. `vox-radio.yaml` から Bot トークンを環境変数で取得
 2. `manifest.json` を読み込み、mp3 パスを自動解決（manifest と同じディレクトリ + `audio_file`）
-3. `slack-spec.yaml` を読み込み・検証
+3. `slack-spec.yaml` を読み込み・検証（テンプレートファイルの存在・構文も検証）
 4. mp3 を Slack へアップロード（親メッセージ = mp3 + 初期コメント）
-5. 要約・コーナーをスレッドに返信（要約・コーナーが両方空の場合はスレッド投稿をスキップ）
+5. `thread` テンプレートをレンダリングし、3000 文字以下の Section ブロックに分割してスレッドに返信
+   （`thread` 結果が空のとき、スレッド投稿はスキップ）
+
+## 検証コマンド（slackpost check）
+
+```bash
+vox-radio slackpost check slack-spec.yaml
+```
+
+以下を検証します:
+
+- strict パース: 未知キー（typo）をエラー化
+- `slack.channel` の存在チェック
+- `slack.message.{parent,thread,fallback}` 指定時: ファイル存在・読み込み・`template.Parse` 構文検証

--- a/internal/cli/slackpost.go
+++ b/internal/cli/slackpost.go
@@ -98,6 +98,7 @@ func newSlackpostCheckCmd() *cobra.Command {
 
   (a) strict パース: 未知キー（typo）をエラー化
   (b) 必須フィールド: slack.channel の存在チェック
+  (c) テンプレートファイル: slack.message.{parent,thread,fallback} 指定時にファイルの存在・読み込み・構文を検証
 
 成功時は標準出力に OK メッセージを出力し、ゼロで終了します。
 失敗時は非ゼロで終了します（CI での自動検知に使用できます）。`,

--- a/internal/cli/templates-sample/slack-parent.tmpl
+++ b/internal/cli/templates-sample/slack-parent.tmpl
@@ -1,0 +1,8 @@
+{{/*
+  slack-parent.tmpl — 親メッセージ（mp3 アップロード時の最初のコメント）
+
+  データ文脈: manifest 全体（model.Manifest）
+  .EpisodeNumber が 0 のとき「第N回」は自動で消えます（{{if .EpisodeNumber}} が偽）
+  .EpisodeTitle が空のとき「」は自動で消えます（{{if .EpisodeTitle}} が偽）
+*/}}
+🎙️ {{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}}{{if .EpisodeTitle}}「{{.EpisodeTitle}}」{{end}}

--- a/internal/cli/templates-sample/slack-spec.yaml
+++ b/internal/cli/templates-sample/slack-spec.yaml
@@ -9,30 +9,10 @@ slack:
   # チャンネルIDは Slack のチャンネル詳細画面の最下部などで確認できます。
   channel: "C0123456789"
 
-  # 投稿文のひな型（省略すると組み込みの標準テンプレートを使います）。
-  # 使える置き換え語:
-  #   {title}           番組タイトル
-  #   {episode_number}  回番号（0のときは「第N回」の部分が消えます）
-  #   {episode_title}   その回のサブタイトル（空のときは「」が消えます）
-  #   {description}     番組説明
-  #   {summary}         要約
-  #   {datetime}        配信日時
-  #   {audio_file}      音声ファイル名
-  # コーナー内で追加で使える置き換え語:
-  #   {corner_title}    コーナータイトル
-  #   {corner_summary}  コーナー要約
-  #   {articles}        記事リスト（article のひな型を各記事に当てはめて改行でつなぎます）
-  # 記事内で使える置き換え語:
-  #   {title}           記事タイトル
-  #   {url}             記事URL
+  # 投稿文テンプレートのファイルパス（省略すると組み込みのデフォルトテンプレートを使います）。
+  # vox-radio init --sample で slack-parent.tmpl・slack-thread.tmpl が同時に生成されます。
   message:
-    # 親メッセージ（mp3 をアップロードするときの最初のコメント）。
-    header: "🎙️ {title} 第{episode_number}回「{episode_title}」"
-    # スレッド返信の通知に使うプレーンテキスト。
-    fallback: "{title} 第{episode_number}回 を配信しました"
-    # スレッド返信に載せる要約（空のときは省略）。
-    summary: "*今回のまとめ*\n{summary}"
-    # コーナーごとの本文（{articles} は下の article を展開してつなぎます）。
-    corner: "*{corner_title}*\n{corner_summary}\n{articles}"
-    # 記事1件分のひな型。
-    article: " • <{url}|{title}>"
+    # 親メッセージ（mp3 アップロード時の最初のコメント）のテンプレートファイル。
+    parent: "slack-parent.tmpl"
+    # スレッド返信（要約＋コーナー）のテンプレートファイル。3000文字超は自動分割されます。
+    thread: "slack-thread.tmpl"

--- a/internal/cli/templates-sample/slack-thread.tmpl
+++ b/internal/cli/templates-sample/slack-thread.tmpl
@@ -1,0 +1,23 @@
+{{/*
+  slack-thread.tmpl — スレッド返信本文（要約＋コーナー）
+
+  URL なし記事は {{if .URL}} でスキップします。
+  3000 文字超は vox-radio が自動で複数の Section ブロックに分割します。
+  corner "<id>" 関数で特定コーナーを取り出せます。
+  hasLinks <corner> 関数でリンクあり/なしを判定できます。
+*/}}
+{{- with .Summary}}*今回のまとめ*
+{{.}}
+{{- end}}
+{{- range .Corners}}
+
+*{{.Title}}*
+{{- with .Summary}}
+{{.}}
+{{- end}}
+{{- range .Articles}}
+{{- if .URL}}
+ • <{{.URL}}|{{.Title}}>
+{{- end}}
+{{- end}}
+{{- end}}

--- a/internal/cli/templates/slack-parent.tmpl
+++ b/internal/cli/templates/slack-parent.tmpl
@@ -1,0 +1,19 @@
+{{/*
+  slack-parent.tmpl — 親メッセージ（mp3 アップロード時の最初のコメント）
+
+  データ文脈: manifest 全体（model.Manifest）
+  利用可能な主なフィールド:
+    .Title          番組タイトル
+    .EpisodeNumber  回番号（0 のとき {{if .EpisodeNumber}} が偽になり「第N回」が消えます）
+    .EpisodeTitle   サブタイトル（空のとき {{if .EpisodeTitle}} が偽になり「」が消えます）
+    .Summary        要約
+    .Description    番組説明
+    .Datetime       配信日時
+    .AudioFile      音声ファイル名
+    .Credits        クレジット（[]string）— range または join で使えます
+    .Corners        コーナー一覧（[]ManifestCorner）— 各 Corner は .ID .Title .Summary .Articles
+  関数:
+    corner "<id>"   — 指定 ID のコーナーを返す（見つからない場合は nil）
+    hasLinks <c>    — コーナーに URL 付き記事が 1 件以上あれば true
+*/}}
+🎙️ {{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}}{{if .EpisodeTitle}}「{{.EpisodeTitle}}」{{end}}

--- a/internal/cli/templates/slack-spec.yaml
+++ b/internal/cli/templates/slack-spec.yaml
@@ -8,30 +8,17 @@ slack:
   # 投稿先チャンネルのID（必須。"C" で始まる文字列）。自分のチャンネルIDに置き換えてください。
   channel: "C0123456789"
 
-  # 投稿文のひな型（省略すると組み込みの標準テンプレートを使います）。
-  # 使える置き換え語:
-  #   {title}           番組タイトル
-  #   {episode_number}  回番号（0のときは「第N回」の部分が消えます）
-  #   {episode_title}   その回のサブタイトル（空のときは「」が消えます）
-  #   {description}     番組説明
-  #   {summary}         要約
-  #   {datetime}        配信日時
-  #   {audio_file}      音声ファイル名
-  # コーナー内で追加で使える置き換え語:
-  #   {corner_title}    コーナータイトル
-  #   {corner_summary}  コーナー要約
-  #   {articles}        記事リスト（article のひな型を各記事に当てはめて改行でつなぎます）
-  # 記事内で使える置き換え語:
-  #   {title}           記事タイトル
-  #   {url}             記事URL
+  # 投稿文テンプレートのファイルパス（省略すると組み込みのデフォルトテンプレートを使います）。
+  # パスは slack-spec.yaml のディレクトリ基準の相対パスか絶対パスで指定します。
+  # vox-radio init で slack-parent.tmpl・slack-thread.tmpl が同時に生成されます。
+  # テンプレートは Go 標準の text/template 記法を使います。
+  # 利用可能な関数:
+  #   corner "<id>"        — 指定 ID のコーナーを返す（見つからない場合は nil）
+  #   hasLinks <corner>    — コーナーに URL 付き記事が 1 件以上あれば true
   message:
-    # 親メッセージ（mp3 をアップロードするときの最初のコメント）。
-    header: "🎙️ {title} 第{episode_number}回「{episode_title}」"
-    # スレッド返信の通知に使うプレーンテキスト。
-    fallback: "{title} 第{episode_number}回 を配信しました"
-    # スレッド返信に載せる要約（空のときは省略）。
-    summary: "*今回のまとめ*\n{summary}"
-    # コーナーごとの本文（{articles} は下の article を展開してつなぎます）。
-    corner: "*{corner_title}*\n{corner_summary}\n{articles}"
-    # 記事1件分のひな型。
-    article: " • <{url}|{title}>"
+    # 親メッセージ（mp3 アップロード時の最初のコメント）のテンプレートファイル。
+    parent: "slack-parent.tmpl"
+    # スレッド返信（要約＋コーナー）のテンプレートファイル。3000文字超は自動分割されます。
+    thread: "slack-thread.tmpl"
+    # スレッド通知用プレーンテキストのテンプレートファイル（省略可）。
+    # fallback: "slack-fallback.tmpl"

--- a/internal/cli/templates/slack-thread.tmpl
+++ b/internal/cli/templates/slack-thread.tmpl
@@ -1,0 +1,56 @@
+{{/*
+  slack-thread.tmpl — スレッド返信本文（要約＋コーナー）
+
+  データ文脈: manifest 全体（model.Manifest）
+  利用可能な主なフィールド:
+    .Summary        全体要約
+    .Corners        コーナー一覧（[]ManifestCorner）
+      各 Corner:
+        .ID         コーナー ID（例: "news"）
+        .Title      コーナータイトル
+        .Summary    コーナー要約
+        .Articles   記事一覧（[]ArticleRef）
+          各 Article:
+            .Title  記事タイトル
+            .URL    記事 URL（空の場合がある）
+  関数:
+    corner "<id>"          — 指定 ID のコーナーを返す（見つからない場合は nil）
+    hasLinks <c>           — コーナーに URL 付き記事が 1 件以上あれば true
+  URL なし記事のスキップ: {{if .URL}} で条件分岐します
+  特定コーナーの出し分け: {{if eq .ID "xxx"}} または {{with corner "xxx"}} で指定します
+  3000 文字超のテキストは vox-radio が自動で複数の Section ブロックに分割します
+
+  ---- カスタマイズ例 ----
+  {{if eq .ID "oheri"}} でお便りコーナーだけ別表記:
+    {{range .Corners}}
+    {{if eq .ID "oheri"}}*{{.Title}}*（URL なし）
+    {{.Summary}}
+    {{- else}}
+    *{{.Title}}*
+    {{.Summary}}
+    {{range .Articles}}{{if .URL}} • <{{.URL}}|{{.Title}}>
+    {{end}}{{end}}
+    {{- end}}
+    {{end}}
+
+  特定コーナーを見出しごと非表示（hasLinks）:
+    {{range .Corners}}{{if hasLinks .}}
+    *{{.Title}}*
+    ...
+    {{end}}{{end}}
+*/}}
+{{- with .Summary}}*今回のまとめ*
+{{.}}
+{{- end}}
+{{- range .Corners}}
+
+*{{.Title}}*
+{{- with .Summary}}
+{{.}}
+{{- end}}
+{{- range .Articles}}
+{{- if .URL}}
+ • <{{.URL}}|{{.Title}}>
+{{- end}}
+{{- end}}
+{{- end}}

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -7,6 +7,21 @@ import (
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
+// stubFuncMap returns a FuncMap with the same signatures as the real FuncMap,
+// used for template syntax validation without a concrete manifest.
+func stubFuncMap() template.FuncMap {
+	return template.FuncMap{
+		"corner":   func(id string) *model.ManifestCorner { return nil },
+		"hasLinks": func(c model.ManifestCorner) bool { return false },
+	}
+}
+
+// Parse validates the template syntax including the corner/hasLinks FuncMap.
+func Parse(tmplText string) error {
+	_, err := template.New("").Funcs(stubFuncMap()).Parse(tmplText)
+	return err
+}
+
 // Render executes the given text/template source with the manifest as data context.
 // FuncMap provides:
 //   - corner(id string) *model.ManifestCorner — returns the corner with the given ID (nil if not found)

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -34,6 +34,38 @@ func makeManifest() model.Manifest {
 	}
 }
 
+// Parse
+
+func TestParse_ValidSyntax_NoError(t *testing.T) {
+	if err := render.Parse(`{{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}}`); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParse_InvalidSyntax_Error(t *testing.T) {
+	if err := render.Parse(`{{invalid`); err == nil {
+		t.Error("expected error for invalid template syntax")
+	}
+}
+
+func TestParse_WithCornerFunction_ValidSyntax(t *testing.T) {
+	// Templates using corner/hasLinks must pass Parse without FuncMap error.
+	if err := render.Parse(`{{with corner "news"}}{{.Title}}{{end}}`); err != nil {
+		t.Errorf("unexpected error for template using corner function: %v", err)
+	}
+	if err := render.Parse(`{{range .Corners}}{{if hasLinks .}}{{.Title}}{{end}}{{end}}`); err != nil {
+		t.Errorf("unexpected error for template using hasLinks function: %v", err)
+	}
+}
+
+func TestParse_EmptyTemplate_NoError(t *testing.T) {
+	if err := render.Parse(``); err != nil {
+		t.Errorf("unexpected error for empty template: %v", err)
+	}
+}
+
+// Render
+
 func TestRender_BasicTemplate(t *testing.T) {
 	m := makeManifest()
 	tmpl := `タイトル: {{.Title}}`

--- a/internal/slack/message.go
+++ b/internal/slack/message.go
@@ -1,35 +1,42 @@
 package slack
 
 import (
-	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	slackgo "github.com/slack-go/slack"
 
 	"github.com/canpok1/vox-radio/internal/model"
+	"github.com/canpok1/vox-radio/internal/render"
 )
 
-// BuildHeader builds the initial comment text for the parent mp3 upload message.
-func BuildHeader(manifest model.Manifest, tmpl MessageTemplate) string {
-	s := tmpl.Header
-	s = replacePlaceholders(s, manifest)
+const maxSectionRunes = 3000
 
-	// remove empty episode title quotes
-	s = strings.ReplaceAll(s, "「」", "")
-
-	// remove 第0回 segment when episode number is 0
-	if manifest.EpisodeNumber == 0 {
-		s = removeEpisodeSegment(s)
+// BuildParent renders the parent template (mp3 upload initial comment).
+func BuildParent(manifest model.Manifest, tmplText string) (string, error) {
+	result, err := render.Render(tmplText, manifest)
+	if err != nil {
+		return "", err
 	}
-
-	return strings.TrimSpace(s)
+	return strings.TrimSpace(result), nil
 }
 
-// BuildFallback builds the fallback plain text for thread reply notifications.
-func BuildFallback(manifest model.Manifest, tmpl MessageTemplate) string {
-	s := tmpl.Fallback
-	s = replacePlaceholders(s, manifest)
-	return strings.TrimSpace(s)
+// BuildFallback renders the fallback template (notification plain text).
+func BuildFallback(manifest model.Manifest, tmplText string) (string, error) {
+	result, err := render.Render(tmplText, manifest)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result), nil
+}
+
+// BuildThread renders the thread body template to a single string.
+func BuildThread(manifest model.Manifest, tmplText string) (string, error) {
+	result, err := render.Render(tmplText, manifest)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(result), nil
 }
 
 // BuildAudioTitle returns the Slack file title for the audio upload.
@@ -41,105 +48,38 @@ func BuildAudioTitle(manifest model.Manifest) string {
 	return manifest.Title
 }
 
-// BuildThreadBlocks builds the Block Kit blocks and fallback text for the thread reply.
-// Returns nil blocks when both summary and corners are empty (thread should be skipped).
-func BuildThreadBlocks(manifest model.Manifest, tmpl MessageTemplate) ([]slackgo.Block, string) {
+// SplitIntoSectionBlocks splits text into Slack Section blocks of at most
+// maxSectionRunes runes each. Splits occur at newline boundaries.
+// Returns nil when text is empty.
+func SplitIntoSectionBlocks(text string) []slackgo.Block {
+	if text == "" {
+		return nil
+	}
+
+	lines := strings.Split(text, "\n")
 	var blocks []slackgo.Block
+	var current strings.Builder
 
-	if manifest.Summary != "" {
-		summaryText := replacePlaceholders(tmpl.Summary, manifest)
-		blocks = append(blocks, slackgo.NewSectionBlock(
-			slackgo.NewTextBlockObject(slackgo.MarkdownType, summaryText, false, false),
-			nil, nil,
-		))
-	}
-
-	if len(manifest.Corners) > 0 {
-		if manifest.Summary != "" {
-			blocks = append(blocks, slackgo.NewDividerBlock())
-		}
-		for _, corner := range manifest.Corners {
-			text := buildCornerText(corner, tmpl)
-			blocks = append(blocks, slackgo.NewSectionBlock(
-				slackgo.NewTextBlockObject(slackgo.MarkdownType, text, false, false),
-				nil, nil,
-			))
-		}
-	}
-
-	if len(blocks) == 0 {
-		return nil, ""
-	}
-
-	fallback := BuildFallback(manifest, tmpl)
-	return blocks, fallback
-}
-
-func buildCornerText(corner model.ManifestCorner, tmpl MessageTemplate) string {
-	articlesText := buildArticlesText(corner.Articles, tmpl.Article)
-
-	s := tmpl.Corner
-	s = strings.ReplaceAll(s, "{corner_title}", corner.Title)
-	s = strings.ReplaceAll(s, "{corner_summary}", corner.Summary)
-	s = strings.ReplaceAll(s, "{articles}", articlesText)
-
-	// remove empty lines
-	lines := strings.Split(s, "\n")
-	var kept []string
 	for _, line := range lines {
-		if strings.TrimSpace(line) != "" {
-			kept = append(kept, line)
+		lineWithNL := line + "\n"
+		newLen := utf8.RuneCountInString(current.String()) + utf8.RuneCountInString(lineWithNL)
+		if newLen > maxSectionRunes && current.Len() > 0 {
+			blocks = append(blocks, newSectionBlock(strings.TrimRight(current.String(), "\n")))
+			current.Reset()
 		}
+		current.WriteString(lineWithNL)
 	}
-	return strings.Join(kept, "\n")
+
+	if s := strings.TrimRight(current.String(), "\n"); s != "" {
+		blocks = append(blocks, newSectionBlock(s))
+	}
+
+	return blocks
 }
 
-func buildArticlesText(articles []model.ArticleRef, articleTmpl string) string {
-	if len(articles) == 0 {
-		return ""
-	}
-	var parts []string
-	for _, a := range articles {
-		line := articleTmpl
-		if a.URL == "" {
-			// Remove Slack link wrappers "<{url}|...>" → inner text only
-			const open = "<{url}|"
-			for {
-				before, after, found := strings.Cut(line, open)
-				if !found {
-					break
-				}
-				inner, tail, ok := strings.Cut(after, ">")
-				if !ok {
-					break
-				}
-				line = before + inner + tail
-			}
-			line = strings.ReplaceAll(line, "{url}", "")
-		} else {
-			line = strings.ReplaceAll(line, "{url}", a.URL)
-		}
-		line = strings.ReplaceAll(line, "{title}", a.Title)
-		parts = append(parts, line)
-	}
-	return strings.Join(parts, "\n")
-}
-
-// replacePlaceholders replaces {placeholder} tokens with manifest field values.
-func replacePlaceholders(s string, manifest model.Manifest) string {
-	s = strings.ReplaceAll(s, "{title}", manifest.Title)
-	s = strings.ReplaceAll(s, "{episode_number}", strconv.Itoa(manifest.EpisodeNumber))
-	s = strings.ReplaceAll(s, "{episode_title}", manifest.EpisodeTitle)
-	s = strings.ReplaceAll(s, "{description}", manifest.Description)
-	s = strings.ReplaceAll(s, "{summary}", manifest.Summary)
-	s = strings.ReplaceAll(s, "{datetime}", manifest.Datetime)
-	s = strings.ReplaceAll(s, "{audio_file}", manifest.AudioFile)
-	s = strings.ReplaceAll(s, "{credit}", strings.Join(manifest.Credits, "\n"))
-	return s
-}
-
-// removeEpisodeSegment removes the 第0回 portion from a header string.
-// TrimSpace is applied by the caller (BuildHeader).
-func removeEpisodeSegment(s string) string {
-	return strings.ReplaceAll(s, "第0回", "")
+func newSectionBlock(text string) *slackgo.SectionBlock {
+	return slackgo.NewSectionBlock(
+		slackgo.NewTextBlockObject(slackgo.MarkdownType, text, false, false),
+		nil, nil,
+	)
 }

--- a/internal/slack/message.go
+++ b/internal/slack/message.go
@@ -12,31 +12,27 @@ import (
 
 const maxSectionRunes = 3000
 
-// BuildParent renders the parent template (mp3 upload initial comment).
-func BuildParent(manifest model.Manifest, tmplText string) (string, error) {
+func renderTemplate(manifest model.Manifest, tmplText string) (string, error) {
 	result, err := render.Render(tmplText, manifest)
 	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(result), nil
+}
+
+// BuildParent renders the parent template (mp3 upload initial comment).
+func BuildParent(manifest model.Manifest, tmplText string) (string, error) {
+	return renderTemplate(manifest, tmplText)
 }
 
 // BuildFallback renders the fallback template (notification plain text).
 func BuildFallback(manifest model.Manifest, tmplText string) (string, error) {
-	result, err := render.Render(tmplText, manifest)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(result), nil
+	return renderTemplate(manifest, tmplText)
 }
 
 // BuildThread renders the thread body template to a single string.
 func BuildThread(manifest model.Manifest, tmplText string) (string, error) {
-	result, err := render.Render(tmplText, manifest)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(result), nil
+	return renderTemplate(manifest, tmplText)
 }
 
 // BuildAudioTitle returns the Slack file title for the audio upload.
@@ -59,15 +55,18 @@ func SplitIntoSectionBlocks(text string) []slackgo.Block {
 	lines := strings.Split(text, "\n")
 	var blocks []slackgo.Block
 	var current strings.Builder
+	var currentRunes int
 
 	for _, line := range lines {
 		lineWithNL := line + "\n"
-		newLen := utf8.RuneCountInString(current.String()) + utf8.RuneCountInString(lineWithNL)
-		if newLen > maxSectionRunes && current.Len() > 0 {
+		lineRunes := utf8.RuneCountInString(lineWithNL)
+		if currentRunes+lineRunes > maxSectionRunes && current.Len() > 0 {
 			blocks = append(blocks, newSectionBlock(strings.TrimRight(current.String(), "\n")))
 			current.Reset()
+			currentRunes = 0
 		}
 		current.WriteString(lineWithNL)
+		currentRunes += lineRunes
 	}
 
 	if s := strings.TrimRight(current.String(), "\n"); s != "" {

--- a/internal/slack/message_test.go
+++ b/internal/slack/message_test.go
@@ -3,6 +3,7 @@ package slack_test
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	slackgo "github.com/slack-go/slack"
 
@@ -19,6 +20,7 @@ func makeManifest() model.Manifest {
 		AudioFile:     "episode42.mp3",
 		Corners: []model.ManifestCorner{
 			{
+				ID:      "news",
 				Title:   "今週のニュース",
 				Summary: "各社の新モデル発表が相次いだ一週間でした。",
 				Articles: []model.ArticleRef{
@@ -27,6 +29,7 @@ func makeManifest() model.Manifest {
 				},
 			},
 			{
+				ID:      "deep",
 				Title:   "深掘りコーナー",
 				Summary: "エージェント設計のベストプラクティスを議論。",
 				Articles: []model.ArticleRef{
@@ -37,171 +40,307 @@ func makeManifest() model.Manifest {
 	}
 }
 
-func makeTemplate() slack.MessageTemplate {
-	return slack.MessageTemplate{
-		Header:   "🎙️ {title} 第{episode_number}回「{episode_title}」",
-		Fallback: "{title} 第{episode_number}回 を配信しました",
-		Summary:  "*今回のまとめ*\n{summary}",
-		Corner:   "*{corner_title}*\n{corner_summary}\n{articles}",
-		Article:  " • <{url}|{title}>",
+// BuildParent
+
+func TestBuildParent_FullManifest(t *testing.T) {
+	m := makeManifest()
+	tmpl := `🎙️ {{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}}{{if .EpisodeTitle}}「{{.EpisodeTitle}}」{{end}}`
+
+	got, err := slack.BuildParent(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildParent: unexpected error: %v", err)
 	}
-}
-
-func TestBuildHeader_FullManifest(t *testing.T) {
-	manifest := makeManifest()
-	tmpl := makeTemplate()
-
-	header := slack.BuildHeader(manifest, tmpl)
-
 	want := "🎙️ ずんだもんテックラジオ 第42回「大規模言語モデルの最前線」"
-	if header != want {
-		t.Errorf("BuildHeader = %q, want %q", header, want)
+	if got != want {
+		t.Errorf("BuildParent = %q, want %q", got, want)
 	}
 }
 
-func TestBuildHeader_EmptyEpisodeTitle_RemovesEmptyQuotes(t *testing.T) {
-	manifest := makeManifest()
-	manifest.EpisodeTitle = ""
-	tmpl := makeTemplate()
+func TestBuildParent_EpisodeNumberZero_OmitsEpisodeSegment(t *testing.T) {
+	m := makeManifest()
+	m.EpisodeNumber = 0
+	tmpl := `🎙️ {{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}}{{if .EpisodeTitle}}「{{.EpisodeTitle}}」{{end}}`
 
-	header := slack.BuildHeader(manifest, tmpl)
-
-	if header == "" {
-		t.Error("BuildHeader must not be empty")
+	got, err := slack.BuildParent(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildParent: unexpected error: %v", err)
 	}
-	if strings.Contains(header, "「」") {
-		t.Errorf("BuildHeader should not contain empty quotes 「」, got %q", header)
+	if strings.Contains(got, "第0回") {
+		t.Errorf("BuildParent should not contain 第0回 when EpisodeNumber is 0, got %q", got)
 	}
-}
-
-func TestBuildHeader_EpisodeNumberZero_RemovesEpisodeSegment(t *testing.T) {
-	manifest := makeManifest()
-	manifest.EpisodeNumber = 0
-	tmpl := makeTemplate()
-
-	header := slack.BuildHeader(manifest, tmpl)
-
-	if strings.Contains(header, "第0回") {
-		t.Errorf("BuildHeader should not contain 第0回, got %q", header)
-	}
-	if strings.Contains(header, "第") {
-		t.Errorf("BuildHeader should not contain episode segment when EpisodeNumber is 0, got %q", header)
+	if strings.Contains(got, "第") {
+		t.Errorf("BuildParent should not contain episode segment when EpisodeNumber is 0, got %q", got)
 	}
 }
 
-func TestBuildFallback(t *testing.T) {
-	manifest := makeManifest()
-	tmpl := makeTemplate()
+func TestBuildParent_EmptyEpisodeTitle_OmitsEmptyQuotes(t *testing.T) {
+	m := makeManifest()
+	m.EpisodeTitle = ""
+	tmpl := `🎙️ {{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}}{{if .EpisodeTitle}}「{{.EpisodeTitle}}」{{end}}`
 
-	fallback := slack.BuildFallback(manifest, tmpl)
+	got, err := slack.BuildParent(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildParent: unexpected error: %v", err)
+	}
+	if strings.Contains(got, "「」") {
+		t.Errorf("BuildParent should not contain empty quotes 「」, got %q", got)
+	}
+	if got == "" {
+		t.Error("BuildParent must not be empty")
+	}
+}
 
+func TestBuildParent_InvalidTemplate_Error(t *testing.T) {
+	m := makeManifest()
+	_, err := slack.BuildParent(m, "{{invalid")
+	if err == nil {
+		t.Error("expected error for invalid template syntax")
+	}
+}
+
+func TestBuildParent_TrimsWhitespace(t *testing.T) {
+	m := makeManifest()
+	tmpl := "  {{.Title}}  "
+
+	got, err := slack.BuildParent(m, tmpl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != strings.TrimSpace(got) {
+		t.Errorf("BuildParent should trim whitespace, got %q", got)
+	}
+}
+
+// BuildFallback
+
+func TestBuildFallback_BasicRender(t *testing.T) {
+	m := makeManifest()
+	tmpl := `{{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}} を配信しました`
+
+	got, err := slack.BuildFallback(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildFallback: unexpected error: %v", err)
+	}
 	want := "ずんだもんテックラジオ 第42回 を配信しました"
-	if fallback != want {
-		t.Errorf("BuildFallback = %q, want %q", fallback, want)
+	if got != want {
+		t.Errorf("BuildFallback = %q, want %q", got, want)
 	}
 }
 
-func TestBuildThreadBlocks_WithSummaryAndCorners(t *testing.T) {
-	manifest := makeManifest()
-	tmpl := makeTemplate()
-
-	blocks, fallback := slack.BuildThreadBlocks(manifest, tmpl)
-
-	if fallback == "" {
-		t.Error("fallback must not be empty")
+func TestBuildFallback_InvalidTemplate_Error(t *testing.T) {
+	m := makeManifest()
+	_, err := slack.BuildFallback(m, "{{invalid")
+	if err == nil {
+		t.Error("expected error for invalid template syntax")
 	}
-	if len(blocks) == 0 {
-		t.Fatal("blocks must not be empty when summary and corners are present")
-	}
+}
 
-	// 要約 Section + Divider + コーナー Section×2 = 4ブロック以上
-	if len(blocks) < 4 {
-		t.Errorf("expected at least 4 blocks (summary+divider+corner×2), got %d", len(blocks))
-	}
+// BuildThread
 
-	// 最初のブロックは summary Section
-	firstSection, ok := blocks[0].(*slackgo.SectionBlock)
+func TestBuildThread_RendersTemplate(t *testing.T) {
+	m := makeManifest()
+	tmpl := `{{.Summary}}`
+
+	got, err := slack.BuildThread(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildThread: unexpected error: %v", err)
+	}
+	if got != m.Summary {
+		t.Errorf("BuildThread = %q, want %q", got, m.Summary)
+	}
+}
+
+func TestBuildThread_URLSkip(t *testing.T) {
+	m := makeManifest()
+	m.Corners = []model.ManifestCorner{
+		{
+			Title: "テック",
+			Articles: []model.ArticleRef{
+				{Title: "URL付き記事", URL: "https://example.com"},
+				{Title: "URLなし記事", URL: ""},
+			},
+		},
+	}
+	tmpl := `{{range .Corners}}{{range .Articles}}{{if .URL}} • <{{.URL}}|{{.Title}}>
+{{end}}{{end}}{{end}}`
+
+	got, err := slack.BuildThread(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildThread: unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "URL付き記事") {
+		t.Errorf("BuildThread should contain URL付き記事, got: %q", got)
+	}
+	if strings.Contains(got, "URLなし記事") {
+		t.Errorf("BuildThread should NOT contain URLなし記事, got: %q", got)
+	}
+}
+
+func TestBuildThread_CornerFunction(t *testing.T) {
+	m := makeManifest()
+	tmpl := `{{with corner "news"}}コーナー: {{.Title}}{{end}}`
+
+	got, err := slack.BuildThread(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildThread: unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "今週のニュース") {
+		t.Errorf("BuildThread should contain corner title via corner function, got: %q", got)
+	}
+}
+
+func TestBuildThread_CornerFunctionNotFound_ReturnsEmpty(t *testing.T) {
+	m := makeManifest()
+	tmpl := `{{with corner "nonexistent"}}{{.Title}}{{end}}`
+
+	got, err := slack.BuildThread(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildThread: unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("BuildThread corner function with unknown ID should return empty, got: %q", got)
+	}
+}
+
+func TestBuildThread_HasLinksFunction(t *testing.T) {
+	m := model.Manifest{
+		Corners: []model.ManifestCorner{
+			{
+				ID:    "withlinks",
+				Title: "リンクあり",
+				Articles: []model.ArticleRef{
+					{Title: "A", URL: "https://example.com"},
+				},
+			},
+			{
+				ID:    "nolinks",
+				Title: "リンクなし",
+				Articles: []model.ArticleRef{
+					{Title: "B", URL: ""},
+				},
+			},
+		},
+	}
+	tmpl := `{{range .Corners}}{{if hasLinks .}}{{.Title}}
+{{end}}{{end}}`
+
+	got, err := slack.BuildThread(m, tmpl)
+	if err != nil {
+		t.Fatalf("BuildThread: unexpected error: %v", err)
+	}
+	if !strings.Contains(got, "リンクあり") {
+		t.Errorf("BuildThread should include corner with links, got: %q", got)
+	}
+	if strings.Contains(got, "リンクなし") {
+		t.Errorf("BuildThread should exclude corner without links, got: %q", got)
+	}
+}
+
+func TestBuildThread_InvalidTemplate_Error(t *testing.T) {
+	m := makeManifest()
+	_, err := slack.BuildThread(m, "{{invalid")
+	if err == nil {
+		t.Error("expected error for invalid template syntax")
+	}
+}
+
+func TestBuildThread_TrimsWhitespace(t *testing.T) {
+	m := makeManifest()
+	tmpl := "  {{.Title}}  "
+
+	got, err := slack.BuildThread(m, tmpl)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != strings.TrimSpace(got) {
+		t.Errorf("BuildThread should trim whitespace, got %q", got)
+	}
+}
+
+// SplitIntoSectionBlocks
+
+func TestSplitIntoSectionBlocks_EmptyText_ReturnsNil(t *testing.T) {
+	blocks := slack.SplitIntoSectionBlocks("")
+	if len(blocks) != 0 {
+		t.Errorf("expected 0 blocks for empty text, got %d", len(blocks))
+	}
+}
+
+func TestSplitIntoSectionBlocks_ShortText_OneBlock(t *testing.T) {
+	text := "短いテキスト"
+	blocks := slack.SplitIntoSectionBlocks(text)
+	if len(blocks) != 1 {
+		t.Errorf("expected 1 block for short text, got %d", len(blocks))
+	}
+	section, ok := blocks[0].(*slackgo.SectionBlock)
 	if !ok {
-		t.Fatalf("blocks[0] should be SectionBlock, got %T", blocks[0])
+		t.Fatalf("block[0] should be SectionBlock, got %T", blocks[0])
 	}
-	if firstSection.Text == nil || firstSection.Text.Text == "" {
-		t.Error("first section text must not be empty")
-	}
-
-	// 2番目は Divider
-	_, ok = blocks[1].(*slackgo.DividerBlock)
-	if !ok {
-		t.Errorf("blocks[1] should be DividerBlock, got %T", blocks[1])
+	if section.Text.Text != text {
+		t.Errorf("section text: got %q, want %q", section.Text.Text, text)
 	}
 }
 
-func TestBuildThreadBlocks_EmptySummary_NoBummarySection(t *testing.T) {
-	manifest := makeManifest()
-	manifest.Summary = ""
-	tmpl := makeTemplate()
-
-	blocks, _ := slack.BuildThreadBlocks(manifest, tmpl)
-
-	if len(blocks) == 0 {
-		t.Fatal("blocks must not be empty when corners are present")
+func TestSplitIntoSectionBlocks_LongText_MultipleBlocks(t *testing.T) {
+	// 100文字 * 35行 = 3500文字（3000文字超）
+	line := strings.Repeat("あ", 100)
+	var sb strings.Builder
+	for i := 0; i < 35; i++ {
+		sb.WriteString(line)
+		sb.WriteString("\n")
 	}
+	text := strings.TrimRight(sb.String(), "\n")
 
-	// 要約がないので最初のブロックは Divider ではなく Corner Section になる
-	_, isDivider := blocks[0].(*slackgo.DividerBlock)
-	if isDivider {
-		t.Error("first block should not be Divider when summary is empty")
+	blocks := slack.SplitIntoSectionBlocks(text)
+	if len(blocks) < 2 {
+		t.Errorf("expected multiple blocks for text > 3000 chars, got %d", len(blocks))
 	}
-}
-
-func TestBuildThreadBlocks_NoCorners_NoDivider(t *testing.T) {
-	manifest := makeManifest()
-	manifest.Corners = nil
-	tmpl := makeTemplate()
-
-	blocks, _ := slack.BuildThreadBlocks(manifest, tmpl)
-
-	// コーナーが0件なので divider 以降は出ない
-	for _, b := range blocks {
-		if _, ok := b.(*slackgo.DividerBlock); ok {
-			t.Error("blocks should not contain Divider when no corners")
+	// 各ブロックは 3000 rune 以下
+	for i, b := range blocks {
+		section, ok := b.(*slackgo.SectionBlock)
+		if !ok {
+			t.Fatalf("block[%d] is not SectionBlock, got %T", i, b)
+		}
+		count := utf8.RuneCountInString(section.Text.Text)
+		if count > 3000 {
+			t.Errorf("block[%d] has %d runes, exceeds 3000", i, count)
 		}
 	}
 }
 
-func TestBuildThreadBlocks_BothEmpty_NilBlocks(t *testing.T) {
-	manifest := makeManifest()
-	manifest.Summary = ""
-	manifest.Corners = nil
-	tmpl := makeTemplate()
-
-	blocks, _ := slack.BuildThreadBlocks(manifest, tmpl)
-
-	if len(blocks) != 0 {
-		t.Errorf("expected empty blocks when both summary and corners are empty, got %d blocks", len(blocks))
+func TestSplitIntoSectionBlocks_ExactlyAtLimit_OneBlock(t *testing.T) {
+	// ちょうど 3000 文字
+	text := strings.Repeat("a", 3000)
+	blocks := slack.SplitIntoSectionBlocks(text)
+	if len(blocks) != 1 {
+		t.Errorf("expected 1 block for exactly 3000 chars, got %d", len(blocks))
 	}
 }
 
-func TestBuildThreadBlocks_CornerEmptyArticles_NoArticleLines(t *testing.T) {
-	manifest := makeManifest()
-	manifest.Summary = ""
-	manifest.Corners = []model.ManifestCorner{
-		{Title: "タイトルのみ", Summary: "", Articles: nil},
+func TestSplitIntoSectionBlocks_AllBlocksWithinLimit(t *testing.T) {
+	// 長いテキストを作成
+	line := strings.Repeat("x", 200)
+	var sb strings.Builder
+	for i := 0; i < 30; i++ {
+		sb.WriteString(line)
+		sb.WriteString("\n")
 	}
-	tmpl := makeTemplate()
+	text := strings.TrimRight(sb.String(), "\n")
 
-	blocks, _ := slack.BuildThreadBlocks(manifest, tmpl)
-
-	if len(blocks) == 0 {
-		t.Fatal("blocks must not be empty when corner title exists")
-	}
-	section, ok := blocks[0].(*slackgo.SectionBlock)
-	if !ok {
-		t.Fatalf("blocks[0] should be SectionBlock, got %T", blocks[0])
-	}
-	if section.Text == nil {
-		t.Error("section text must not be nil")
+	blocks := slack.SplitIntoSectionBlocks(text)
+	for i, b := range blocks {
+		section, ok := b.(*slackgo.SectionBlock)
+		if !ok {
+			t.Fatalf("block[%d] is not SectionBlock", i)
+		}
+		count := utf8.RuneCountInString(section.Text.Text)
+		if count > 3000 {
+			t.Errorf("block[%d] has %d runes, exceeds 3000", i, count)
+		}
 	}
 }
+
+// BuildAudioTitle (unchanged behavior)
 
 func TestBuildAudioTitle_WithEpisodeTitle(t *testing.T) {
 	manifest := makeManifest()
@@ -217,64 +356,5 @@ func TestBuildAudioTitle_WithoutEpisodeTitle(t *testing.T) {
 	title := slack.BuildAudioTitle(manifest)
 	if title != manifest.Title {
 		t.Errorf("BuildAudioTitle = %q, want title %q", title, manifest.Title)
-	}
-}
-
-func TestBuildThreadBlocks_ArticleEmptyURL_NoSlackLinkSyntax(t *testing.T) {
-	manifest := makeManifest()
-	manifest.Summary = ""
-	manifest.Corners = []model.ManifestCorner{
-		{
-			Title: "テック",
-			Articles: []model.ArticleRef{
-				{Title: "URL無し記事", URL: ""},
-			},
-		},
-	}
-	tmpl := makeTemplate()
-
-	blocks, _ := slack.BuildThreadBlocks(manifest, tmpl)
-
-	if len(blocks) == 0 {
-		t.Fatal("blocks must not be empty")
-	}
-	section, ok := blocks[0].(*slackgo.SectionBlock)
-	if !ok {
-		t.Fatalf("blocks[0] should be SectionBlock, got %T", blocks[0])
-	}
-	text := section.Text.Text
-	if strings.Contains(text, "<|") {
-		t.Errorf("article with empty URL must not produce broken Slack link '<|...>', got: %q", text)
-	}
-	if !strings.Contains(text, "URL無し記事") {
-		t.Errorf("article title should appear in output even when URL is empty, got: %q", text)
-	}
-}
-
-func TestBuildHeader_CreditPlaceholder(t *testing.T) {
-	m := makeManifest()
-	m.Credits = []string{"OtoLogic / CC BY 4.0", "VOICEVOX:ずんだもん"}
-	tmpl := makeTemplate()
-	tmpl.Header = "{credit}"
-
-	got := slack.BuildHeader(m, tmpl)
-
-	want := "OtoLogic / CC BY 4.0\nVOICEVOX:ずんだもん"
-	if got != want {
-		t.Errorf("BuildHeader with {credit} = %q, want %q", got, want)
-	}
-}
-
-func TestBuildHeader_CreditPlaceholder_EmptyCredits(t *testing.T) {
-	m := makeManifest()
-	m.Credits = []string{}
-	tmpl := makeTemplate()
-	tmpl.Header = "タイトル: {title}\nクレジット: {credit}"
-
-	got := slack.BuildHeader(m, tmpl)
-
-	want := "タイトル: ずんだもんテックラジオ\nクレジット:"
-	if got != want {
-		t.Errorf("BuildHeader with empty credits = %q, want %q", got, want)
 	}
 }

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -29,9 +29,22 @@ func Run(opts Options, poster Poster) error {
 		opts.Out = os.Stdout
 	}
 
-	tmpl := opts.Spec.Slack.EffectiveMessageTemplate()
-	header := BuildHeader(opts.Manifest, tmpl)
-	blocks, fallback := BuildThreadBlocks(opts.Manifest, tmpl)
+	templates, err := opts.Spec.Slack.LoadTemplates(opts.Spec.BaseDir)
+	if err != nil {
+		return fmt.Errorf("load templates: %w", err)
+	}
+
+	header, err := BuildParent(opts.Manifest, templates.Parent)
+	if err != nil {
+		return fmt.Errorf("render parent template: %w", err)
+	}
+
+	threadText, err := BuildThread(opts.Manifest, templates.Thread)
+	if err != nil {
+		return fmt.Errorf("render thread template: %w", err)
+	}
+	blocks := SplitIntoSectionBlocks(threadText)
+
 	audioTitle := BuildAudioTitle(opts.Manifest)
 
 	if opts.DryRun {
@@ -76,30 +89,34 @@ func Run(opts Options, poster Poster) error {
 		}
 	}
 
-	var err error
+	var runErr error
 	if needUpload {
-		state.FileID, err = poster.UploadAudio(ctx, UploadParams{
+		state.FileID, runErr = poster.UploadAudio(ctx, UploadParams{
 			Channel:        channel,
 			FilePath:       opts.AudioPath,
 			Title:          audioTitle,
 			Filename:       opts.Manifest.AudioFile,
 			InitialComment: header,
 		})
-		if err != nil {
-			return fmt.Errorf("upload audio: %w", err)
+		if runErr != nil {
+			return fmt.Errorf("upload audio: %w", runErr)
 		}
 		_ = saveState(statePath, state)
 	}
 
 	if len(blocks) > 0 && state.ThreadTS == "" {
-		state.ThreadTS, err = poster.ResolveThreadTS(ctx, state.FileID, channel)
-		if err != nil {
-			return err
+		state.ThreadTS, runErr = poster.ResolveThreadTS(ctx, state.FileID, channel)
+		if runErr != nil {
+			return runErr
 		}
 		_ = saveState(statePath, state)
 	}
 
 	if len(blocks) > 0 {
+		fallback, err := BuildFallback(opts.Manifest, templates.Fallback)
+		if err != nil {
+			return fmt.Errorf("render fallback template: %w", err)
+		}
 		if err := poster.PostThreadReply(ctx, ReplyParams{
 			Channel:  channel,
 			ThreadTS: state.ThreadTS,

--- a/internal/slack/slack.go
+++ b/internal/slack/slack.go
@@ -45,6 +45,11 @@ func Run(opts Options, poster Poster) error {
 	}
 	blocks := SplitIntoSectionBlocks(threadText)
 
+	fallback, err := BuildFallback(opts.Manifest, templates.Fallback)
+	if err != nil {
+		return fmt.Errorf("render fallback template: %w", err)
+	}
+
 	audioTitle := BuildAudioTitle(opts.Manifest)
 
 	if opts.DryRun {
@@ -113,10 +118,6 @@ func Run(opts Options, poster Poster) error {
 	}
 
 	if len(blocks) > 0 {
-		fallback, err := BuildFallback(opts.Manifest, templates.Fallback)
-		if err != nil {
-			return fmt.Errorf("render fallback template: %w", err)
-		}
 		if err := poster.PostThreadReply(ctx, ReplyParams{
 			Channel:  channel,
 			ThreadTS: state.ThreadTS,

--- a/internal/slack/spec.go
+++ b/internal/slack/spec.go
@@ -3,53 +3,95 @@ package slack
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
 
 	"github.com/canpok1/vox-radio/internal/fileio"
 )
 
 const (
-	defaultHeaderTemplate   = "🎙️ {title} 第{episode_number}回「{episode_title}」"
-	defaultFallbackTemplate = "{title} 第{episode_number}回 を配信しました"
-	defaultSummaryTemplate  = "*今回のまとめ*\n{summary}"
-	defaultCornerTemplate   = "*{corner_title}*\n{corner_summary}\n{articles}"
-	defaultArticleTemplate  = " • <{url}|{title}>"
+	defaultParentTemplate = `🎙️ {{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}}{{if .EpisodeTitle}}「{{.EpisodeTitle}}」{{end}}`
+
+	defaultFallbackTemplate = `{{.Title}}{{if .EpisodeNumber}} 第{{.EpisodeNumber}}回{{end}} を配信しました`
+
+	defaultThreadTemplate = `{{- with .Summary}}*今回のまとめ*
+{{.}}
+{{- end}}
+{{- range .Corners}}
+
+*{{.Title}}*
+{{- with .Summary}}
+{{.}}
+{{- end}}
+{{- range .Articles}}
+{{- if .URL}}
+ • <{{.URL}}|{{.Title}}>
+{{- end}}
+{{- end}}
+{{- end}}`
 )
 
-// MessageTemplate holds template strings for composing Slack messages.
-type MessageTemplate struct {
-	Header   string `yaml:"header"`
-	Fallback string `yaml:"fallback"`
-	Summary  string `yaml:"summary"`
-	Corner   string `yaml:"corner"`
-	Article  string `yaml:"article"`
+// MessagePaths holds file paths for template files used in Slack messages.
+// Each field is a path to a text/template file. Relative paths are resolved
+// against the directory of the slack-spec.yaml file. Omit a field to use the
+// built-in default template.
+type MessagePaths struct {
+	Parent   string `yaml:"parent"`   // parent message (mp3 upload initial comment)
+	Thread   string `yaml:"thread"`   // thread reply body
+	Fallback string `yaml:"fallback"` // notification plain text
 }
 
 // SlackChannelConfig holds channel and message settings for a program.
 type SlackChannelConfig struct {
-	Channel string          `yaml:"channel"`
-	Message MessageTemplate `yaml:"message"`
-}
-
-// EffectiveMessageTemplate returns the configured template, falling back to defaults per field.
-func (c SlackChannelConfig) EffectiveMessageTemplate() MessageTemplate {
-	or := func(s, def string) string {
-		if s != "" {
-			return s
-		}
-		return def
-	}
-	return MessageTemplate{
-		Header:   or(c.Message.Header, defaultHeaderTemplate),
-		Fallback: or(c.Message.Fallback, defaultFallbackTemplate),
-		Summary:  or(c.Message.Summary, defaultSummaryTemplate),
-		Corner:   or(c.Message.Corner, defaultCornerTemplate),
-		Article:  or(c.Message.Article, defaultArticleTemplate),
-	}
+	Channel string       `yaml:"channel"`
+	Message MessagePaths `yaml:"message"`
 }
 
 // SlackSpec is the top-level structure for slack-spec.yaml.
 type SlackSpec struct {
-	Slack SlackChannelConfig `yaml:"slack"`
+	Slack   SlackChannelConfig `yaml:"slack"`
+	BaseDir string             `yaml:"-"` // directory of the spec file; set by LoadSlackSpec
+}
+
+// LoadedTemplates holds the loaded text/template source texts for the three message types.
+type LoadedTemplates struct {
+	Parent   string
+	Thread   string
+	Fallback string
+}
+
+// LoadTemplates returns the template text for each message type. When a path is
+// empty the built-in default template is used. When a path is set it is read
+// from disk; relative paths are resolved against baseDir.
+func (c SlackChannelConfig) LoadTemplates(baseDir string) (LoadedTemplates, error) {
+	parent, err := loadTemplateSrc(c.Message.Parent, defaultParentTemplate, baseDir)
+	if err != nil {
+		return LoadedTemplates{}, fmt.Errorf("load parent template: %w", err)
+	}
+	thread, err := loadTemplateSrc(c.Message.Thread, defaultThreadTemplate, baseDir)
+	if err != nil {
+		return LoadedTemplates{}, fmt.Errorf("load thread template: %w", err)
+	}
+	fallback, err := loadTemplateSrc(c.Message.Fallback, defaultFallbackTemplate, baseDir)
+	if err != nil {
+		return LoadedTemplates{}, fmt.Errorf("load fallback template: %w", err)
+	}
+	return LoadedTemplates{Parent: parent, Thread: thread, Fallback: fallback}, nil
+}
+
+func loadTemplateSrc(path, defaultText, baseDir string) (string, error) {
+	if path == "" {
+		return defaultText, nil
+	}
+	if !filepath.IsAbs(path) && baseDir != "" {
+		path = filepath.Join(baseDir, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 // LoadSlackSpec reads and parses a slack-spec.yaml file.
@@ -68,14 +110,42 @@ func loadSlackSpecWith(path string, strict bool) (SlackSpec, error) {
 	if err := fileio.DecodeYAML(path, &spec, strict); err != nil {
 		return SlackSpec{}, fmt.Errorf("load slack spec: %w", err)
 	}
+	spec.BaseDir = filepath.Dir(path)
 	return spec, nil
 }
 
 // ValidateSlackSpec validates the semantic correctness of a SlackSpec.
+// It checks that the channel is set and that any specified template file paths
+// exist and contain valid text/template syntax.
 func ValidateSlackSpec(spec SlackSpec) error {
 	var errs []error
 	if spec.Slack.Channel == "" {
 		errs = append(errs, errors.New("slack.channel is required"))
+	}
+	m := spec.Slack.Message
+	for _, entry := range []struct {
+		field string
+		path  string
+	}{
+		{"slack.message.parent", m.Parent},
+		{"slack.message.thread", m.Thread},
+		{"slack.message.fallback", m.Fallback},
+	} {
+		if entry.path == "" {
+			continue
+		}
+		p := entry.path
+		if !filepath.IsAbs(p) && spec.BaseDir != "" {
+			p = filepath.Join(spec.BaseDir, p)
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", entry.field, err))
+			continue
+		}
+		if _, err := template.New("").Parse(string(data)); err != nil {
+			errs = append(errs, fmt.Errorf("%s: template parse error: %w", entry.field, err))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/internal/slack/spec.go
+++ b/internal/slack/spec.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"text/template"
 
 	"github.com/canpok1/vox-radio/internal/fileio"
+	"github.com/canpok1/vox-radio/internal/render"
 )
 
 const (
@@ -80,14 +80,18 @@ func (c SlackChannelConfig) LoadTemplates(baseDir string) (LoadedTemplates, erro
 	return LoadedTemplates{Parent: parent, Thread: thread, Fallback: fallback}, nil
 }
 
+func resolvePath(path, baseDir string) string {
+	if !filepath.IsAbs(path) && baseDir != "" {
+		return filepath.Join(baseDir, path)
+	}
+	return path
+}
+
 func loadTemplateSrc(path, defaultText, baseDir string) (string, error) {
 	if path == "" {
 		return defaultText, nil
 	}
-	if !filepath.IsAbs(path) && baseDir != "" {
-		path = filepath.Join(baseDir, path)
-	}
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(resolvePath(path, baseDir))
 	if err != nil {
 		return "", err
 	}
@@ -134,16 +138,12 @@ func ValidateSlackSpec(spec SlackSpec) error {
 		if entry.path == "" {
 			continue
 		}
-		p := entry.path
-		if !filepath.IsAbs(p) && spec.BaseDir != "" {
-			p = filepath.Join(spec.BaseDir, p)
-		}
-		data, err := os.ReadFile(p)
+		data, err := os.ReadFile(resolvePath(entry.path, spec.BaseDir))
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %w", entry.field, err))
 			continue
 		}
-		if _, err := template.New("").Parse(string(data)); err != nil {
+		if err := render.Parse(string(data)); err != nil {
 			errs = append(errs, fmt.Errorf("%s: template parse error: %w", entry.field, err))
 		}
 	}

--- a/internal/slack/spec_test.go
+++ b/internal/slack/spec_test.go
@@ -204,6 +204,28 @@ func TestValidateSlackSpec_ValidTemplatePaths_Success(t *testing.T) {
 	}
 }
 
+func TestValidateSlackSpec_TemplateWithCornerFunction_Success(t *testing.T) {
+	dir := t.TempDir()
+	// Templates using corner/hasLinks must pass validation (render.Parse includes FuncMap).
+	tmplContent := `{{with corner "news"}}{{.Title}}{{end}}`
+	if err := os.WriteFile(filepath.Join(dir, "thread.tmpl"), []byte(tmplContent), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	spec := slack.SlackSpec{
+		Slack: slack.SlackChannelConfig{
+			Channel: "C0123456789",
+			Message: slack.MessagePaths{
+				Thread: "thread.tmpl",
+			},
+		},
+		BaseDir: dir,
+	}
+	if err := slack.ValidateSlackSpec(spec); err != nil {
+		t.Errorf("ValidateSlackSpec must accept template with corner function: %v", err)
+	}
+}
+
 func TestLoadTemplates_EmptyPaths_UsesDefaults(t *testing.T) {
 	config := slack.SlackChannelConfig{
 		Channel: "C0123456789",

--- a/internal/slack/spec_test.go
+++ b/internal/slack/spec_test.go
@@ -1,7 +1,10 @@
 package slack_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"text/template"
 
 	"github.com/canpok1/vox-radio/internal/slack"
 	"github.com/canpok1/vox-radio/internal/testutil"
@@ -10,12 +13,15 @@ import (
 const validSlackSpecYAML = `
 slack:
   channel: "C0123456789"
+`
+
+const validSlackSpecWithPathsYAML = `
+slack:
+  channel: "C0123456789"
   message:
-    header: "🎙️ {title} 第{episode_number}回「{episode_title}」"
-    fallback: "{title} 第{episode_number}回 を配信しました"
-    summary: "*今回のまとめ*\n{summary}"
-    corner: "*{corner_title}*\n{corner_summary}\n{articles}"
-    article: " • <{url}|{title}>"
+    parent: "slack-parent.tmpl"
+    thread: "slack-thread.tmpl"
+    fallback: "slack-fallback.tmpl"
 `
 
 func TestLoadSlackSpec_ValidYAML(t *testing.T) {
@@ -29,11 +35,40 @@ func TestLoadSlackSpec_ValidYAML(t *testing.T) {
 	if spec.Slack.Channel != "C0123456789" {
 		t.Errorf("Slack.Channel: got %q, want %q", spec.Slack.Channel, "C0123456789")
 	}
-	if spec.Slack.Message.Header == "" {
-		t.Error("Slack.Message.Header must not be empty")
+}
+
+func TestLoadSlackSpec_SetsBaseDir(t *testing.T) {
+	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(validSlackSpecYAML))
+
+	spec, err := slack.LoadSlackSpec(path)
+	if err != nil {
+		t.Fatalf("LoadSlackSpec: unexpected error: %v", err)
 	}
-	if spec.Slack.Message.Fallback == "" {
-		t.Error("Slack.Message.Fallback must not be empty")
+
+	if spec.BaseDir == "" {
+		t.Error("BaseDir must be set after loading")
+	}
+	if spec.BaseDir != filepath.Dir(path) {
+		t.Errorf("BaseDir: got %q, want %q", spec.BaseDir, filepath.Dir(path))
+	}
+}
+
+func TestLoadSlackSpec_WithMessagePaths(t *testing.T) {
+	path := testutil.WriteTempFile(t, "slack-spec.yaml", []byte(validSlackSpecWithPathsYAML))
+
+	spec, err := slack.LoadSlackSpec(path)
+	if err != nil {
+		t.Fatalf("LoadSlackSpec: unexpected error: %v", err)
+	}
+
+	if spec.Slack.Message.Parent != "slack-parent.tmpl" {
+		t.Errorf("Message.Parent: got %q, want %q", spec.Slack.Message.Parent, "slack-parent.tmpl")
+	}
+	if spec.Slack.Message.Thread != "slack-thread.tmpl" {
+		t.Errorf("Message.Thread: got %q, want %q", spec.Slack.Message.Thread, "slack-thread.tmpl")
+	}
+	if spec.Slack.Message.Fallback != "slack-fallback.tmpl" {
+		t.Errorf("Message.Fallback: got %q, want %q", spec.Slack.Message.Fallback, "slack-fallback.tmpl")
 	}
 }
 
@@ -85,8 +120,11 @@ slack:
 	if err != nil {
 		t.Fatalf("LoadSlackSpec: unexpected error: %v", err)
 	}
-	if spec.Slack.Message.Header != "" {
-		t.Errorf("Message.Header should be empty when omitted, got %q", spec.Slack.Message.Header)
+	if spec.Slack.Message.Parent != "" {
+		t.Errorf("Message.Parent should be empty when omitted, got %q", spec.Slack.Message.Parent)
+	}
+	if spec.Slack.Message.Thread != "" {
+		t.Errorf("Message.Thread should be empty when omitted, got %q", spec.Slack.Message.Thread)
 	}
 }
 
@@ -108,55 +146,165 @@ func TestValidateSlackSpec_EmptyChannel_Error(t *testing.T) {
 	}
 }
 
-func TestSlackSpec_EffectiveMessageTemplate_UsesCustomWhenSet(t *testing.T) {
+func TestValidateSlackSpec_MissingTemplateFile_Error(t *testing.T) {
 	spec := slack.SlackSpec{
 		Slack: slack.SlackChannelConfig{
 			Channel: "C0123456789",
-			Message: slack.MessageTemplate{
-				Header:   "custom header",
-				Fallback: "custom fallback",
-				Summary:  "custom summary",
-				Corner:   "custom corner",
-				Article:  "custom article",
+			Message: slack.MessagePaths{
+				Parent: "nonexistent-parent.tmpl",
 			},
 		},
+		BaseDir: t.TempDir(),
 	}
-	tmpl := spec.Slack.EffectiveMessageTemplate()
-	if tmpl.Header != "custom header" {
-		t.Errorf("Header: got %q, want %q", tmpl.Header, "custom header")
-	}
-	if tmpl.Fallback != "custom fallback" {
-		t.Errorf("Fallback: got %q, want %q", tmpl.Fallback, "custom fallback")
-	}
-	if tmpl.Summary != "custom summary" {
-		t.Errorf("Summary: got %q, want %q", tmpl.Summary, "custom summary")
-	}
-	if tmpl.Corner != "custom corner" {
-		t.Errorf("Corner: got %q, want %q", tmpl.Corner, "custom corner")
-	}
-	if tmpl.Article != "custom article" {
-		t.Errorf("Article: got %q, want %q", tmpl.Article, "custom article")
+	if err := slack.ValidateSlackSpec(spec); err == nil {
+		t.Error("expected error for missing template file")
 	}
 }
 
-func TestSlackSpec_EffectiveMessageTemplate_FallsBackToDefault(t *testing.T) {
+func TestValidateSlackSpec_InvalidTemplateSyntax_Error(t *testing.T) {
+	dir := t.TempDir()
+	badTmpl := "{{invalid template syntax"
+	badPath := filepath.Join(dir, "bad.tmpl")
+	if err := os.WriteFile(badPath, []byte(badTmpl), 0o644); err != nil {
+		t.Fatalf("write bad template: %v", err)
+	}
+
 	spec := slack.SlackSpec{
-		Slack: slack.SlackChannelConfig{Channel: "C0123456789"},
+		Slack: slack.SlackChannelConfig{
+			Channel: "C0123456789",
+			Message: slack.MessagePaths{
+				Parent: "bad.tmpl",
+			},
+		},
+		BaseDir: dir,
 	}
-	tmpl := spec.Slack.EffectiveMessageTemplate()
-	if tmpl.Header == "" {
-		t.Error("Header should fall back to default when not set")
+	if err := slack.ValidateSlackSpec(spec); err == nil {
+		t.Error("expected error for invalid template syntax")
 	}
-	if tmpl.Fallback == "" {
-		t.Error("Fallback should fall back to default when not set")
+}
+
+func TestValidateSlackSpec_ValidTemplatePaths_Success(t *testing.T) {
+	dir := t.TempDir()
+	tmplContent := `{{.Title}} {{if .EpisodeNumber}}第{{.EpisodeNumber}}回{{end}}`
+	if err := os.WriteFile(filepath.Join(dir, "parent.tmpl"), []byte(tmplContent), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
 	}
-	if tmpl.Summary == "" {
-		t.Error("Summary should fall back to default when not set")
+
+	spec := slack.SlackSpec{
+		Slack: slack.SlackChannelConfig{
+			Channel: "C0123456789",
+			Message: slack.MessagePaths{
+				Parent: "parent.tmpl",
+			},
+		},
+		BaseDir: dir,
 	}
-	if tmpl.Corner == "" {
-		t.Error("Corner should fall back to default when not set")
+	if err := slack.ValidateSlackSpec(spec); err != nil {
+		t.Errorf("unexpected error for valid template path: %v", err)
 	}
-	if tmpl.Article == "" {
-		t.Error("Article should fall back to default when not set")
+}
+
+func TestLoadTemplates_EmptyPaths_UsesDefaults(t *testing.T) {
+	config := slack.SlackChannelConfig{
+		Channel: "C0123456789",
+	}
+	templates, err := config.LoadTemplates("")
+	if err != nil {
+		t.Fatalf("LoadTemplates: unexpected error: %v", err)
+	}
+	if templates.Parent == "" {
+		t.Error("Parent template must not be empty when using defaults")
+	}
+	if templates.Thread == "" {
+		t.Error("Thread template must not be empty when using defaults")
+	}
+	if templates.Fallback == "" {
+		t.Error("Fallback template must not be empty when using defaults")
+	}
+	// Defaults must be valid text/template syntax
+	if _, err := template.New("").Parse(templates.Parent); err != nil {
+		t.Errorf("default parent template parse error: %v", err)
+	}
+	if _, err := template.New("").Parse(templates.Thread); err != nil {
+		t.Errorf("default thread template parse error: %v", err)
+	}
+	if _, err := template.New("").Parse(templates.Fallback); err != nil {
+		t.Errorf("default fallback template parse error: %v", err)
+	}
+}
+
+func TestLoadTemplates_WithFilePaths_ReadsFiles(t *testing.T) {
+	dir := t.TempDir()
+	parentContent := `親メッセージ: {{.Title}}`
+	threadContent := `スレッド: {{.Summary}}`
+	fallbackContent := `フォールバック: {{.Title}}`
+
+	for name, content := range map[string]string{
+		"parent.tmpl":   parentContent,
+		"thread.tmpl":   threadContent,
+		"fallback.tmpl": fallbackContent,
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	config := slack.SlackChannelConfig{
+		Channel: "C0123456789",
+		Message: slack.MessagePaths{
+			Parent:   "parent.tmpl",
+			Thread:   "thread.tmpl",
+			Fallback: "fallback.tmpl",
+		},
+	}
+	templates, err := config.LoadTemplates(dir)
+	if err != nil {
+		t.Fatalf("LoadTemplates: unexpected error: %v", err)
+	}
+
+	if templates.Parent != parentContent {
+		t.Errorf("Parent: got %q, want %q", templates.Parent, parentContent)
+	}
+	if templates.Thread != threadContent {
+		t.Errorf("Thread: got %q, want %q", templates.Thread, threadContent)
+	}
+	if templates.Fallback != fallbackContent {
+		t.Errorf("Fallback: got %q, want %q", templates.Fallback, fallbackContent)
+	}
+}
+
+func TestLoadTemplates_AbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	content := `絶対パステスト: {{.Title}}`
+	absPath := filepath.Join(dir, "abs.tmpl")
+	if err := os.WriteFile(absPath, []byte(content), 0o644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	config := slack.SlackChannelConfig{
+		Channel: "C0123456789",
+		Message: slack.MessagePaths{
+			Parent: absPath, // absolute path
+		},
+	}
+	templates, err := config.LoadTemplates("/some/other/dir")
+	if err != nil {
+		t.Fatalf("LoadTemplates: unexpected error: %v", err)
+	}
+	if templates.Parent != content {
+		t.Errorf("Parent: got %q, want %q", templates.Parent, content)
+	}
+}
+
+func TestLoadTemplates_MissingFile_Error(t *testing.T) {
+	config := slack.SlackChannelConfig{
+		Channel: "C0123456789",
+		Message: slack.MessagePaths{
+			Parent: "nonexistent.tmpl",
+		},
+	}
+	_, err := config.LoadTemplates(t.TempDir())
+	if err == nil {
+		t.Error("expected error for missing template file")
 	}
 }


### PR DESCRIPTION
関連タスク: [slackpost のメッセージ整形を text/template ベースの2テンプレ構成へ刷新する](https://todoist.com/app/task/6grqcMJPPHR2Mjh3)

## Summary

- `slack.message` フィールドを `parent` / `thread` / `fallback` のテンプレファイルパス指定へ刷新（旧インラインフィールド撤去）
- 共有エンジン `internal/render.Render()` / `render.Parse()` を使って `text/template` + FuncMap(`corner`/`hasLinks`) + manifest データ文脈で整形
- スレッド本文を 3000 文字以下の Section ブロックへ自動分割
- 特殊処理（`「」`除去・`第0回`除去・リンク剥がし・空行除去）を廃止し、テンプレ条件分岐へ移行
- `slackpost check` がテンプレファイルの存在・構文（`render.Parse` = FuncMap 付き）を検証
- `init` が `slack-spec.yaml`（テンプレパス指定）+ `slack-parent.tmpl` / `slack-thread.tmpl` を生成（ユーザー向けコメント付き）
- `references/slack-spec.md` を書き方ガイドとして充実（パス指定・データ文脈・FuncMap・レシピ集）
- `/simplify` 改善: `renderTemplate` ヘルパー抽出・`resolvePath` 重複除去・`currentRunes` カウンタ・`fallback` 事前レンダリング
- self-review: `render.Parse` ユニットテスト追加・`corner` 関数使用テンプレの ValidateSlackSpec 通過テスト追加

## Test plan

- [ ] `go test ./...` 全テスト通過を確認
- [ ] `gofmt -l .` / `golangci-lint run` がクリーン
- [ ] `vox-radio init` で `slack-spec.yaml` + `.tmpl` ファイルが生成されることを確認
- [ ] `vox-radio slackpost check <path>` でテンプレファイル存在・構文エラー検出を確認
- [ ] `corner`/`hasLinks` 使用テンプレが `slackpost check` でエラーにならないことを確認

---
🤖 Generated with [Claude Code](https://claude.ai/code)