### PR TITLE
docs: ADR-0079 サンプル episode-spec を text/template で単一ソース化する

### DIFF
--- a/docs/adr/0078-init-sample-with-assets-flag.md
+++ b/docs/adr/0078-init-sample-with-assets-flag.md
@@ -12,7 +12,7 @@ ADR-0064 でサンプル音源パック（sample-assets）を GitHub Release で
 パック前提で音割り当て済みの設定を生成する `init --sample-with-assets` を追加する。
 
 - 生成物は `vox-radio.yaml` と割り当て済み `episode-spec.yaml`（＋ feed/slack）。`assets/assets.yaml` は生成せずパック展開に委ねる。
-- 共通ファイルは `templates-sample` を再利用し `episode-spec.yaml` のみオーバーレイする。`--sample` とは排他。
+- 共通ファイルは `templates-sample` を再利用し `episode-spec.yaml` のみオーバーレイする。`--sample` とは排他。（この生成メカニズムは ADR-0079 で text/template 単一ソース化に更新。）
 
 ## 結果
 

--- a/docs/adr/0079-templatize-sample-episode-spec.md
+++ b/docs/adr/0079-templatize-sample-episode-spec.md
@@ -1,0 +1,24 @@
+# 0079. サンプル episode-spec を text/template で単一ソース化する
+
+- ステータス: 採用
+- 日付: 2026-06-16
+
+## コンテキスト
+
+ADR-0078 で `init --sample-with-assets` を追加した際、共通ファイルは `templates-sample` を再利用し `episode-spec.yaml` のみを別ツリー（`templates-sample-with-assets`）でオーバーレイする方式を採った。しかし2つの `episode-spec.yaml` は番組本文（`program` / `casts` / `corners` の台本・長さ・`condition`・`source`）約140行が完全一致で、差分はヘッダ/フッタのコメント・`corner_defaults`・`opening`/`ending` の `start_audio`/`end_audio` の十数行のみ。本文が丸ごと複製されているため、将来本文を編集する際に両ファイルの手動同期が必要で更新漏れリスクがあった。差分が散在するため単純な部分オーバーレイや連結では解消できない。
+
+## 決定
+
+本文を単一テンプレート `templates-sample/episode-spec.yaml.tmpl` に集約し、`text/template`（`struct { WithAssets bool }`）の `{{if .WithAssets}}` で音割り当て差分のみを分岐させる。`init` は埋め込みテンプレートをレンダリングして `episode-spec.yaml` を書き出す（`--sample` は `WithAssets=false`、`--sample-with-assets` は `true`）。`templates-sample-with-assets` ディレクトリと `sampleWithAssetsFS` 埋め込みは廃止する。現行2ファイルとのバイト等価はゴールデンテストで担保する。ADR-0078 の「episode-spec.yaml のみオーバーレイする」生成メカニズムは本 ADR で更新する。
+
+## 結果
+
+- 番組本文が単一ソース化され、二重管理と同期漏れリスクが解消される。
+- ゴールデン比較テストで移行のバイト等価と意図しないテンプレ変更を検知できる。`text/template` は render・slackpost で既に採用済みで前例と整合する。
+- トレードオフ: テンプレートが標準 YAML でなくなり、教育用コメントにテンプレート命令が混ざるため可読性は低下する（ユーザー合意のうえ許容）。`--sample` 系もレンダリング経由になる。
+
+## 検討した代替案
+
+- **ドリフト検知テスト**: 2ファイルを残し本文一致を CI で検証する案。同期漏れは防げるが本文の二重管理（2ファイル編集）は残るため却下。
+- **base＋パッチ生成（ゴールデン）**: base から行アンカー挿入で音入り版を生成する案。アンカー挿入が脆く実装が重いため却下。
+- **現状維持**: 安定した教育用フィクスチャとして放置する案。更新漏れリスクが残るため却下。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -84,3 +84,4 @@
 | [0076](0076-pipeline-progress-log-convention.md) | パイプライン進捗ログの出力規約を定める | 採用 | 2026-06-16 |
 | [0077](0077-per-episode-output-layout.md) | episodegen の出力を回数別名・回ごとディレクトリにする | 採用 | 2026-06-16 |
 | [0078](0078-init-sample-with-assets-flag.md) | init --sample-with-assets で音入りサンプルを生成する | 採用 | 2026-06-16 |
+| [0079](0079-templatize-sample-episode-spec.md) | サンプル episode-spec を text/template で単一ソース化する | 採用 | 2026-06-16 |


### PR DESCRIPTION
関連タスク: [サンプル episode-spec.yaml を text/template で単一ソース化（templates-sample-with-assets を廃止）](https://app.todoist.com/app/task/6gv53p6wrGxjRwHV)

## 概要

`discuss` スキルでの仕様確定に伴い、サンプル `episode-spec.yaml` の本文重複を **text/template による単一ソース化**で解消する方針を決定した。その生成メカニズムの判断を ADR-0079 として記録する（ADR-0078 のオーバーレイ方式を更新）。

本 PR は **ADR の追加のみ**で、コード実装は含まない（実装は関連タスクで対応）。

## 変更内容

- `docs/adr/0079-templatize-sample-episode-spec.md` を追加
- `docs/adr/README.md` のインデックスに 0079 を追記
- `docs/adr/0078-init-sample-with-assets-flag.md` に「生成メカニズムは ADR-0079 で更新」の参照を追記

## 決定の要点

- 本文を `templates-sample/episode-spec.yaml.tmpl` に集約し、`struct { WithAssets bool }` の `{{if .WithAssets}}` で音割り当て差分（`corner_defaults` / `opening` の `start_audio` / `ending` の `end_audio` / ヘッダ・フッタコメント）のみを分岐
- `templates-sample-with-assets` ディレクトリと `sampleWithAssetsFS` 埋め込みを廃止
- 現行2ファイルとのバイト等価はゴールデンテストで担保
- トレードオフ: テンプレートが標準 YAML でなくなり可読性は低下する（ユーザー合意のうえ許容）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDk5GPBtkzTgVhugGQ6RRA)_