### PR TITLE
docs: ADR-0080 slackpost のチャンネルを環境変数名の間接指定にする

### DIFF
--- a/docs/adr/0080-slackpost-channel-via-env-var-name.md
+++ b/docs/adr/0080-slackpost-channel-via-env-var-name.md
@@ -1,0 +1,22 @@
+# 0080. slackpost の投稿先チャンネルを環境変数名の間接指定にする
+
+- ステータス: 採用
+- 日付: 2026-06-16
+
+## コンテキスト
+
+投稿先チャンネルは `slack-spec.yaml` の `slack.channel` に ID を直値で書いていた。CI の自動投稿で本番／検証など環境ごとに投稿先を切り替えたいが、直値だと spec を分けるか書き換える必要があり、設定を共有したまま env だけで切り替えられない。env 切り替えには固定上書き env（ADR-0042/0055）と、Bot トークンの間接指定（`bot_token_env`）の先例がある。
+
+## 決定
+
+`slack.channel`（直値）を廃止し、env 変数名を指定する `slack.channel_env` へ置き換える。`bot_token_env` と同じ間接指定に揃える。チャンネル ID は実行時に `os.Getenv(channel_env)` で解決し、トークン同様に CLI 層（`slackpost.go`）で解決して `slack.Run` へ渡す。`slackpost check` は `channel_env` の存在のみ検証し、値は実行時に検証する（未設定かつ非 dry-run でエラー）。
+
+## 結果
+
+CI は env の値を差し替えるだけで投稿先を切り替えられ、spec を共有・固定したまま運用できる。トークン・チャンネルとも扱いが揃う。一方 `slack.channel` を含む既存 spec は動かなくなる破壊的変更で、利用者は `channel_env` への移行が必要。
+
+## 検討した代替案
+
+- **固定上書き env（`VOX_RADIO_SLACK_CHANNEL`）**: ADR-0042/0055 と同型だが変数名が固定で投げ分けに弱く、env 名を spec で決める方が CI に馴染むため却下。
+- **`--channel` フラグ**: CI の secret/variable と直接噛み合う env 方式が適合するため却下。
+- **`channel` と `channel_env` の併用**: 後方互換だが解決順序の分岐で複雑化するため却下。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,3 +85,4 @@
 | [0077](0077-per-episode-output-layout.md) | episodegen の出力を回数別名・回ごとディレクトリにする | 採用 | 2026-06-16 |
 | [0078](0078-init-sample-with-assets-flag.md) | init --sample-with-assets で音入りサンプルを生成する | 採用 | 2026-06-16 |
 | [0079](0079-templatize-sample-episode-spec.md) | サンプル episode-spec を text/template で単一ソース化する | 採用 | 2026-06-16 |
+| [0080](0080-slackpost-channel-via-env-var-name.md) | slackpost の投稿先チャンネルを環境変数名の間接指定にする | 採用 | 2026-06-16 |


### PR DESCRIPTION
関連タスク: [slackpost の投稿先チャンネルを slack.channel から slack.channel_env（環境変数名指定）へ置き換える](https://app.todoist.com/app/task/6gv7fHv6pQm5rFJ3)

## 概要

slackpost の投稿先チャンネルを、CI で環境ごと（本番／検証）に切り替えられるようにするための設計判断を ADR-0080 として記録します。

`slack-spec.yaml` の `slack.channel`（直値）を廃止し、`bot_token_env` と同方式の `slack.channel_env`（環境変数名を指定）へ置き換える方針です。チャンネル ID は実行時に `os.Getenv(channel_env)` で解決します。

## 決定の要点

- **方式**: `channel_env` による環境変数名の間接指定（固定上書き env・`--channel` フラグは不採用）
- **解決層**: Bot トークンと同様に CLI 層で解決し、`slack.Run` へ値で渡す
- **検証**: `slackpost check` は `channel_env` の存在のみ検証（env の実値は実行時に検証）
- **破壊的変更**: 既存の `slack.channel` を含む spec は `channel_env` への移行が必要

## 変更内容

- `docs/adr/0080-slackpost-channel-via-env-var-name.md` を追加
- `docs/adr/README.md` のインデックスに ADR-0080 を追記

実装は本 PR には含みません（関連タスクで対応）。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1Wp5jJNr5nCEiaGKS1HDv)_