### PR TITLE
ci: GitHub Actions ワークフローに permissions: contents: read を追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     tags-ignore:
       - '*'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/prompt-eval.yml
+++ b/.github/workflows/prompt-eval.yml
@@ -10,6 +10,9 @@ on:
         required: false
         default: ''
 
+permissions:
+  contents: read
+
 jobs:
   eval:
     runs-on: ubuntu-latest


### PR DESCRIPTION
関連タスク: [GitHub Actions ワークフローに明示的な permissions: contents: read を追加](https://app.todoist.com/app/task/6gvQXwx8P84QGvfV)

## Summary

- CodeQL Code scanning の Medium アラート `actions/missing-workflow-permissions` への対応
- `.github/workflows/build.yml` および `.github/workflows/prompt-eval.yml` にワークフローレベルの `permissions: contents: read` ブロックを明示的に追加
- 両ファイルのジョブはいずれも読み取りのみのため `contents: read` で十分

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)