### PR TITLE
refactor(testutil): StrPtr/Float64Ptr/BoolPtr をジェネリクス Ptr[T any] に統合する

### DIFF
--- a/internal/assemble/filter_test.go
+++ b/internal/assemble/filter_test.go
@@ -151,7 +151,7 @@ func TestBuildFFmpegArgs_SESegment(t *testing.T) {
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			SE: map[string]config.SEEntry{
-				"chime": {File: "/assets/chime.wav", Volume: 0.8, Overlay: testutil.BoolPtr(true)},
+				"chime": {File: "/assets/chime.wav", Volume: 0.8, Overlay: testutil.Ptr(true)},
 			},
 		},
 		PauseSec: 0.5,
@@ -851,7 +851,7 @@ func TestBuildFFmpegArgs_SEAfterPause_HasShiftedOffset(t *testing.T) {
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			SE: map[string]config.SEEntry{
-				"chime": {File: "/assets/chime.wav", Volume: 1.0, Overlay: testutil.BoolPtr(true)},
+				"chime": {File: "/assets/chime.wav", Volume: 1.0, Overlay: testutil.Ptr(true)},
 			},
 		},
 		PauseSec: 0.5,
@@ -1346,7 +1346,7 @@ func TestBuildFFmpegArgs_SameSpeakerContinuation_SEOffsetConsistent(t *testing.T
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			SE: map[string]config.SEEntry{
-				"chime": {File: "/assets/chime.wav", Volume: 1.0, Overlay: testutil.BoolPtr(true)},
+				"chime": {File: "/assets/chime.wav", Volume: 1.0, Overlay: testutil.Ptr(true)},
 			},
 		},
 		PauseSec: 0.3,
@@ -1481,7 +1481,7 @@ func TestBuildFFmpegArgs_SE_SequentialDurationAdvancesOverlaySEOffset(t *testing
 		Assets: config.AssetsConfig{
 			SE: map[string]config.SEEntry{
 				"seq_se":     {File: "/assets/seq.wav", Volume: 1.0},
-				"overlay_se": {File: "/assets/overlay.wav", Volume: 1.0, Overlay: testutil.BoolPtr(true)},
+				"overlay_se": {File: "/assets/overlay.wav", Volume: 1.0, Overlay: testutil.Ptr(true)},
 			},
 		},
 		SEDurations: map[string]float64{"seq_se": 1.5},
@@ -1534,7 +1534,7 @@ func TestBuildFFmpegArgs_Golden_FilterComplex(t *testing.T) {
 				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, DuckRatio: 4.0},
 			},
 			SE: map[string]config.SEEntry{
-				"chime": {File: "/assets/chime.wav", Volume: 0.8, Overlay: testutil.BoolPtr(true)},
+				"chime": {File: "/assets/chime.wav", Volume: 0.8, Overlay: testutil.Ptr(true)},
 			},
 			Jingle: map[string]config.JingleEntry{
 				"op": {File: "/assets/op.wav", FadeIn: 0.3},
@@ -1660,7 +1660,7 @@ func TestBuildSEOverlay_OneOverlayEvent(t *testing.T) {
 	events := []seEvent{{assetName: "chime", offsetMs: 2000}}
 	assets := config.AssetsConfig{
 		SE: map[string]config.SEEntry{
-			"chime": {File: "/chime.wav", Volume: 0.8, Overlay: testutil.BoolPtr(true)},
+			"chime": {File: "/chime.wav", Volume: 0.8, Overlay: testutil.Ptr(true)},
 		},
 	}
 	outLabel := buildSEOverlay(b, events, assets, 0, "[input]")
@@ -1742,7 +1742,7 @@ func TestBuildFFmpegArgs_BGMFadeInOut_A1(t *testing.T) {
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			BGM: map[string]config.BGMEntry{
-				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Float64Ptr(0.5), FadeOut: testutil.Float64Ptr(0.5)},
+				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Ptr(0.5), FadeOut: testutil.Ptr(0.5)},
 			},
 		},
 		PauseSec: 0.5,
@@ -1822,7 +1822,7 @@ func TestBuildFFmpegArgs_BGMFadeDisabled_A5(t *testing.T) {
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			BGM: map[string]config.BGMEntry{
-				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Float64Ptr(0), FadeOut: testutil.Float64Ptr(0)},
+				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Ptr(0.0), FadeOut: testutil.Ptr(0.0)},
 			},
 		},
 		PauseSec: 0.5,
