### PR TITLE
refactor(feed): BuildFeed のチャンネルメタデータ抽出を channelMeta struct に集約する

### DIFF
--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -59,16 +59,28 @@ type rssEnclosure struct {
 	Type   string `xml:"type,attr"`
 }
 
+type channelMeta struct {
+	title       string
+	description string
+	author      string
+}
+
+func extractChannelMeta(entries []cache.Entry) channelMeta {
+	if len(entries) == 0 {
+		return channelMeta{}
+	}
+	e := entries[len(entries)-1]
+	return channelMeta{
+		title:       e.Title,
+		description: e.Description,
+		author:      e.Author,
+	}
+}
+
 // BuildFeed generates a podcast RSS 2.0 + iTunes feed XML from cache entries.
 // Channel title/description/author come from the latest entry. Items are ordered newest first.
 func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
-	var channelTitle, channelDescription, channelAuthor string
-	if len(entries) > 0 {
-		latest := entries[len(entries)-1]
-		channelTitle = latest.Title
-		channelDescription = latest.Description
-		channelAuthor = latest.Author
-	}
+	meta := extractChannelMeta(entries)
 
 	var cat *itunesCategory
 	if cfg.Feed.Category != "" {
@@ -103,11 +115,11 @@ func BuildFeed(cfg FeedSpec, entries []cache.Entry) (string, error) {
 		Version:     "2.0",
 		XmlnsItunes: "http://www.itunes.com/dtds/podcast-1.0.dtd",
 		Channel: rssChannel{
-			Title:          channelTitle,
-			Description:    channelDescription,
+			Title:          meta.title,
+			Description:    meta.description,
 			Language:       cfg.Feed.Language,
 			Link:           cfg.Feed.SiteURL,
-			ItunesAuthor:   channelAuthor,
+			ItunesAuthor:   meta.author,
 			ItunesEmail:    cfg.Feed.Email,
 			ItunesCategory: cat,
 			ItunesExplicit: explicitStr,

--- a/internal/feed/feed_internal_test.go
+++ b/internal/feed/feed_internal_test.go
@@ -1,0 +1,59 @@
+package feed
+
+import (
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/cache"
+)
+
+func TestExtractChannelMeta(t *testing.T) {
+	tests := []struct {
+		name       string
+		entries    []cache.Entry
+		wantTitle  string
+		wantDesc   string
+		wantAuthor string
+	}{
+		{
+			name:       "empty entries returns zero value",
+			entries:    []cache.Entry{},
+			wantTitle:  "",
+			wantDesc:   "",
+			wantAuthor: "",
+		},
+		{
+			name: "single entry returns its fields",
+			entries: []cache.Entry{
+				{Title: "タイトル", Description: "説明", Author: "著者"},
+			},
+			wantTitle:  "タイトル",
+			wantDesc:   "説明",
+			wantAuthor: "著者",
+		},
+		{
+			name: "multiple entries returns latest (last) entry fields",
+			entries: []cache.Entry{
+				{Title: "古いタイトル", Description: "古い説明", Author: "古い著者"},
+				{Title: "最新タイトル", Description: "最新説明", Author: "最新著者"},
+			},
+			wantTitle:  "最新タイトル",
+			wantDesc:   "最新説明",
+			wantAuthor: "最新著者",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractChannelMeta(tt.entries)
+			if got.title != tt.wantTitle {
+				t.Errorf("title = %q, want %q", got.title, tt.wantTitle)
+			}
+			if got.description != tt.wantDesc {
+				t.Errorf("description = %q, want %q", got.description, tt.wantDesc)
+			}
+			if got.author != tt.wantAuthor {
+				t.Errorf("author = %q, want %q", got.author, tt.wantAuthor)
+			}
+		})
+	}
+}


### PR DESCRIPTION
関連タスク: [BuildFeed のチャンネルメタデータ抽出を struct/ポインタに統合してリファクタ](https://app.todoist.com/app/task/6grx34RwpWXWRJQ3)

## Summary

- `BuildFeed` 冒頭の `channelTitle` / `channelDescription` / `channelAuthor` 変数3本を、`channelMeta` struct + `extractChannelMeta` 関数に一本化した
- フィールドが増えるたびに変数が増殖する構造を解消し、追加は struct の1フィールドで済むようにした
- `extractChannelMeta` の直接ユニットテスト (`feed_internal_test.go`) を追加し、空/単一/複数エントリの3ケースをカバーした

---
🤖 Generated with [Claude Code](https://claude.ai/code)