### PR TITLE
feat(cache): add Last helper and unify slice-tail access pattern

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -312,15 +312,23 @@ func CornerAppearances(entries []Entry) map[string]CornerAppearance {
 	})
 }
 
+// Last returns the last entry (most recent), or nil if entries is empty.
+func Last(entries []Entry) *Entry {
+	if len(entries) == 0 {
+		return nil
+	}
+	return &entries[len(entries)-1]
+}
+
 // NextEpisodeNumber returns the episode number to assign to the next episode.
 // If entries is empty, returns 1.
 // If the latest entry has EpisodeNumber > 0, returns that number + 1.
 // Otherwise (legacy entries without episode_number), returns len(entries) + 1.
 func NextEpisodeNumber(entries []Entry) int {
-	if len(entries) == 0 {
+	latest := Last(entries)
+	if latest == nil {
 		return 1
 	}
-	latest := entries[len(entries)-1]
 	if latest.EpisodeNumber > 0 {
 		return latest.EpisodeNumber + 1
 	}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -975,35 +975,32 @@ func TestBuildEntryFromManifest_CreditsNonNilWhenEmpty(t *testing.T) {
 	}
 }
 
-func TestLast_EmptySlice_ReturnsNil(t *testing.T) {
-	got := cache.Last([]cache.Entry{})
-	if got != nil {
-		t.Errorf("Last(empty): got %v, want nil", got)
+func TestLast(t *testing.T) {
+	tests := []struct {
+		name              string
+		entries           []cache.Entry
+		wantNil           bool
+		wantEpisodeNumber int
+	}{
+		{"empty", []cache.Entry{}, true, 0},
+		{"single", []cache.Entry{{EpisodeNumber: 1}}, false, 1},
+		{"multiple", []cache.Entry{{EpisodeNumber: 1}, {EpisodeNumber: 2}, {EpisodeNumber: 3}}, false, 3},
 	}
-}
-
-func TestLast_SingleEntry_ReturnsThatEntry(t *testing.T) {
-	entries := []cache.Entry{{EpisodeNumber: 1}}
-	got := cache.Last(entries)
-	if got == nil {
-		t.Fatal("Last(single): got nil, want non-nil")
-	}
-	if got.EpisodeNumber != 1 {
-		t.Errorf("Last(single): EpisodeNumber got %d, want 1", got.EpisodeNumber)
-	}
-}
-
-func TestLast_MultipleEntries_ReturnsLastEntry(t *testing.T) {
-	entries := []cache.Entry{
-		{EpisodeNumber: 1},
-		{EpisodeNumber: 2},
-		{EpisodeNumber: 3},
-	}
-	got := cache.Last(entries)
-	if got == nil {
-		t.Fatal("Last(multiple): got nil, want non-nil")
-	}
-	if got.EpisodeNumber != 3 {
-		t.Errorf("Last(multiple): EpisodeNumber got %d, want 3", got.EpisodeNumber)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cache.Last(tc.entries)
+			if tc.wantNil {
+				if got != nil {
+					t.Errorf("got %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil, want non-nil")
+			}
+			if got.EpisodeNumber != tc.wantEpisodeNumber {
+				t.Errorf("EpisodeNumber got %d, want %d", got.EpisodeNumber, tc.wantEpisodeNumber)
+			}
+		})
 	}
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -974,3 +974,36 @@ func TestBuildEntryFromManifest_CreditsNonNilWhenEmpty(t *testing.T) {
 		t.Error("Credits should be non-nil (empty slice) when manifest has no credits")
 	}
 }
+
+func TestLast_EmptySlice_ReturnsNil(t *testing.T) {
+	got := cache.Last([]cache.Entry{})
+	if got != nil {
+		t.Errorf("Last(empty): got %v, want nil", got)
+	}
+}
+
+func TestLast_SingleEntry_ReturnsThatEntry(t *testing.T) {
+	entries := []cache.Entry{{EpisodeNumber: 1}}
+	got := cache.Last(entries)
+	if got == nil {
+		t.Fatal("Last(single): got nil, want non-nil")
+	}
+	if got.EpisodeNumber != 1 {
+		t.Errorf("Last(single): EpisodeNumber got %d, want 1", got.EpisodeNumber)
+	}
+}
+
+func TestLast_MultipleEntries_ReturnsLastEntry(t *testing.T) {
+	entries := []cache.Entry{
+		{EpisodeNumber: 1},
+		{EpisodeNumber: 2},
+		{EpisodeNumber: 3},
+	}
+	got := cache.Last(entries)
+	if got == nil {
+		t.Fatal("Last(multiple): got nil, want non-nil")
+	}
+	if got.EpisodeNumber != 3 {
+		t.Errorf("Last(multiple): EpisodeNumber got %d, want 3", got.EpisodeNumber)
+	}
+}

--- a/internal/feed/feed.go
+++ b/internal/feed/feed.go
@@ -66,10 +66,10 @@ type channelMeta struct {
 }
 
 func extractChannelMeta(entries []cache.Entry) channelMeta {
-	if len(entries) == 0 {
+	e := cache.Last(entries)
+	if e == nil {
 		return channelMeta{}
 	}
-	e := entries[len(entries)-1]
 	return channelMeta{
 		title:       e.Title,
 		description: e.Description,


### PR DESCRIPTION
関連タスク: [cache パッケージに Last(entries []Entry) *Entry ヘルパーを追加してスライス末尾取得を一本化する](https://app.todoist.com/app/task/6gv3c6QhC8fwm953)

## Summary

- `cache.Last(entries []Entry) *Entry` を `internal/cache/cache.go` に追加
  - スライスが空の場合は `nil` を返す
  - テーブル駆動ユニットテスト（空・1件・複数の3ケース）を追加
- `cache.NextEpisodeNumber` が `cache.Last` を使うよう変更（末尾取得の重複を除去）
- `feed.extractChannelMeta` が `cache.Last` を使うよう変更（同パターンの重複を除去）

---
🤖 Generated with [Claude Code](https://claude.ai/code)