@@ -1863,8 +1863,8 @@ func TestBuildFFmpegArgs_BGMCrossfade_A2(t *testing.T) {
 		ClipsDir: "/clips",
 		Assets: config.AssetsConfig{
 			BGM: map[string]config.BGMEntry{
-				"bgm_a": {File: "/assets/bgm_a.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Float64Ptr(0.5), FadeOut: testutil.Float64Ptr(1.0)},
-				"bgm_b": {File: "/assets/bgm_b.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Float64Ptr(1.0), FadeOut: testutil.Float64Ptr(0.5)},
+				"bgm_a": {File: "/assets/bgm_a.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Ptr(0.5), FadeOut: testutil.Ptr(1.0)},
+				"bgm_b": {File: "/assets/bgm_b.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Ptr(1.0), FadeOut: testutil.Ptr(0.5)},
 			},
 		},
 		PauseSec: 0.5,
@@ -1929,7 +1929,7 @@ func TestBuildFFmpegArgs_BGMShortClamp_A4(t *testing.T) {
 		Assets: config.AssetsConfig{
 			BGM: map[string]config.BGMEntry{
 				// FadeIn=1.0 and FadeOut=1.0 both exceed half the BGM interval duration
-				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Float64Ptr(1.0), FadeOut: testutil.Float64Ptr(1.0)},
+				"talk_bgm": {File: "/assets/bgm.mp3", Volume: 0.3, Loop: true, FadeIn: testutil.Ptr(1.0), FadeOut: testutil.Ptr(1.0)},
 			},
 		},
 		PauseSec: 0.5,

--- a/internal/assemble/preview_test.go
+++ b/internal/assemble/preview_test.go
@@ -114,8 +114,8 @@ func TestBuildPreviewFFmpegArgs_BGM_ContainsExpectedFilters(t *testing.T) {
 			"talk": {
 				File:    "/audio/talk.mp3",
 				Volume:  0.3,
-				FadeIn:  testutil.Float64Ptr(1.0),
-				FadeOut: testutil.Float64Ptr(1.0),
+				FadeIn:  testutil.Ptr(1.0),
+				FadeOut: testutil.Ptr(1.0),
 			},
 		},
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -287,7 +287,7 @@ func TestValidateEpisodeSpecAssets(t *testing.T) {
 			name: "valid start_audio jingle",
 			spec: &config.EpisodeSpec{
 				Corners: []config.CornerConfig{
-					{Title: "C1", StartAudio: &config.AudioRef{Type: "jingle", ID: "opening"}, BGM: testutil.StrPtr("talk_bgm")},
+					{Title: "C1", StartAudio: &config.AudioRef{Type: "jingle", ID: "opening"}, BGM: testutil.Ptr("talk_bgm")},
 				},
 				Assets: config.AssetsConfig{
 					Jingle: map[string]config.JingleEntry{"opening": {File: "opening.mp3"}},
@@ -374,7 +374,7 @@ func TestValidateEpisodeSpecAssets(t *testing.T) {
 		{
 			name: "unknown bgm",
 			spec: &config.EpisodeSpec{
-				Corners: []config.CornerConfig{{Title: "C1", BGM: testutil.StrPtr("nonexistent")}},
+				Corners: []config.CornerConfig{{Title: "C1", BGM: testutil.Ptr("nonexistent")}},
 				Assets: config.AssetsConfig{
 					Jingle: map[string]config.JingleEntry{},
 					BGM:    map[string]config.BGMEntry{},
@@ -1459,8 +1459,8 @@ func TestJingleEntry_EffectiveTrimSilence(t *testing.T) {
 		want bool
 	}{
 		{nil, true},
-		{testutil.BoolPtr(false), false},
-		{testutil.BoolPtr(true), true},
+		{testutil.Ptr(false), false},
+		{testutil.Ptr(true), true},
 	}
 	for _, c := range cases {
 		e := config.JingleEntry{TrimSilence: c.ptr}
@@ -1476,8 +1476,8 @@ func TestSEEntry_EffectiveTrimSilence(t *testing.T) {
 		want bool
 	}{
 		{nil, true},
-		{testutil.BoolPtr(false), false},
-		{testutil.BoolPtr(true), true},
+		{testutil.Ptr(false), false},
+		{testutil.Ptr(true), true},
 	}
 	for _, c := range cases {
 		e := config.SEEntry{TrimSilence: c.ptr}
@@ -1493,8 +1493,8 @@ func TestSEEntry_EffectiveOverlay(t *testing.T) {
 		want bool
 	}{
 		{nil, false},
-		{testutil.BoolPtr(false), false},
-		{testutil.BoolPtr(true), true},
+		{testutil.Ptr(false), false},
+		{testutil.Ptr(true), true},
 	}
 	for _, c := range cases {
 		e := config.SEEntry{Overlay: c.ptr}
@@ -1511,8 +1511,8 @@ func TestCornerConfig_EffectiveBGM(t *testing.T) {
 		want string
 	}{
 		{name: "nil returns empty", bgm: nil, want: ""},
-		{name: "empty string returns empty (disabled)", bgm: testutil.StrPtr(""), want: ""},
-		{name: "key returned as-is", bgm: testutil.StrPtr("talk_bgm"), want: "talk_bgm"},
+		{name: "empty string returns empty (disabled)", bgm: testutil.Ptr(""), want: ""},
+		{name: "key returned as-is", bgm: testutil.Ptr("talk_bgm"), want: "talk_bgm"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1531,7 +1531,7 @@ func TestCornerConfig_EffectiveStartPauseSec(t *testing.T) {
 		want float64
 	}{
 		{name: "nil returns 0", sec: nil, want: 0},
-		{name: "explicit value returned", sec: testutil.Float64Ptr(1.5), want: 1.5},
+		{name: "explicit value returned", sec: testutil.Ptr(1.5), want: 1.5},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1550,7 +1550,7 @@ func TestCornerConfig_EffectiveEndPauseSec(t *testing.T) {
 		want float64
 	}{
 		{name: "nil returns 0", sec: nil, want: 0},
-		{name: "explicit value returned", sec: testutil.Float64Ptr(2.0), want: 2.0},
+		{name: "explicit value returned", sec: testutil.Ptr(2.0), want: 2.0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1679,7 +1679,7 @@ func TestLoadEpisodeSpec_CornerDefaults_BackwardCompat(t *testing.T) {
 func TestValidateAssets_CornerDefaults_EmptyBGM_Error(t *testing.T) {
 	spec := &config.EpisodeSpec{
 		CornerDefaults: &config.CornerDefaults{
-			BGM: testutil.StrPtr(""),
+			BGM: testutil.Ptr(""),
 		},
 		Assets: config.AssetsConfig{
 			BGM: map[string]config.BGMEntry{},
@@ -1693,7 +1693,7 @@ func TestValidateAssets_CornerDefaults_EmptyBGM_Error(t *testing.T) {
 func TestValidateAssets_CornerDefaults_UnknownBGM_Error(t *testing.T) {
 	spec := &config.EpisodeSpec{
 		CornerDefaults: &config.CornerDefaults{
-			BGM: testutil.StrPtr("nonexistent"),
+			BGM: testutil.Ptr("nonexistent"),
 		},
 		Assets: config.AssetsConfig{
 			BGM: map[string]config.BGMEntry{},
@@ -1707,7 +1707,7 @@ func TestValidateAssets_CornerDefaults_UnknownBGM_Error(t *testing.T) {
 func TestValidateAssets_CornerDefaults_Valid(t *testing.T) {
 	spec := &config.EpisodeSpec{
 		CornerDefaults: &config.CornerDefaults{
-			BGM:        testutil.StrPtr("talk_bgm"),
+			BGM:        testutil.Ptr("talk_bgm"),
 			StartAudio: &config.AudioRef{Type: "jingle", ID: "opening"},
 		},
 		Assets: config.AssetsConfig{
@@ -1806,9 +1806,9 @@ func TestBGMEntry_EffectiveFadeIn(t *testing.T) {
 		want float64
 	}{
 		{"nil defaults to DefaultBGMFadeSec", nil, config.DefaultBGMFadeSec},
-		{"zero disables fade-in", testutil.Float64Ptr(0.0), 0.0},
-		{"positive value used as-is", testutil.Float64Ptr(2.0), 2.0},
-		{"negative clamped to zero", testutil.Float64Ptr(-1.0), 0.0},
+		{"zero disables fade-in", testutil.Ptr(0.0), 0.0},
+		{"positive value used as-is", testutil.Ptr(2.0), 2.0},
+		{"negative clamped to zero", testutil.Ptr(-1.0), 0.0},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -1827,9 +1827,9 @@ func TestBGMEntry_EffectiveFadeOut(t *testing.T) {
 		want float64
 	}{
 		{"nil defaults to DefaultBGMFadeSec", nil, config.DefaultBGMFadeSec},
-		{"zero disables fade-out", testutil.Float64Ptr(0.0), 0.0},
-		{"positive value used as-is", testutil.Float64Ptr(2.0), 2.0},
-		{"negative clamped to zero", testutil.Float64Ptr(-1.0), 0.0},
+		{"zero disables fade-out", testutil.Ptr(0.0), 0.0},
+		{"positive value used as-is", testutil.Ptr(2.0), 2.0},
+		{"negative clamped to zero", testutil.Ptr(-1.0), 0.0},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2021,8 +2021,8 @@ func TestJingleEntry_EffectiveTrimSilenceThresholdDB(t *testing.T) {
 		want float64
 	}{
 		{"nil uses default", nil, -50.0},
-		{"explicit -40", testutil.Float64Ptr(-40.0), -40.0},
-		{"explicit -47.5", testutil.Float64Ptr(-47.5), -47.5},
+		{"explicit -40", testutil.Ptr(-40.0), -40.0},
+		{"explicit -47.5", testutil.Ptr(-47.5), -47.5},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2041,8 +2041,8 @@ func TestSEEntry_EffectiveTrimSilenceThresholdDB(t *testing.T) {
 		want float64
 	}{
 		{"nil uses default", nil, -50.0},
-		{"explicit -40", testutil.Float64Ptr(-40.0), -40.0},
-		{"explicit -47.5", testutil.Float64Ptr(-47.5), -47.5},
+		{"explicit -40", testutil.Ptr(-40.0), -40.0},
+		{"explicit -47.5", testutil.Ptr(-47.5), -47.5},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2065,9 +2065,9 @@ func TestJingleEntry_Validate(t *testing.T) {
 		{"fade_in negative", config.JingleEntry{FadeIn: -1.0, FadeOut: 0}, true},
 		{"fade_out negative", config.JingleEntry{FadeIn: 0, FadeOut: -0.5}, true},
 		{"trim_silence_threshold nil is valid", config.JingleEntry{TrimSilenceThreshold: nil}, false},
-		{"trim_silence_threshold negative is valid", config.JingleEntry{TrimSilenceThreshold: testutil.Float64Ptr(-40.0)}, false},
-		{"trim_silence_threshold zero is invalid", config.JingleEntry{TrimSilenceThreshold: testutil.Float64Ptr(0.0)}, true},
-		{"trim_silence_threshold positive is invalid", config.JingleEntry{TrimSilenceThreshold: testutil.Float64Ptr(1.0)}, true},
+		{"trim_silence_threshold negative is valid", config.JingleEntry{TrimSilenceThreshold: testutil.Ptr(-40.0)}, false},
+		{"trim_silence_threshold zero is invalid", config.JingleEntry{TrimSilenceThreshold: testutil.Ptr(0.0)}, true},
+		{"trim_silence_threshold positive is invalid", config.JingleEntry{TrimSilenceThreshold: testutil.Ptr(1.0)}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2089,9 +2089,9 @@ func TestSEEntry_Validate(t *testing.T) {
 		{"valid positive volume", config.SEEntry{Volume: 0.8}, false},
 		{"volume negative", config.SEEntry{Volume: -0.1}, true},
 		{"trim_silence_threshold nil is valid", config.SEEntry{TrimSilenceThreshold: nil}, false},
-		{"trim_silence_threshold negative is valid", config.SEEntry{TrimSilenceThreshold: testutil.Float64Ptr(-40.0)}, false},
-		{"trim_silence_threshold zero is invalid", config.SEEntry{TrimSilenceThreshold: testutil.Float64Ptr(0.0)}, true},
-		{"trim_silence_threshold positive is invalid", config.SEEntry{TrimSilenceThreshold: testutil.Float64Ptr(1.0)}, true},
+		{"trim_silence_threshold negative is valid", config.SEEntry{TrimSilenceThreshold: testutil.Ptr(-40.0)}, false},
+		{"trim_silence_threshold zero is invalid", config.SEEntry{TrimSilenceThreshold: testutil.Ptr(0.0)}, true},
+		{"trim_silence_threshold positive is invalid", config.SEEntry{TrimSilenceThreshold: testutil.Ptr(1.0)}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -2115,12 +2115,12 @@ func TestBGMEntry_Validate(t *testing.T) {
 		{"duck_ratio zero", config.BGMEntry{Volume: 0.3, DuckRatio: 0}, true},
 		{"duck_ratio less than 1", config.BGMEntry{Volume: 0.3, DuckRatio: 0.5}, true},
 		{"fade_in nil is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: nil}, false},
-		{"fade_in zero is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: testutil.Float64Ptr(0.0)}, false},
-		{"fade_in positive is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: testutil.Float64Ptr(1.0)}, false},
-		{"fade_in negative", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: testutil.Float64Ptr(-1.0)}, true},
+		{"fade_in zero is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: testutil.Ptr(0.0)}, false},
+		{"fade_in positive is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: testutil.Ptr(1.0)}, false},
+		{"fade_in negative", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeIn: testutil.Ptr(-1.0)}, true},
 		{"fade_out nil is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeOut: nil}, false},
-		{"fade_out zero is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeOut: testutil.Float64Ptr(0.0)}, false},
-		{"fade_out negative", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeOut: testutil.Float64Ptr(-0.5)}, true},
+		{"fade_out zero is valid", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeOut: testutil.Ptr(0.0)}, false},
+		{"fade_out negative", config.BGMEntry{Volume: 0.3, DuckRatio: 8, FadeOut: testutil.Ptr(-0.5)}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/script/script_test.go
+++ b/internal/script/script_test.go
@@ -361,7 +361,7 @@ func TestBuildScriptLines_TransfersCornerAudio(t *testing.T) {
 			Title:      "OP",
 			Direction:  "dir",
 			StartAudio: &config.AudioRef{Type: "jingle", ID: "opening"},
-			BGM:        testutil.StrPtr("bgm1"),
+			BGM:        testutil.Ptr("bgm1"),
 		},
 		{
 			Title:    "ED",

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -6,14 +6,8 @@ import (
 	"testing"
 )
 
-// StrPtr returns a pointer to v.
-func StrPtr(v string) *string { return &v }
-
-// Float64Ptr returns a pointer to v.
-func Float64Ptr(v float64) *float64 { return &v }
-
-// BoolPtr returns a pointer to v.
-func BoolPtr(v bool) *bool { return &v }
+// Ptr returns a pointer to v.
+func Ptr[T any](v T) *T { return &v }
 
 // WriteTempFile writes content to a temp file named name inside t.TempDir() and returns its path.
 func WriteTempFile(t *testing.T, name string, content []byte) string {

--- a/internal/testutil/testutil_test.go
+++ b/internal/testutil/testutil_test.go
@@ -34,57 +34,32 @@ func TestWriteTempFile_FileIsCleanedUpAfterTest(t *testing.T) {
 	}
 }
 
-func TestStrPtr(t *testing.T) {
-	tests := []struct {
-		name string
-		v    string
-	}{
-		{"empty string", ""},
-		{"non-empty string", "hello"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := testutil.StrPtr(tt.v)
-			if *got != tt.v {
-				t.Errorf("*StrPtr(%q) = %q, want %q", tt.v, *got, tt.v)
+func TestPtr_ReturnsPointerToValue(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		cases := []string{"", "hello"}
+		for _, v := range cases {
+			got := testutil.Ptr(v)
+			if *got != v {
+				t.Errorf("*Ptr(%q) = %q, want %q", v, *got, v)
 			}
-		})
-	}
-}
-
-func TestFloat64Ptr(t *testing.T) {
-	tests := []struct {
-		name string
-		v    float64
-	}{
-		{"zero", 0.0},
-		{"positive", 1.5},
-		{"negative", -0.5},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := testutil.Float64Ptr(tt.v)
-			if *got != tt.v {
-				t.Errorf("*Float64Ptr(%v) = %v, want %v", tt.v, *got, tt.v)
+		}
+	})
+	t.Run("float64", func(t *testing.T) {
+		cases := []float64{0.0, 1.5, -0.5}
+		for _, v := range cases {
+			got := testutil.Ptr(v)
+			if *got != v {
+				t.Errorf("*Ptr(%v) = %v, want %v", v, *got, v)
 			}
-		})
-	}
-}
-
-func TestBoolPtr(t *testing.T) {
-	tests := []struct {
-		name string
-		v    bool
-	}{
-		{"false", false},
-		{"true", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := testutil.BoolPtr(tt.v)
-			if *got != tt.v {
-				t.Errorf("*BoolPtr(%v) = %v, want %v", tt.v, *got, tt.v)
+		}
+	})
+	t.Run("bool", func(t *testing.T) {
+		cases := []bool{false, true}
+		for _, v := range cases {
+			got := testutil.Ptr(v)
+			if *got != v {
+				t.Errorf("*Ptr(%v) = %v, want %v", v, *got, v)
 			}
-		})
-	}
+		}
+	})
 }


### PR DESCRIPTION
関連タスク: [testutil のポインタヘルパーをジェネリクス `Ptr[T any]` に統一する](https://app.todoist.com/app/task/6grwpMVMmrjq8gwV)

## Summary

- `internal/testutil` にあった型別ポインタヘルパー3関数（`StrPtr` / `Float64Ptr` / `BoolPtr`）を Go 1.18+ ジェネリクスの単一関数 `Ptr[T any](v T) *T` に統合
- 呼び出し元 65 箇所（5ファイル）を一括置換
- 将来 `int` / `int64` 等が必要になっても型別関数を追加するコストがゼロになる

---
🤖 Generated with [Claude Code](https://claude.ai/code)