### PR TITLE
refactor(logging): StartStep ヘルパーで開始/完了ログパターンを集約

### DIFF
--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -70,7 +70,7 @@ func New(assetsConfig config.AssetsConfig, program config.ProgramConfig, opts ..
 // It returns the duration and file size of the resulting mp3.
 func (a *Assembler) Run(ctx context.Context, script model.Script, clips model.ClipsMeta, clipsDir string, outPath string, meta model.EpisodeMeta) (*Result, error) {
 	logger := a.logger.With("step", "assemble")
-	done := logging.StartStep(logger, "開始")
+	done := logging.StartStep(ctx, logger, "開始")
 
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return nil, fmt.Errorf("create output dir: %w", err)

--- a/internal/assemble/assemble.go
+++ b/internal/assemble/assemble.go
@@ -9,9 +9,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/logging"
 	"github.com/canpok1/vox-radio/internal/mediainfo"
 	"github.com/canpok1/vox-radio/internal/model"
 )
@@ -70,9 +70,7 @@ func New(assetsConfig config.AssetsConfig, program config.ProgramConfig, opts ..
 // It returns the duration and file size of the resulting mp3.
 func (a *Assembler) Run(ctx context.Context, script model.Script, clips model.ClipsMeta, clipsDir string, outPath string, meta model.EpisodeMeta) (*Result, error) {
 	logger := a.logger.With("step", "assemble")
-	start := time.Now()
-
-	logger.Info("開始")
+	done := logging.StartStep(logger, "開始")
 
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return nil, fmt.Errorf("create output dir: %w", err)
@@ -129,7 +127,7 @@ func (a *Assembler) Run(ctx context.Context, script model.Script, clips model.Cl
 		return nil, fmt.Errorf("get file size: %w", err)
 	}
 
-	logger.Info(fmt.Sprintf("完了 (duration=%.1fs, %.2fMB, %.1fs)", dur, float64(size)/(1024*1024), time.Since(start).Seconds()))
+	done(fmt.Sprintf("duration=%.1fs, %.2fMB", dur, float64(size)/(1024*1024)))
 
 	seSequentialDurations := make(map[string]float64, len(seDurations))
 	for name, dur := range seDurations {

--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -118,7 +118,7 @@ func (c *Collector) RunAll(ctx context.Context, corners []config.CornerConfig, e
 		}
 	}
 
-	done := logging.StartStep(logger, "開始")
+	done := logging.StartStep(ctx, logger, "開始")
 
 	result := make([]model.CornerArticles, 0, len(filtered))
 	totalArticles := 0

--- a/internal/collect/collect.go
+++ b/internal/collect/collect.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/httpretry"
+	"github.com/canpok1/vox-radio/internal/logging"
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
@@ -101,7 +102,6 @@ func (c *Collector) Run(ctx context.Context, cfg config.FeedsConfig, excluded ma
 // excludedDedupKeys is a list of DedupKeys to skip when fetching from feeds (nil means no exclusion).
 func (c *Collector) RunAll(ctx context.Context, corners []config.CornerConfig, excludedDedupKeys []string) (model.Articles, error) {
 	logger := c.logger.With("step", "collect")
-	start := time.Now()
 
 	var excluded map[string]struct{}
 	if len(excludedDedupKeys) > 0 {
@@ -118,7 +118,7 @@ func (c *Collector) RunAll(ctx context.Context, corners []config.CornerConfig, e
 		}
 	}
 
-	logger.Info("開始")
+	done := logging.StartStep(logger, "開始")
 
 	result := make([]model.CornerArticles, 0, len(filtered))
 	totalArticles := 0
@@ -140,7 +140,7 @@ func (c *Collector) RunAll(ctx context.Context, corners []config.CornerConfig, e
 		})
 	}
 
-	logger.Info(fmt.Sprintf("完了 (%d記事 / %dコーナー, %.1fs)", totalArticles, len(result), time.Since(start).Seconds()))
+	done(fmt.Sprintf("%d記事 / %dコーナー", totalArticles, len(result)))
 
 	return model.Articles{Corners: result}, nil
 }

--- a/internal/logging/timer.go
+++ b/internal/logging/timer.go
@@ -11,9 +11,10 @@ import (
 // The completion function accepts a summary string and logs
 // "完了 (SUMMARY, T.Ts)" when summary is non-empty, or "完了 (T.Ts)" when empty.
 // The same attrs are included in both the start and completion log entries.
-func StartStep(logger *slog.Logger, startMsg string, attrs ...slog.Attr) func(summary string) {
+// ctx is forwarded to slog so context-propagated values (e.g. trace IDs) appear in both lines.
+func StartStep(ctx context.Context, logger *slog.Logger, startMsg string, attrs ...slog.Attr) func(summary string) {
 	start := time.Now()
-	logger.LogAttrs(context.Background(), slog.LevelInfo, startMsg, attrs...)
+	logger.LogAttrs(ctx, slog.LevelInfo, startMsg, attrs...)
 	return func(summary string) {
 		elapsed := time.Since(start).Seconds()
 		var msg string
@@ -22,6 +23,6 @@ func StartStep(logger *slog.Logger, startMsg string, attrs ...slog.Attr) func(su
 		} else {
 			msg = fmt.Sprintf("完了 (%s, %.1fs)", summary, elapsed)
 		}
-		logger.LogAttrs(context.Background(), slog.LevelInfo, msg, attrs...)
+		logger.LogAttrs(ctx, slog.LevelInfo, msg, attrs...)
 	}
 }

--- a/internal/logging/timer.go
+++ b/internal/logging/timer.go
@@ -1,0 +1,27 @@
+package logging
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// StartStep logs startMsg with optional attrs and returns a completion function.
+// The completion function accepts a summary string and logs
+// "完了 (SUMMARY, T.Ts)" when summary is non-empty, or "完了 (T.Ts)" when empty.
+// The same attrs are included in both the start and completion log entries.
+func StartStep(logger *slog.Logger, startMsg string, attrs ...slog.Attr) func(summary string) {
+	start := time.Now()
+	logger.LogAttrs(context.Background(), slog.LevelInfo, startMsg, attrs...)
+	return func(summary string) {
+		elapsed := time.Since(start).Seconds()
+		var msg string
+		if summary == "" {
+			msg = fmt.Sprintf("完了 (%.1fs)", elapsed)
+		} else {
+			msg = fmt.Sprintf("完了 (%s, %.1fs)", summary, elapsed)
+		}
+		logger.LogAttrs(context.Background(), slog.LevelInfo, msg, attrs...)
+	}
+}

--- a/internal/logging/timer_test.go
+++ b/internal/logging/timer_test.go
@@ -1,0 +1,125 @@
+package logging_test
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/logging"
+)
+
+func splitLogLines(s string) []string {
+	return strings.Split(strings.TrimRight(s, "\n"), "\n")
+}
+
+func TestStartStep_LogsStartMessage(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+
+	done := logging.StartStep(logger, "開始")
+	defer done("")
+
+	lines := splitLogLines(buf.String())
+	if len(lines) < 1 || !strings.Contains(lines[0], "開始") {
+		t.Errorf("start message not found in %q", buf.String())
+	}
+}
+
+func TestStartStep_LogsDoneMessageWithElapsed(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+
+	done := logging.StartStep(logger, "開始")
+	done("")
+
+	lines := splitLogLines(buf.String())
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[1], "完了") {
+		t.Errorf("done message not found in line: %q", lines[1])
+	}
+	if !strings.Contains(lines[1], "s)") {
+		t.Errorf("elapsed time not found in done line: %q", lines[1])
+	}
+}
+
+func TestStartStep_EmptySummary_DoneFormatIsElapsedOnly(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+
+	done := logging.StartStep(logger, "開始")
+	done("")
+
+	lines := splitLogLines(buf.String())
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), buf.String())
+	}
+	doneLine := lines[1]
+	// "完了 (T.Ts)" format: no extra comma before elapsed
+	if !strings.Contains(doneLine, "完了 (") {
+		t.Errorf("done line should contain '完了 (': %q", doneLine)
+	}
+	// should not have a comma (no summary prefix)
+	if strings.Contains(doneLine, ", ") {
+		t.Errorf("done line should not have summary separator when summary is empty: %q", doneLine)
+	}
+}
+
+func TestStartStep_WithSummary_DoneFormatIncludesSummary(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+
+	done := logging.StartStep(logger, "開始")
+	done("5クリップ")
+
+	lines := splitLogLines(buf.String())
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), buf.String())
+	}
+	doneLine := lines[1]
+	if !strings.Contains(doneLine, "完了 (5クリップ,") {
+		t.Errorf("done line should contain summary: %q", doneLine)
+	}
+	if !strings.Contains(doneLine, "s)") {
+		t.Errorf("done line should contain elapsed: %q", doneLine)
+	}
+}
+
+func TestStartStep_AttrsAppearedInBothStartAndDone(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+
+	done := logging.StartStep(logger, "開始", slog.String("corner", "テストコーナー"))
+	done("")
+
+	lines := splitLogLines(buf.String())
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), buf.String())
+	}
+	if !strings.Contains(lines[0], "corner=テストコーナー") {
+		t.Errorf("start line should contain attr: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "corner=テストコーナー") {
+		t.Errorf("done line should contain attr: %q", lines[1])
+	}
+}
+
+func TestStartStep_MultipleAttrs(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+
+	done := logging.StartStep(logger, "開始",
+		slog.String("corner", "コーナーA"),
+		slog.Int("count", 3),
+	)
+	done("3記事")
+
+	output := buf.String()
+	if !strings.Contains(output, "corner=コーナーA") {
+		t.Errorf("output should contain corner attr: %q", output)
+	}
+	if !strings.Contains(output, "count=3") {
+		t.Errorf("output should contain count attr: %q", output)
+	}
+}

