### PR TITLE
chore: golangci-lint を v2.12.2 へ更新し最新 Go でビルドさせる

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ PROFILE ?= sample/episode-spec.yaml
 OUT_DIR ?= output/$(shell date +%Y%m%d%H%M%S)
 
 setup:
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+	# golangci-lint の go.mod は go ディレクティブを「最新-1」に固定するため、
+	# 素の go install（GOTOOLCHAIN=auto）だと古い Go でビルドされ、本モジュール
+	# （go.mod の go ディレクティブ）を lint しようとするとバージョン不整合で失敗する。
+	# 本モジュールが要求する Go バージョンでビルドさせるため GOTOOLCHAIN を明示する。
+	GOTOOLCHAIN=go$$(go list -m -f '{{.GoVersion}}') go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 	go install github.com/goreleaser/goreleaser/v2@v2.14.3
 
 build:


### PR DESCRIPTION
関連タスク: [golangci-lint を v2.5.0 → v2.12.2 へ更新（最新Go 1.26非対応の解消）](https://app.todoist.com/app/task/6gv4g852JCWQjFFV)

## Summary

環境の Go が 1.26 系に上がった結果、`go1.25` でビルドされた golangci-lint v2.5.0 が `make lint` で以下のエラーになり使用できなくなっていた。

```
Error: can't load config: the Go language version (go1.25) used to build
golangci-lint is lower than the targeted Go version (1.26.1)
```

golangci-lint は go.mod の `go` ディレクティブを「最新-1」に固定する方針のため、最新版 v2.12.2 でも素の `go install`（`GOTOOLCHAIN=auto`）では一つ前の Go でビルドされ、本モジュール（`go.mod` の `go` ディレクティブ）を lint するとバージョン不整合が再発する。

## 変更内容

- `Makefile` の `setup` で golangci-lint を **v2.5.0 → v2.12.2** に更新
- インストール時に `GOTOOLCHAIN=go$(go list -m -f '{{.GoVersion}}')` を明示し、本モジュールが要求する Go バージョン（go.mod から動的取得）でビルドさせる
  - バージョンの二重管理を避けるため、固定値ではなく go.mod から取得

## 検証

- `make setup` 相当のコマンドで再インストール後、`golangci-lint version` が `v2.12.2 built with go1.26.1` を表示することを確認
- `make lint`（`golangci-lint run ./...`）が **0 issues** で完走（exit 0）することを確認
- `.golangci.yml`（`version: "2"`）は v2.12.2 でそのまま読み込み・実行可能（スキーマ変更対応は不要）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei4rboc41TnKDiEGZfbi6b)_