### PR TITLE
ci: Dependabot による依存自動更新と patch/minor 自動マージを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+
+updates:
+  # Go モジュール（ルートの go.mod / go.sum）
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      # minor / patch をまとめて 1 PR に集約（自動マージ対象）
+      go-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions（.github/workflows/）
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # devcontainer features（.devcontainer/devcontainer.json）
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      devcontainers-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: dependabot-auto-merge
+
+# Dependabot が作成した PR のうち、patch / minor 更新を自動マージする。
+# major 更新は破壊的変更を含みやすいため自動マージ対象外（手動レビュー）。
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/adr/0082-dependabot-auto-update-with-auto-merge.md
+++ b/docs/adr/0082-dependabot-auto-update-with-auto-merge.md
@@ -1,0 +1,36 @@
+# 0082. Dependabot による依存自動更新と patch/minor の自動マージ
+
+- ステータス: 採用
+- 日付: 2026-06-18
+
+## コンテキスト
+
+vox-radio は Go モジュール（`go.mod`）、GitHub Actions（`.github/workflows/`）、devcontainer features（`.devcontainer/devcontainer.json`）に依存している。これらの依存更新は従来手動で、追従漏れによりセキュリティ修正や互換性更新が遅れるリスクがあった。
+
+依存更新を自動化したいが、次の要件がある。
+
+- 更新頻度は週 1 回に抑え、通知ノイズを減らしたい。
+- 同時に複数の更新が出る場合は PR を 1 つにまとめ、レビュー・CI 実行の手間を減らしたい。
+- 安全な更新（patch / minor）はレビューなしで取り込み、メンテナンス負荷を下げたい。一方で破壊的変更を含みやすい major 更新は人手で確認したい。
+
+## 決定
+
+`.github/dependabot.yml` を追加し、上記 3 エコシステムに対して週次（`interval: weekly`）で更新を行う。各エコシステムで `groups` を用い、`update-types` に `minor` / `patch` を指定して、これらを 1 つの PR に集約する。major 更新はグループ対象外とし、Dependabot が個別 PR を作成する。
+
+自動マージは `.github/dependabot.yml` 単体では実現できないため、`.github/workflows/dependabot-auto-merge.yml` を追加する。`pull_request` イベントで起動し、`github.actor == 'dependabot[bot]'` の PR に対して `dependabot/fetch-metadata` で更新種別を取得し、`update-type` が `semver-patch` / `semver-minor` の場合のみ `gh pr merge --auto --squash` で自動マージを有効化する。グループ PR の `update-type` はグループ内で最も大きい semver 変更が反映されるため、minor/patch グループは自動マージ対象になる。
+
+前提として、リポジトリ設定で「Allow auto-merge」を有効化する必要がある（コードでは設定できないため運用で担保する）。`--auto` は必須ステータスチェックの完了を待ってからマージするため、ブランチ保護で `build` を必須チェックに設定することを推奨する。
+
+## 結果
+
+- 依存が週次で自動追従され、追従漏れによるセキュリティ・互換性リスクが下がる。
+- 複数更新が 1 PR に集約され、レビュー・CI 実行回数が減る。
+- patch / minor は CI 通過後に自動マージされ、メンテナンス負荷が下がる。
+- major 更新は個別 PR・手動マージのままとなり、破壊的変更を人手で確認できる。
+- 「Allow auto-merge」とブランチ保護の設定はリポジトリ管理画面での手動操作が必要で、ADR・README には記載するが自動化はされない。
+
+## 検討した代替案
+
+- **すべての更新を自動マージ**: メンテナンス負荷は最小だが、major 更新の破壊的変更が無確認で取り込まれるリスクがあるため却下。
+- **全更新を 1 グループに集約（update-type で分けない）**: 単純だが、グループ内に major が 1 件でもあるとグループ全体が自動マージ対象外になり、安全な更新の取り込みまで滞るため却下。minor/patch と major をグループで分離する方式を採用。
+- **自動マージを行わず PR 作成のみ**: 安全だが手動マージの手間が残り、自動化の主目的（メンテナンス負荷低減）を満たさないため却下。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -87,3 +87,4 @@
 | [0079](0079-templatize-sample-episode-spec.md) | サンプル episode-spec を text/template で単一ソース化する | 採用 | 2026-06-16 |
 | [0080](0080-slackpost-channel-via-env-var-name.md) | slackpost の投稿先チャンネルを環境変数名の間接指定にする | 採用 | 2026-06-16 |
 | [0081](0081-load-env-file-on-startup.md) | 起動時に .env ファイルから環境変数を読み込む | 採用 | 2026-06-16 |
+| [0082](0082-dependabot-auto-update-with-auto-merge.md) | Dependabot による依存自動更新と patch/minor の自動マージ | 採用 | 2026-06-18 |


### PR DESCRIPTION
- gomod / github-actions / devcontainers を週次更新
- minor/patch をグループ化して 1 PR に集約、major は個別 PR
- patch/minor のみ自動マージするワークフローを追加（ADR-0082）

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VE1VguCfAi4dwKvRTxfcUu