--- a/internal/logging/timer_test.go
+++ b/internal/logging/timer_test.go
@@ -1,6 +1,7 @@
 package logging_test
 
 import (
+	"context"
 	"log/slog"
 	"strings"
 	"testing"
@@ -12,11 +13,16 @@ func splitLogLines(s string) []string {
 	return strings.Split(strings.TrimRight(s, "\n"), "\n")
 }
 
-func TestStartStep_LogsStartMessage(t *testing.T) {
+func newTestLogger(t *testing.T) (*slog.Logger, *strings.Builder) {
+	t.Helper()
 	var buf strings.Builder
-	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+	return slog.New(logging.NewTextHandler(&buf, slog.LevelInfo)), &buf
+}
 
-	done := logging.StartStep(logger, "開始")
+func TestStartStep_LogsStartMessage(t *testing.T) {
+	logger, buf := newTestLogger(t)
+
+	done := logging.StartStep(context.Background(), logger, "開始")
 	defer done("")
 
 	lines := splitLogLines(buf.String())
@@ -25,30 +31,10 @@ func TestStartStep_LogsStartMessage(t *testing.T) {
 	}
 }
 
-func TestStartStep_LogsDoneMessageWithElapsed(t *testing.T) {
-	var buf strings.Builder
-	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+func TestStartStep_EmptySummary(t *testing.T) {
+	logger, buf := newTestLogger(t)
 
-	done := logging.StartStep(logger, "開始")
-	done("")
-
-	lines := splitLogLines(buf.String())
-	if len(lines) < 2 {
-		t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), buf.String())
-	}
-	if !strings.Contains(lines[1], "完了") {
-		t.Errorf("done message not found in line: %q", lines[1])
-	}
-	if !strings.Contains(lines[1], "s)") {
-		t.Errorf("elapsed time not found in done line: %q", lines[1])
-	}
-}
-
-func TestStartStep_EmptySummary_DoneFormatIsElapsedOnly(t *testing.T) {
-	var buf strings.Builder
-	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
-
-	done := logging.StartStep(logger, "開始")
+	done := logging.StartStep(context.Background(), logger, "開始")
 	done("")
 
 	lines := splitLogLines(buf.String())
@@ -56,21 +42,22 @@ func TestStartStep_EmptySummary_DoneFormatIsElapsedOnly(t *testing.T) {
 		t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), buf.String())
 	}
 	doneLine := lines[1]
