### PR TITLE
fix(devcontainer): trust canpok1/tap before installing vox-actor cask

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,6 +10,7 @@ npm install -g @doist/todoist-cli
 # install vox-actor via Homebrew
 eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 brew tap canpok1/tap
+brew trust canpok1/tap
 brew install --cask vox-actor
 
 # install build tools (golangci-lint, lefthook) and activate git hooks


### PR DESCRIPTION
## 概要

devcontainer の `post-create.sh` で、未信頼 tap（`canpok1/tap`）からの cask インストールが Homebrew に拒否され、セットアップが失敗していた問題を修正する。

```
Error: Refusing to load cask canpok1/tap/vox-actor from untrusted tap canpok1/tap.
```

## 変更内容

`brew install --cask vox-actor` の前に `brew trust canpok1/tap` を追加し、tap を信頼済みにしてからインストールするようにした。

## 確認したこと

- shellcheck: 指摘なし
- pre-push の test フック: 全パッケージ pass

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpHP2XjsXegeYYg6ffiBWv)_