### PR TITLE
feat(feed): 番組著者名（channel itunes:author）を ProgramConfig.Author に一本化

### DIFF
--- a/docs/cli/vox-radio_feedgen_check.md
+++ b/docs/cli/vox-radio_feedgen_check.md
@@ -7,7 +7,7 @@ feed-spec.yaml を strict モードでフル検証する
 指定した feed-spec.yaml を strict モードでパースし、以下を検証します:
 
   (a) strict パース: 未知キー（typo）をエラー化
-  (b) 必須フィールド: feed.language / feed.author / feed.email /
+  (b) 必須フィールド: feed.language / feed.email /
       feed.site_url / feed.audio_url_template の存在チェック
   (c) URL / email 形式: 各フィールドの値が正しい形式かチェック
   (d) プレースホルダ: audio_url_template に {episode_number} と {audio_file} が含まれるかチェック

--- a/e2e/features/check.feature
+++ b/e2e/features/check.feature
@@ -61,7 +61,6 @@
       """
       feed:
         language: "ja"
-        author: "テスター"
         email: "test@example.com"
         category: "Technology"
         explicit: false

--- a/e2e/fixtures/feed-spec.yaml
+++ b/e2e/fixtures/feed-spec.yaml
@@ -1,7 +1,6 @@
 # e2e テスト用のフィード生成設定。
 feed:
   language: "ja"
-  author: "E2Eテスター"
   email: "e2e@example.com"
   category: "Technology"
   explicit: false

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -40,6 +40,7 @@ type Entry struct {
 	Datetime          string                   `json:"datetime"`
 	EpisodeNumber     int                      `json:"episode_number,omitempty"`
 	EpisodeTitle      string                   `json:"episode_title,omitempty"`
+	Author            string                   `json:"author,omitempty"` // omitempty: backward compat with pre-author cache entries
 	Title             string                   `json:"title"`
 	Summary           string                   `json:"summary"`
 	Description       string                   `json:"description,omitempty"`
@@ -223,6 +224,7 @@ func BuildEntryFromManifest(programID string, m model.Manifest, rd model.Rundown
 		Datetime:          m.Datetime,
 		EpisodeNumber:     m.EpisodeNumber,
 		EpisodeTitle:      m.EpisodeTitle,
+		Author:            m.Author,
 		Title:             m.Title,
 		Summary:           m.Summary,
 		Description:       m.Description,

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -926,6 +926,35 @@ func TestPastDedupKeys_EmptyEntries(t *testing.T) {
 	}
 }
 
+func TestBuildEntryFromManifest_AuthorCopied(t *testing.T) {
+	m := model.Manifest{
+		Title:    "エピソード",
+		Datetime: "2026-06-01T00:00:00Z",
+		Author:   "テスト配信者",
+		Corners:  []model.ManifestCorner{},
+	}
+	rd := model.Rundown{}
+
+	got := cache.BuildEntryFromManifest("p", m, rd, 0, 0)
+	if got.Author != "テスト配信者" {
+		t.Errorf("Author: got %q, want %q", got.Author, "テスト配信者")
+	}
+}
+
+func TestBuildEntryFromManifest_AuthorEmptyWhenNotSet(t *testing.T) {
+	m := model.Manifest{
+		Title:    "エピソード",
+		Datetime: "2026-06-01T00:00:00Z",
+		Corners:  []model.ManifestCorner{},
+	}
+	rd := model.Rundown{}
+
+	got := cache.BuildEntryFromManifest("p", m, rd, 0, 0)
+	if got.Author != "" {
+		t.Errorf("Author: got %q, want empty", got.Author)
+	}
+}
+
 func TestBuildEntryFromManifest_CreditsIncluded(t *testing.T) {
 	m := model.Manifest{
 		Title:    "エピソード",

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -941,20 +941,6 @@ func TestBuildEntryFromManifest_AuthorCopied(t *testing.T) {
 	}
 }
 
-func TestBuildEntryFromManifest_AuthorEmptyWhenNotSet(t *testing.T) {
-	m := model.Manifest{
-		Title:    "エピソード",
-		Datetime: "2026-06-01T00:00:00Z",
-		Corners:  []model.ManifestCorner{},
-	}
-	rd := model.Rundown{}
-
-	got := cache.BuildEntryFromManifest("p", m, rd, 0, 0)
-	if got.Author != "" {
-		t.Errorf("Author: got %q, want empty", got.Author)
-	}
-}
-
 func TestBuildEntryFromManifest_CreditsIncluded(t *testing.T) {
 	m := model.Manifest{
 		Title:    "エピソード",

--- a/internal/cli/feedgen.go
+++ b/internal/cli/feedgen.go
@@ -59,7 +59,7 @@ func newFeedgenCheckCmd() *cobra.Command {
 		Long: `指定した feed-spec.yaml を strict モードでパースし、以下を検証します:
 
   (a) strict パース: 未知キー（typo）をエラー化
-  (b) 必須フィールド: feed.language / feed.author / feed.email /
+  (b) 必須フィールド: feed.language / feed.email /
       feed.site_url / feed.audio_url_template の存在チェック
   (c) URL / email 形式: 各フィールドの値が正しい形式かチェック
   (d) プレースホルダ: audio_url_template に {episode_number} と {audio_file} が含まれるかチェック

--- a/internal/cli/feedgen_check_test.go
+++ b/internal/cli/feedgen_check_test.go
@@ -35,7 +35,6 @@ func TestFeedgenCheck_UnknownKey_Error(t *testing.T) {
 func TestFeedgenCheck_MissingRequiredField_Error(t *testing.T) {
 	// feed.language が欠落した feed-spec.yaml
 	specPath := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(`feed:
-  author: Test Author
   email: test@example.com
   site_url: https://example.com/
   audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"
@@ -56,7 +55,6 @@ func TestFeedgenCheck_ProgramID_RaisesUnknownKey(t *testing.T) {
 	specPath := testutil.WriteTempFile(t, "feed-spec.yaml", []byte(`program_id: my-radio
 feed:
   language: ja
-  author: Test Author
   email: test@example.com
   site_url: https://example.com/
   audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"

--- a/internal/cli/skills/vox-radio/references/episode-spec.md
+++ b/internal/cli/skills/vox-radio/references/episode-spec.md
@@ -12,7 +12,7 @@
 |---|---|---|---|
 | `id` | string | 必須 | 番組を識別するID。キャッシュファイル名（`.vox-radio/cache/{id}.jsonl`）とキャッシュエントリの記録キーに使用。日替わりコーナーやゲストの登場回もこのIDをキーに数える |
 | `title` | string | 任意 | 番組タイトル |
-| `author` | string | 任意 | 番組の作者名。生成 MP3 のアーティストタグ（ID3 TPE1）に埋め込まれる。空の場合はタグが省略される |
+| `author` | string | 任意 | 番組の作者名。生成 MP3 のアーティストタグ（ID3 TPE1）と RSS フィードの channel `itunes:author` に使われる。空の場合はそれぞれ省略される |
 | `description` | string | 任意 | 番組の説明（LLM への指示に使用）。RSSフィード・Slack通知にも露出する公開フィールド |
 | `direction` | string | 任意 | 番組全体の演出方針（direct ステップのみに渡る）。SE・pause の挿入タイミングに関する指示。台本生成・manifest・feed・Slack には渡されない |
 | `script_note` | string | 任意 | 番組全体の台本指示（write ステップのみに渡る）。非公開フィールド。manifest・feed・Slack には露出しない。コーナーを問わず全台本に適用したいルールや注意事項を記述する |

--- a/internal/cli/skills/vox-radio/references/feed-spec.md
+++ b/internal/cli/skills/vox-radio/references/feed-spec.md
@@ -9,7 +9,6 @@
 | フィールド | 型 | 必須/任意 | 説明 |
 |---|---|---|---|
 | `feed.language` | string | 必須 | 言語コード（RSS channel language）。例: `ja` |
-| `feed.author` | string | 必須 | 配信者名（itunes:author） |
 | `feed.email` | string | 必須 | 連絡先メールアドレス（itunes:email） |
 | `feed.site_url` | string | 必須 | 番組サイト URL（RSS channel link） |
 | `feed.audio_url_template` | string | 必須 | 各エピソード音声ファイルの URL テンプレート。`{episode_number}` と `{audio_file}` が cache の値で置換される |

--- a/internal/cli/templates-sample/feed-spec.yaml
+++ b/internal/cli/templates-sample/feed-spec.yaml
@@ -7,8 +7,6 @@
 feed:
   # 番組の言語。
   language: "ja"
-  # 配信者の名前。
-  author: "あなたの名前"
   # 連絡先メールアドレス。
   email: "you@example.com"
   # ジャンル（Apple Podcasts などのカテゴリ）。不要なら空文字にします。

--- a/internal/cli/templates/feed-spec.yaml
+++ b/internal/cli/templates/feed-spec.yaml
@@ -7,8 +7,6 @@
 feed:
   # 番組の言語。
   language: "ja"
-  # 配信者の名前。
-  author: "あなたの名前"
   # 連絡先メールアドレス。
   email: "you@example.com"
   # ジャンル（Apple Podcasts などのカテゴリ）。不要なら空文字にするとタグが省かれます。

--- a/internal/config/testdata/feed_spec.yaml
+++ b/internal/config/testdata/feed_spec.yaml
@@ -1,6 +1,5 @@
 feed:
   language: ja
-  author: Test Author
   email: test@example.com
   site_url: https://example.com/
   audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"

--- a/internal/config/testdata/feed_spec_unknown_key.yaml
+++ b/internal/config/testdata/feed_spec_unknown_key.yaml
@@ -1,6 +1,5 @@
 feed:
   language: ja
-  author: Test Author
   email: test@example.com
   site_url: https://example.com/
   audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -23,7 +23,7 @@ type rssChannel struct {
 	Description    string          `xml:"description"`
 	Language       string          `xml:"language"`
 	Link           string          `xml:"link"`
-	ItunesAuthor   string          `xml:"itunes:author"`
+	ItunesAuthor   string          `xml:"itunes:author,omitempty"`
 	ItunesEmail    string          `xml:"itunes:email"`
 	ItunesCategory *itunesCategory `xml:"itunes:category"`
 	ItunesExplicit string          `xml:"itunes:explicit"`

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -61,13 +61,14 @@ type rssEnclosure struct {
 }
 
 // BuildFeed generates a podcast RSS 2.0 + iTunes feed XML from cache entries.
-// Channel title/description come from the latest entry. Items are ordered newest first.
+// Channel title/description/author come from the latest entry. Items are ordered newest first.
 func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
-	var channelTitle, channelDescription string
+	var channelTitle, channelDescription, channelAuthor string
 	if len(entries) > 0 {
 		latest := entries[len(entries)-1]
 		channelTitle = latest.Title
 		channelDescription = latest.Description
+		channelAuthor = latest.Author
 	}
 
 	var cat *itunesCategory
@@ -110,7 +111,7 @@ func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
 			Description:    channelDescription,
 			Language:       cfg.Feed.Language,
 			Link:           cfg.Feed.SiteURL,
-			ItunesAuthor:   cfg.Feed.Author,
+			ItunesAuthor:   channelAuthor,
 			ItunesEmail:    cfg.Feed.Email,
 			ItunesCategory: cat,
 			ItunesExplicit: explicitStr,

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -14,7 +14,6 @@ func TestBuildFeed_GoldenOutput(t *testing.T) {
 	cfg := feed.FeedSpec{
 		Feed: feed.FeedConfig{
 			Language:         "ja",
-			Author:           "testauthor",
 			Email:            "test@example.com",
 			Category:         "Technology",
 			Explicit:         false,
@@ -31,6 +30,7 @@ func TestBuildFeed_GoldenOutput(t *testing.T) {
 			Datetime:      "2024-01-01T10:00:00+09:00",
 			EpisodeNumber: 1,
 			EpisodeTitle:  "AIニュース特集",
+			Author:        "testauthor",
 			Title:         "テストラジオ",
 			Summary:       "エピソード1の概要",
 			Description:   "番組説明テキスト",
@@ -43,6 +43,7 @@ func TestBuildFeed_GoldenOutput(t *testing.T) {
 			Datetime:      "2024-01-08T10:00:00+09:00",
 			EpisodeNumber: 2,
 			EpisodeTitle:  "Go言語特集",
+			Author:        "testauthor",
 			Title:         "テストラジオ",
 			Summary:       "エピソード2の概要",
 			Description:   "番組説明テキスト",
@@ -135,6 +136,50 @@ func TestBuildFeed_GUID(t *testing.T) {
 
 	if !strings.Contains(got, "ep-5") {
 		t.Errorf("BuildFeed: expected GUID 'ep-5' in output\ngot:\n%s", got)
+	}
+}
+
+func TestBuildFeed_ChannelAuthorFromLatestEntry(t *testing.T) {
+	cfg := feed.FeedSpec{
+		Feed: feed.FeedConfig{
+			AudioURLTemplate: "https://host.example/{episode_number}/{audio_file}",
+		},
+	}
+	entries := []cache.Entry{
+		{
+			ProgramID:     "radio",
+			Datetime:      "2024-01-01T00:00:00Z",
+			EpisodeNumber: 1,
+			Author:        "古い配信者",
+			Title:         "古いタイトル",
+			Summary:       "古い要約",
+			AudioFile:     "ep001.mp3",
+			Bytes:         1000,
+			DurationSec:   600,
+		},
+		{
+			ProgramID:     "radio",
+			Datetime:      "2024-01-08T00:00:00Z",
+			EpisodeNumber: 2,
+			Author:        "最新配信者",
+			Title:         "最新タイトル",
+			Summary:       "最新要約",
+			AudioFile:     "ep002.mp3",
+			Bytes:         2000,
+			DurationSec:   700,
+		},
+	}
+
+	got, err := feed.BuildFeed(cfg, entries)
+	if err != nil {
+		t.Fatalf("BuildFeed: %v", err)
+	}
+
+	if !strings.Contains(got, "最新配信者") {
+		t.Errorf("BuildFeed: channel itunes:author should be from latest entry '最新配信者'\ngot:\n%s", got)
+	}
+	if strings.Contains(got, "古い配信者") {
+		t.Errorf("BuildFeed: channel itunes:author should NOT be '古い配信者'\ngot:\n%s", got)
 	}
 }
 

--- a/internal/feed/feed_test.go
+++ b/internal/feed/feed_test.go
@@ -246,6 +246,9 @@ func TestBuildFeed_EmptyEntries(t *testing.T) {
 	if strings.Contains(got, "<item>") {
 		t.Errorf("BuildFeed: expected no <item> elements for empty entries\ngot:\n%s", got)
 	}
+	if strings.Contains(got, "itunes:author") {
+		t.Errorf("BuildFeed: itunes:author should be omitted when Author is empty\ngot:\n%s", got)
+	}
 }
 
 func TestBuildFeed_CreditsAppendedToDescription(t *testing.T) {

--- a/internal/feed/spec.go
+++ b/internal/feed/spec.go
@@ -18,7 +18,6 @@ const (
 // FeedConfig holds RSS feed metadata for feed-spec.yaml.
 type FeedConfig struct {
 	Language         string `yaml:"language"`
-	Author           string `yaml:"author"`
 	Email            string `yaml:"email"`
 	Category         string `yaml:"category"`
 	Explicit         bool   `yaml:"explicit"`
@@ -84,9 +83,6 @@ func ValidateFeedSpec(spec FeedSpec) error {
 	// (b) required fields
 	if spec.Feed.Language == "" {
 		errs = append(errs, errors.New("feed.language is required"))
-	}
-	if spec.Feed.Author == "" {
-		errs = append(errs, errors.New("feed.author is required"))
 	}
 	if spec.Feed.Email == "" {
 		errs = append(errs, errors.New("feed.email is required"))

--- a/internal/feed/spec_test.go
+++ b/internal/feed/spec_test.go
@@ -11,7 +11,6 @@ import (
 const validFeedSpecYAML = `
 feed:
   language: ja
-  author: Test Author
   email: test@example.com
   site_url: https://example.com/
   audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"
@@ -23,7 +22,6 @@ func TestLoadFeedSpec_ValidYAML(t *testing.T) {
 	content := `
 feed:
   language: ja
-  author: testauthor
   email: test@example.com
   category: Technology
   explicit: false
@@ -43,9 +41,6 @@ output:
 
 	if cfg.Feed.Language != "ja" {
 		t.Errorf("Feed.Language: got %q, want %q", cfg.Feed.Language, "ja")
-	}
-	if cfg.Feed.Author != "testauthor" {
-		t.Errorf("Feed.Author: got %q, want %q", cfg.Feed.Author, "testauthor")
 	}
 	if cfg.Feed.Email != "test@example.com" {
 		t.Errorf("Feed.Email: got %q, want %q", cfg.Feed.Email, "test@example.com")
@@ -85,7 +80,6 @@ func TestLoadFeedSpec_CreditsHeaderField(t *testing.T) {
 	content := `
 feed:
   language: ja
-  author: Test Author
   email: test@example.com
   site_url: https://example.com/
   audio_url_template: "https://example.com/ep-{episode_number}/{audio_file}"
@@ -175,7 +169,6 @@ func validSpec() feed.FeedSpec {
 	return feed.FeedSpec{
 		Feed: feed.FeedConfig{
 			Language:         "ja",
-			Author:           "Test Author",
 			Email:            "test@example.com",
 			SiteURL:          "https://example.com/",
 			AudioURLTemplate: "https://example.com/ep-{episode_number}/{audio_file}",
@@ -210,12 +203,6 @@ func TestValidateFeedSpec(t *testing.T) {
 			mutate:      func(s *feed.FeedSpec) { s.Feed.Language = "" },
 			wantErr:     true,
 			errContains: []string{"feed.language"},
-		},
-		{
-			name:        "missing author",
-			mutate:      func(s *feed.FeedSpec) { s.Feed.Author = "" },
-			wantErr:     true,
-			errContains: []string{"feed.author"},
 		},
 		{
 			name:        "missing email",
@@ -281,10 +268,10 @@ func TestValidateFeedSpec(t *testing.T) {
 			name: "multiple errors collected",
 			mutate: func(s *feed.FeedSpec) {
 				s.Feed.Language = ""
-				s.Feed.Author = ""
+				s.Feed.Email = ""
 			},
 			wantErr:     true,
-			errContains: []string{"feed.language", "feed.author"},
+			errContains: []string{"feed.language", "feed.email"},
 		},
 	}
 

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -76,6 +76,7 @@ func Build(p BuildParams) model.Manifest {
 		Title:             p.Program.Title,
 		EpisodeNumber:     p.EpisodeNumber,
 		EpisodeTitle:      p.EpisodeTitle,
+		Author:            p.Program.Author,
 		Description:       p.Program.Description,
 		Summary:           p.Summary,
 		Datetime:          p.GeneratedAt.UTC().Format(time.RFC3339),

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -241,6 +241,22 @@ func TestBuild(t *testing.T) {
 	})
 }
 
+func TestBuild_AuthorCopiedFromProgram(t *testing.T) {
+	p := newMinimalBuildParams()
+	p.Program.Author = "テスト配信者"
+	got := manifest.Build(p)
+	if got.Author != "テスト配信者" {
+		t.Errorf("Author = %q, want %q", got.Author, "テスト配信者")
+	}
+}
+
+func TestBuild_AuthorEmptyWhenNotSet(t *testing.T) {
+	got := manifest.Build(newMinimalBuildParams())
+	if got.Author != "" {
+		t.Errorf("Author = %q, want empty", got.Author)
+	}
+}
+
 func TestBuild_CastsCopiedFromRundown(t *testing.T) {
 	p := newMinimalBuildParams()
 	p.Rundown = model.Rundown{

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -250,13 +250,6 @@ func TestBuild_AuthorCopiedFromProgram(t *testing.T) {
 	}
 }
 
-func TestBuild_AuthorEmptyWhenNotSet(t *testing.T) {
-	got := manifest.Build(newMinimalBuildParams())
-	if got.Author != "" {
-		t.Errorf("Author = %q, want empty", got.Author)
-	}
-}
-
 func TestBuild_CastsCopiedFromRundown(t *testing.T) {
 	p := newMinimalBuildParams()
 	p.Rundown = model.Rundown{

--- a/internal/model/manifest.go
+++ b/internal/model/manifest.go
@@ -119,6 +119,7 @@ type Manifest struct {
 	Title             string             `json:"title"`
 	EpisodeNumber     int                `json:"episode_number,omitempty"`
 	EpisodeTitle      string             `json:"episode_title,omitempty"`
+	Author            string             `json:"author,omitempty"`
 	Description       string             `json:"description"`
 	Summary           string             `json:"summary"`
 	Datetime          string             `json:"datetime"`


### PR DESCRIPTION
関連タスク: [番組の著者名（feed の channel itunes:author）を番組設定 author に一本化する](https://app.todoist.com/app/task/6grwXP8mWQxJhjj3)

## Summary

- `FeedConfig.Author`（`feed.author`）を廃止し、番組設定（`ProgramConfig.Author`）を著者名の唯一の出典に一本化する
- 伝播経路: `ProgramConfig.Author` → `model.Manifest.Author` → `cache.Entry.Author` → feed channel `<itunes:author>`
- 旧 cache エントリとの後方互換は `json:"author,omitempty"` で担保

## Changes

| 層 | 変更内容 |
|----|---------|
| `internal/model/manifest.go` | `Manifest` に `Author string` (omitempty) 追加 |
| `internal/manifest/manifest.go` | `Build()` で `Author: p.Program.Author` を転記 |
| `internal/cache/cache.go` | `Entry` に `Author string` (omitempty) 追加、`BuildEntryFromManifest` で転記 |
| `internal/feed/feed.go` | channel `ItunesAuthor` を `latest.Author`（cache entry）から取得に変更 |
| `internal/feed/spec.go` | `FeedConfig.Author` フィールドと author 必須バリデーションを削除 |
| templates / testdata | `feed-spec.yaml` から `author:` を削除 |
| docs / references | feed-spec リファレンス・CLI docs を更新 |

## 移行手順

既存の `feed-spec.yaml` に `author:` キーが残っている場合、`vox-radio feedgen check` が **unknown key エラー** になります。`author:` 行を削除してから実行してください。

```yaml
# 削除してください:
# author: "あなたの名前"
```

著者名は `vox-radio.yaml`（番組設定）の `author` フィールドのみで管理します。

---

🤖 Generated with [Claude Code](https://claude.ai/code)