-	// "完了 (T.Ts)" format: no extra comma before elapsed
-	if !strings.Contains(doneLine, "完了 (") {
-		t.Errorf("done line should contain '完了 (': %q", doneLine)
+	if !strings.Contains(doneLine, "完了") {
+		t.Errorf("done message not found in line: %q", doneLine)
 	}
-	// should not have a comma (no summary prefix)
+	if !strings.Contains(doneLine, "s)") {
+		t.Errorf("elapsed time not found in done line: %q", doneLine)
+	}
+	// "完了 (T.Ts)" format: no comma (no summary prefix)
 	if strings.Contains(doneLine, ", ") {
 		t.Errorf("done line should not have summary separator when summary is empty: %q", doneLine)
 	}
 }
 
 func TestStartStep_WithSummary_DoneFormatIncludesSummary(t *testing.T) {
-	var buf strings.Builder
-	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+	logger, buf := newTestLogger(t)
 
-	done := logging.StartStep(logger, "開始")
+	done := logging.StartStep(context.Background(), logger, "開始")
 	done("5クリップ")
 
 	lines := splitLogLines(buf.String())
@@ -87,39 +74,41 @@ func TestStartStep_WithSummary_DoneFormatIncludesSummary(t *testing.T) {
 }
 
 func TestStartStep_AttrsAppearedInBothStartAndDone(t *testing.T) {
-	var buf strings.Builder
-	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
-
-	done := logging.StartStep(logger, "開始", slog.String("corner", "テストコーナー"))
-	done("")
-
-	lines := splitLogLines(buf.String())
-	if len(lines) < 2 {
-		t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), buf.String())
+	cases := []struct {
+		name  string
+		attrs []slog.Attr
+		wants []string
+	}{
+		{
+			name:  "single attr",
+			attrs: []slog.Attr{slog.String("corner", "テストコーナー")},
+			wants: []string{"corner=テストコーナー"},
+		},
+		{
+			name:  "multiple attrs",
+			attrs: []slog.Attr{slog.String("corner", "コーナーA"), slog.Int("count", 3)},
+			wants: []string{"corner=コーナーA", "count=3"},
+		},
 	}
-	if !strings.Contains(lines[0], "corner=テストコーナー") {
-		t.Errorf("start line should contain attr: %q", lines[0])
-	}
-	if !strings.Contains(lines[1], "corner=テストコーナー") {
-		t.Errorf("done line should contain attr: %q", lines[1])
-	}
-}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, buf := newTestLogger(t)
 
