### PR TITLE
docs: GitHub Actionsで定期的にSlack投稿するサンプルガイドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ vox-radio feedgen --cache .vox-radio/cache/<program.id>.jsonl --spec feed-spec.y
 
 ```
 SLACK_BOT_TOKEN=xoxb-...
-SLACK_CHANNEL=C0123456789
+SLACK_CHANNEL_ID=C0123456789
 ```
 
 ```bash
@@ -258,6 +258,10 @@ vox-radio install --skills --skills-dir <スキルディレクトリ>
 ### お便りフォームの作成
 
 Google フォームでリスナーからお便りを募り、その回答を RSS フィードとして公開すれば、vox-radio のコーナーのデータソースとして取り込めます（Google フォーム側の設定は vox-radio の責務の範囲外です）。設定方法は[お便りフォームの作成](docs/guides/listener-form.md)を参照してください。
+
+### GitHub Actions で定期投稿
+
+GitHub Actions のスケジュール実行で、番組生成から Slack 投稿までを定期的に自動化できます。最小構成のサンプルは[GitHub Actions で定期的に Slack へ投稿する](docs/guides/github-actions-slack.md)を参照してください。
 
 ## コマンド一覧
 

--- a/docs/guides/github-actions-slack.md
+++ b/docs/guides/github-actions-slack.md
@@ -1,0 +1,91 @@
+# GitHub Actions で定期的に Slack へ投稿する
+
+GitHub Actions のスケジュール実行で、定期的に番組を生成して Slack へ投稿する最小構成のサンプルです。
+
+> **このページの位置づけ**
+> GitHub（リポジトリ・Secrets/Variables）と Slack（Bot・チャンネル）側の準備は vox-radio の責務の**範囲外**で、下記「前提」が整っていることを前提とします。
+
+## 前提
+
+- 設定ファイル（`vox-radio.yaml` / `episode-spec.yaml` / `slack-spec.yaml`）がリポジトリのルートにコミット済みであること（`vox-radio init` で生成し、内容を記入したもの）。
+- Slack Bot を作成し、必要な権限（`chat:write` / `files:write`）を付与済みであること（[README の Slack投稿](../../README.md#slack投稿)を参照）。
+- リポジトリに次の値を登録済みであること。
+
+  | 値 | 登録先 | 既定の環境変数名 | 対応する設定 |
+  |---|---|---|---|
+  | Gemini API キー | Secret | `GEMINI_API_KEY` | `vox-radio.yaml` の LLM 設定 |
+  | Slack Bot トークン | Secret | `SLACK_BOT_TOKEN` | `vox-radio.yaml` の `slack.bot_token_env` |
+  | 投稿先チャンネル ID | Variable | `SLACK_CHANNEL_ID` | `slack-spec.yaml` の `slack.channel_env` |
+
+  環境変数名は設定ファイル側で変更できます。変えた場合はワークフローの `env:` の名前も合わせてください。
+
+## サンプルワークフロー
+
+`.github/workflows/vox-radio-slack.yml` として配置します。
+
+```yaml
+name: vox-radio-slack
+
+on:
+  schedule:
+    # UTC 表記。例は毎日 12:15 JST 相当（00分は混雑するため避ける）。
+    - cron: "15 3 * * *"
+  workflow_dispatch:
+
+concurrency:               # 同時に複数実行されないようにする（キャッシュの取り合いを防ぐ）
+  group: vox-radio-slack
+  cancel-in-progress: false
+
+jobs:
+  generate-and-post:
+    runs-on: ubuntu-latest
+    services:
+      # 音声合成に VOICEVOX エンジンが必要。ランナーの localhost にマップされる。
+      voicevox:
+        image: voicevox/voicevox_engine:cpu-latest
+        ports:
+          - 50021:50021
+    steps:
+      - uses: actions/checkout@v4
+
+      # 1. キャッシュ復元。実行ごとに新しいキーで保存し、直近のキャッシュを引き継ぐ書き方。
+      - uses: actions/cache@v4
+        with:
+          path: .vox-radio/cache
+          key: vox-radio-cache-${{ github.run_id }}
+          restore-keys: vox-radio-cache-
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install vox-radio
+        run: curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | bash
+
+      # 2. 番組生成
+      - name: Generate episode
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          VOX_RADIO_VOICEVOX_URL: http://127.0.0.1:50021
+        run: vox-radio episodegen --spec episode-spec.yaml --out-dir output
+
+      # 3. Slack 投稿
+      - name: Post to Slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+        run: |
+          MANIFEST=$(ls output/*_manifest.json | head -n1)
+          vox-radio slackpost --manifest "$MANIFEST" --spec slack-spec.yaml
+```
+
+## 仕組み
+
+1. **キャッシュ復元** — 過去回の履歴（`.vox-radio/cache/`）を `actions/cache` で復元し、前回までの内容を踏まえた番組を生成します。初回（キャッシュ無し）でも動作し、回番号は 1 から始まります。
+2. **番組生成** — `episodegen` が記事収集から音声合成までを一括実行し（詳細は[README の番組生成](../../README.md#番組生成)）、`output/` に mp3 とマニフェストを出力します。
+3. **Slack 投稿** — `slackpost` がマニフェストをもとに mp3 を Slack へ直接アップロードします。GitHub Release など公開 URL の準備は不要です。
+4. **キャッシュ保存** — 新しい履歴を含む `.vox-radio/cache/` は、復元に使った `actions/cache` の post 処理で自動保存されます。専用ステップは要りません。
+
+## 注意事項
+
+- **キャッシュの保持期間** — `actions/cache` は 7 日間アクセスのないキャッシュを自動削除します。実行間隔が空くと過去回の文脈（番組の連続性）が失われます。日次など定期実行のサンプル用途では問題になりません。連続性を確実に保ちたい場合は、専用ブランチへコミットして永続化する方式もあります（その分ワークフローは長くなります）。
+- **クレジット表記・利用規約** — 合成音声を公開する際の VOICEVOX のクレジット表記など、規約まわりの責任は利用者にあります。詳細は[DISCLAIMER.md](../../DISCLAIMER.md)を参照してください。


### PR DESCRIPTION
関連タスク: [GitHub Actionで定期的にSlack投稿するサンプルをガイド化](https://todoist.com/showTask?id=6gvPqXH27CWPfRCV)

## 概要

vox-radio の応用的な使い方として、GitHub Actions で定期的に番組を生成し Slack へ投稿する**最小構成のサンプル**をドキュメント化しました。流れは「キャッシュ復元 → 番組生成 → Slack 投稿 → キャッシュ保存」の4ステップです。

成果物はドキュメントのみで、Go コードや実ワークフロー（`.github/workflows/` への実ファイル）は追加していません。

## 変更内容

- `docs/guides/github-actions-slack.md` を新規追加
  - 4ステップのサンプルワークフロー（schedule + workflow_dispatch、VOICEVOX サービスコンテナ、ffmpeg/vox-radio インストール）
  - 前提（Secrets/Variables・Slack Bot 権限・設定ファイルのコミット）
  - 仕組み・注意事項（`actions/cache` の7日削除、クレジット表記・免責）
- `README.md` の `## 応用的な使い方` に「GitHub Actions で定期投稿」サブセクションを追加し、上記ガイドへリンク
- あわせて README の Slack投稿節の `.env` 例の誤記を修正（`SLACK_CHANNEL` → `SLACK_CHANNEL_ID`。既定の `channel_env` と一致させ、ガイドとの食い違いも解消）

## 主な設計判断

- **キャッシュ保存先は `actions/cache`（ローリングキー方式）** を採用。復元〜保存込みで約6行と、ブランチコミット方式（fetch/checkout/stage/push ＋ `contents:write`）より実装量が最小。製品アーキテクチャを縛らないサンプル内の選択のため ADR は作成していません。
- **Slack 投稿は mp3 を直接アップロード**するため、GitHub Release など公開 URL の準備は不要。Release/artifact/RSS フィードのステップは含めない最小構成としています。

## 確認

- サンプル YAML のコマンド・フラグ・環境変数名を実装で裏取り済み（`episodegen --spec` 必須、`slackpost --manifest/--spec` 必須、既定 `bot_token_env=SLACK_BOT_TOKEN` / `channel_env=SLACK_CHANNEL_ID`）
- `doc-structure-checker`（ADR-0062 構成方針）: 崩れなし
- `user-doc-reviewer`（利用者視点品質）: 指摘を反映済み
- README/ガイドのアンカーリンク・レイアウトを確認済み

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FLEHRapKTyQksWtKa3PNHM)_