### PR TITLE
feat(workflow-scripts): POLL_INTERVAL 既定値を 60 秒から 300 秒（5分）に変更

### DIFF
--- a/workflow-scripts/lib.sh
+++ b/workflow-scripts/lib.sh
@@ -11,7 +11,7 @@
 #           同じ瞬間に集中（同期）しないよう脱同期させる。
 #
 # 調整用パラメータ（環境変数で上書き可）:
-#   POLL_INTERVAL    ポーリングの基準間隔（秒, 既定 60）
+#   POLL_INTERVAL    ポーリングの基準間隔（秒, 既定 300）
 #   POLL_JITTER      基準間隔へ加算する 0..N 秒のランダム揺らぎ（既定 15）
 #   TD_MIN_GAP       td 呼び出し間の最小間隔（秒, 全ループ横断, 既定 3）
 #   TD_MAX_ATTEMPTS  td 失敗時の最大試行回数（既定 5）
@@ -20,7 +20,7 @@ _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _LOCK_DIR="${_LIB_DIR}/../.tmp/locks"
 mkdir -p "$_LOCK_DIR"
 
-POLL_INTERVAL="${POLL_INTERVAL:-60}"
+POLL_INTERVAL="${POLL_INTERVAL:-300}"
 POLL_JITTER="${POLL_JITTER:-15}"
 TD_MIN_GAP="${TD_MIN_GAP:-3}"
 TD_MAX_ATTEMPTS="${TD_MAX_ATTEMPTS:-5}"


### PR DESCRIPTION
関連タスク: [workflow-scriptsのポーリング間隔を60秒→300秒（5分）に延ばす](https://app.todoist.com/app/task/6gv7pgVqXH84PQ4V)

## Summary

- `workflow-scripts/lib.sh` の `POLL_INTERVAL` 既定値を 60 秒から 300 秒（5分）に変更
- 同ファイルのコメント（調整用パラメータ説明）の既定値表記も同期して更新

auto-assign / auto-solve / auto-analyze の同時ポーリングによる Todoist レート制限を緩和するための変更。`POLL_INTERVAL` は環境変数で上書き可能なため、既存の柔軟性は維持される。

---
🤖 Generated with [Claude Code](https://claude.ai/code)