-func TestStartStep_MultipleAttrs(t *testing.T) {
-	var buf strings.Builder
-	logger := slog.New(logging.NewTextHandler(&buf, slog.LevelInfo))
+			done := logging.StartStep(context.Background(), logger, "開始", tc.attrs...)
+			done("")
 
-	done := logging.StartStep(logger, "開始",
-		slog.String("corner", "コーナーA"),
-		slog.Int("count", 3),
-	)
-	done("3記事")
-
-	output := buf.String()
-	if !strings.Contains(output, "corner=コーナーA") {
-		t.Errorf("output should contain corner attr: %q", output)
-	}
-	if !strings.Contains(output, "count=3") {
-		t.Errorf("output should contain count attr: %q", output)
+			lines := splitLogLines(buf.String())
+			if len(lines) < 2 {
+				t.Fatalf("expected at least 2 lines, got %d: %q", len(lines), buf.String())
+			}
+			for _, want := range tc.wants {
+				if !strings.Contains(lines[0], want) {
+					t.Errorf("start line should contain %q: %q", want, lines[0])
+				}
+				if !strings.Contains(lines[1], want) {
+					t.Errorf("done line should contain %q: %q", want, lines[1])
+				}
+			}
+		})
 	}
 }

--- a/internal/logging/timer_test.go
+++ b/internal/logging/timer_test.go
@@ -22,13 +22,14 @@ func newTestLogger(t *testing.T) (*slog.Logger, *strings.Builder) {
 func TestStartStep_LogsStartMessage(t *testing.T) {
 	logger, buf := newTestLogger(t)
 
+	// StartStep を呼んだ直後の時点でバッファに開始ログが書かれていることを検証する。
+	// done は StartStep の契約上必ず呼ぶ必要があるため検証後に呼び出す。
 	done := logging.StartStep(context.Background(), logger, "開始")
-	defer done("")
-
 	lines := splitLogLines(buf.String())
 	if len(lines) < 1 || !strings.Contains(lines[0], "開始") {
 		t.Errorf("start message not found in %q", buf.String())
 	}
+	done("")
 }
 
 func TestStartStep_EmptySummary(t *testing.T) {

--- a/internal/rundown/rundown.go
+++ b/internal/rundown/rundown.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/canpok1/vox-radio/internal/cache"
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/logging"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/rundown/flow"
 	sel "github.com/canpok1/vox-radio/internal/rundown/select"
@@ -66,8 +66,7 @@ func NewLLMRundowner(selector sel.Selector, summarizer summarize.Summarizer, des
 }
 
 func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, articles model.Articles, casts []model.RundownCast) (model.Rundown, error) {
-	start := time.Now()
-	r.logger.Info("開始")
+	done := logging.StartStep(r.logger, "開始")
 
 	articleMap := articles.CornerMap()
 	rundownCorners := make([]model.RundownCorner, 0, len(corners))
@@ -162,6 +161,6 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 		rd.Corners[i].Flow = designed
 	}
 
-	r.logger.Info(fmt.Sprintf("完了 (%dコーナー, %.1fs)", len(corners), time.Since(start).Seconds()))
+	done(fmt.Sprintf("%dコーナー", len(corners)))
 	return rd, nil
 }

--- a/internal/rundown/rundown.go
+++ b/internal/rundown/rundown.go
@@ -66,7 +66,7 @@ func NewLLMRundowner(selector sel.Selector, summarizer summarize.Summarizer, des
 }
 
 func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, articles model.Articles, casts []model.RundownCast) (model.Rundown, error) {
-	done := logging.StartStep(r.logger, "開始")
+	done := logging.StartStep(ctx, r.logger, "開始")
 
 	articleMap := articles.CornerMap()
 	rundownCorners := make([]model.RundownCorner, 0, len(corners))

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -54,7 +54,7 @@ func NewLLMScriptGenerator(
 
 func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, *model.ProofreadResult, error) {
 	scriptLogger := g.logger.With("step", "script")
-	scriptDone := logging.StartStep(scriptLogger, "開始")
+	scriptDone := logging.StartStep(ctx, scriptLogger, "開始")
 
 	cornerMap := rundown.CornerMap()
 
@@ -65,7 +65,7 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	}
 
 	writeLogger := g.logger.With("step", "script/write")
-	writeDone := logging.StartStep(writeLogger, "開始")
+	writeDone := logging.StartStep(ctx, writeLogger, "開始")
 	cornerLines, err := WriteAll(ctx, g.writer, program, corners, allAssignments, cornerMap, chars)
 	if err != nil {
 		return model.Script{}, model.ScriptLines{}, nil, err
@@ -75,7 +75,7 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	writeDone(fmt.Sprintf("%dコーナー", len(corners)))
 
 	directLogger := g.logger.With("step", "script/direct")
-	directDone := logging.StartStep(directLogger, "開始")
+	directDone := logging.StartStep(ctx, directLogger, "開始")
 	scr, pr, err := g.director.Direct(ctx, scriptLines.Corners, g.assetCatalog, program.Direction)
 	if err != nil {
 		return model.Script{}, model.ScriptLines{}, nil, fmt.Errorf("direct: %w", err)

--- a/internal/script/script.go
+++ b/internal/script/script.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"time"
 	"unicode/utf8"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/logging"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script/direct"
 	"github.com/canpok1/vox-radio/internal/script/write"
@@ -53,10 +53,8 @@ func NewLLMScriptGenerator(
 }
 
 func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.ProgramConfig, rundown model.Rundown, corners []config.CornerConfig, chars map[string]config.CharacterConfig) (model.Script, model.ScriptLines, *model.ProofreadResult, error) {
-	start := time.Now()
-
 	scriptLogger := g.logger.With("step", "script")
-	scriptLogger.Info("開始")
+	scriptDone := logging.StartStep(scriptLogger, "開始")
 
 	cornerMap := rundown.CornerMap()
 
@@ -67,19 +65,17 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	}
 
 	writeLogger := g.logger.With("step", "script/write")
-	writeStart := time.Now()
-	writeLogger.Info("開始")
+	writeDone := logging.StartStep(writeLogger, "開始")
 	cornerLines, err := WriteAll(ctx, g.writer, program, corners, allAssignments, cornerMap, chars)
 	if err != nil {
 		return model.Script{}, model.ScriptLines{}, nil, err
 	}
 	cornerLines = g.regenIfNeeded(ctx, program, cornerLines, corners, allAssignments, cornerMap, chars)
 	scriptLines := model.ScriptLines{Direction: program.Direction, Corners: BuildScriptLines(corners, cornerLines)}
-	writeLogger.Info(fmt.Sprintf("完了 (%dコーナー, %.1fs)", len(corners), time.Since(writeStart).Seconds()))
+	writeDone(fmt.Sprintf("%dコーナー", len(corners)))
 
 	directLogger := g.logger.With("step", "script/direct")
-	directStart := time.Now()
-	directLogger.Info("開始")
+	directDone := logging.StartStep(directLogger, "開始")
 	scr, pr, err := g.director.Direct(ctx, scriptLines.Corners, g.assetCatalog, program.Direction)
 	if err != nil {
 		return model.Script{}, model.ScriptLines{}, nil, fmt.Errorf("direct: %w", err)
@@ -88,9 +84,9 @@ func (g *LLMScriptGenerator) Generate(ctx context.Context, program config.Progra
 	if pr != nil {
 		directLogger.Info("校正完了", "count", len(pr.Corrections))
 	}
-	directLogger.Info(fmt.Sprintf("完了 (%.1fs)", time.Since(directStart).Seconds()))
+	directDone("")
 
-	scriptLogger.Info(fmt.Sprintf("完了 (%dセグメント, %.1fs)", len(scr.Segments), time.Since(start).Seconds()))
+	scriptDone(fmt.Sprintf("%dセグメント", len(scr.Segments)))
 
 	return scr, scriptLines, pr, nil
 }

--- a/internal/script/summary/corner_summary.go
+++ b/internal/script/summary/corner_summary.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
-	"time"
 
+	"github.com/canpok1/vox-radio/internal/logging"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
@@ -53,9 +54,8 @@ type cornerSummaryResponse struct {
 // summaryLength specifies the target character count for the summary.
 func (s *LLMCornerSummarizer) SummarizeCorner(ctx context.Context, corner model.CornerLines, summaryLength int) (model.CornerSummary, error) {
 	title := corner.Title
-	start := time.Now()
-	s.logger.Info("開始", "corner", title)
-	defer func() { s.logger.Info(fmt.Sprintf("完了 (%.1fs)", time.Since(start).Seconds()), "corner", title) }()
+	done := logging.StartStep(s.logger, "開始", slog.String("corner", title))
+	defer func() { done("") }()
 
 	lines := make([]string, 0, len(corner.Lines))
 	for _, l := range corner.Lines {

--- a/internal/script/summary/corner_summary.go
+++ b/internal/script/summary/corner_summary.go
@@ -54,7 +54,7 @@ type cornerSummaryResponse struct {
 // summaryLength specifies the target character count for the summary.
 func (s *LLMCornerSummarizer) SummarizeCorner(ctx context.Context, corner model.CornerLines, summaryLength int) (model.CornerSummary, error) {
 	title := corner.Title
-	done := logging.StartStep(s.logger, "開始", slog.String("corner", title))
+	done := logging.StartStep(ctx, s.logger, "開始", slog.String("corner", title))
 	defer func() { done("") }()
 
 	lines := make([]string, 0, len(corner.Lines))

--- a/internal/script/summary/summary.go
+++ b/internal/script/summary/summary.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
-	"time"
 
+	"github.com/canpok1/vox-radio/internal/logging"
 	"github.com/canpok1/vox-radio/internal/model"
 	"github.com/canpok1/vox-radio/internal/script/llm"
 )
@@ -94,9 +94,8 @@ type speechEntry struct {
 
 // Summarize generates a program summary and conversation notes from the write-step output lines.
 func (s *LLMProgramSummarizer) Summarize(ctx context.Context, lines model.ScriptLines) (model.ProgramSummary, error) {
-	start := time.Now()
-	s.logger.Info("開始")
-	defer func() { s.logger.Info(fmt.Sprintf("完了 (%.1fs)", time.Since(start).Seconds())) }()
+	done := logging.StartStep(s.logger, "開始")
+	defer func() { done("") }()
 
 	totalLines := lines.TotalLines()
 	entries := make([]speechEntry, 0, totalLines)

--- a/internal/script/summary/summary.go
+++ b/internal/script/summary/summary.go
@@ -94,7 +94,7 @@ type speechEntry struct {
 
 // Summarize generates a program summary and conversation notes from the write-step output lines.
 func (s *LLMProgramSummarizer) Summarize(ctx context.Context, lines model.ScriptLines) (model.ProgramSummary, error) {
-	done := logging.StartStep(s.logger, "開始")
+	done := logging.StartStep(ctx, s.logger, "開始")
 	defer func() { done("") }()
 
 	totalLines := lines.TotalLines()

--- a/internal/synth/synth.go
+++ b/internal/synth/synth.go
@@ -61,7 +61,7 @@ func (s *Synth) Run(ctx context.Context, script model.Script, outDir string) (*m
 		}
 	}
 
-	done := logging.StartStep(logger, fmt.Sprintf("開始 (%dクリップ)", len(speechSegs)))
+	done := logging.StartStep(ctx, logger, fmt.Sprintf("開始 (%dクリップ)", len(speechSegs)))
 
 	var presets config.VoicevoxPresets
 	if s.Config != nil {

--- a/internal/synth/synth.go
+++ b/internal/synth/synth.go
@@ -7,10 +7,10 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"time"
 	"unicode/utf8"
 
 	"github.com/canpok1/vox-radio/internal/config"
+	"github.com/canpok1/vox-radio/internal/logging"
 	"github.com/canpok1/vox-radio/internal/mediainfo"
 	"github.com/canpok1/vox-radio/internal/model"
 )
@@ -49,7 +49,6 @@ func New(engineURL string, cfg *config.Config, opts ...Option) *Synth {
 // It also writes clips.json with metadata including durations.
 func (s *Synth) Run(ctx context.Context, script model.Script, outDir string) (*model.ClipsMeta, error) {
 	logger := s.logger.With("step", "synth")
-	start := time.Now()
 
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create output dir: %w", err)
@@ -62,7 +61,7 @@ func (s *Synth) Run(ctx context.Context, script model.Script, outDir string) (*m
 		}
 	}
 
-	logger.Info(fmt.Sprintf("開始 (%dクリップ)", len(speechSegs)))
+	done := logging.StartStep(logger, fmt.Sprintf("開始 (%dクリップ)", len(speechSegs)))
 
 	var presets config.VoicevoxPresets
 	if s.Config != nil {
@@ -111,7 +110,7 @@ func (s *Synth) Run(ctx context.Context, script model.Script, outDir string) (*m
 		return nil, fmt.Errorf("write clips.json: %w", err)
 	}
 
-	logger.Info(fmt.Sprintf("完了 (%dクリップ, %.1fs)", len(clips), time.Since(start).Seconds()))
+	done(fmt.Sprintf("%dクリップ", len(clips)))
 
 	return meta, nil
 }


### PR DESCRIPTION
関連タスク: [進捗ログの開始/完了計測パターンを logging ヘルパーへ抽出し横展開する](https://app.todoist.com/app/task/6gv4G5qccHwfq45V)

## Summary

- `internal/logging/timer.go` に `StartStep(ctx, logger, startMsg, attrs...)` ヘルパーを追加
  - 開始ログ出力 + 経過時間計測 + 完了ログ出力を1箇所に集約
  - `context.Context` を受け取り slog へ転送（trace ID 等の伝播を保持）
  - attrs は開始・完了の両ログに付与
- collect / synth / assemble / rundown / script / script/summary の 7 ファイルで手書きパターンを置き換え
- ADR-0076 の "完了 (…, T.Ts)" 形式を維持したまま重複を除去

## 受け入れ条件の対応

- [x] `internal/logging/` にステップ計測ヘルパーを追加（テスト付）
- [x] collect / synth / assemble / rundown / script / summary の各ステップをヘルパー経由に置き換え、出力ログが現状と同等
- [x] 既存のログ検証テストが通る
- [x] ADR-0076 を参照（規約は変えず実装を集約するのみ）

---
🤖 Generated with [Claude Code](https://claude.ai/code)