### PR TITLE
feat(config): コーナーの source を discriminated array へ再設計（FeedsConfig → SourceConfig）

### DIFF
--- a/docs/guides/listener-form.md
+++ b/docs/guides/listener-form.md
@@ -170,12 +170,12 @@ corners:
     cast: { zundamon: "MC", metan: "MC" }
     length_sec: 120
     source:
-      feeds:
-        - url: "https://script.google.com/macros/s/xxxxxxxx/exec"  # 控えた web アプリの URL
-          max_items: 3   # 収集する最大件数（過去に使った記事は除外して確保）
+      - type: feed
+        url: "https://script.google.com/macros/s/xxxxxxxx/exec"  # 控えた web アプリの URL
+        max_items: 3   # 収集する最大件数（過去に使った記事は除外して確保）
 ```
 
-これで `episodegen`（番組生成）の収集（`gather`）ステップがフィードを読み込み、お便りが番組に取り込まれます。`source.feeds` の設定の詳細は[episode-spec のリファレンス](../../internal/cli/skills/vox-radio/references/episode-spec.md)を参照してください。
+これで `episodegen`（番組生成）の収集（`gather`）ステップがフィードを読み込み、お便りが番組に取り込まれます。`source` の設定の詳細は[episode-spec のリファレンス](../../internal/cli/skills/vox-radio/references/episode-spec.md)を参照してください。
 
 ## 注意事項
 

--- a/e2e/fixtures/episode-spec.yaml.tmpl
+++ b/e2e/fixtures/episode-spec.yaml.tmpl
@@ -28,6 +28,6 @@ corners:
       metan: "解説役"
     length_sec: 120
     source:
-      feeds:
-        - url: {{FEED_URL}}/feed.xml
-          max_items: 5
+      - type: feed
+        url: {{FEED_URL}}/feed.xml
+        max_items: 5

--- a/internal/cli/skills/vox-radio/references/episode-spec.md
+++ b/internal/cli/skills/vox-radio/references/episode-spec.md
@@ -119,30 +119,35 @@ corners:
     condition: { every: 3, offset: 0 }   # 3,6,9,… 回に採用
 ```
 
-### `corners[].source` サブフィールド
+### `corners[].source[]` エントリのフィールド
+
+`source` は type で種別を区別する配列です。各エントリに `type` で `feed` または `web` を指定します。
 
 | フィールド | 型 | 必須/任意 | 説明 |
 |---|---|---|---|
-| `feeds` | []FeedEntry | 任意 | RSS/Atom フィードのリスト |
-| `articles` | []string | 任意 | 個別記事 URL のリスト。`https://` のほか `file://` によるローカルファイル指定も可能（後述） |
+| `type` | string | 必須 | `"feed"`（RSS/Atom フィード）または `"web"`（個別記事） |
+| `url` | string | 必須 | フィードまたは記事の URL。`https://` のほか `file://` によるローカルファイル指定も可能（後述） |
+| `max_items` | int | 任意 | `type: feed` のみ。過去使用URLを除外したうえで確保する最大記事数。デフォルト: 0（実質無制限）。除外で減った分はフィード内の後続記事で補う。`type: web` には指定不可。 |
 
-### `corners[].source.feeds[]` サブフィールド
-
-| フィールド | 型 | 必須/任意 | 説明 |
-|---|---|---|---|
-| `url` | string | 必須 | フィードの URL。`https://` のほか `file://` によるローカルファイル指定も可能（後述） |
-| `max_items` | int | 任意 | 過去使用URLを除外したうえで確保する最大記事数。デフォルト: 0（実質無制限）。除外で減った分はフィード内の後続記事で補う。 |
+```yaml
+source:
+  - type: feed
+    url: https://example.com/rss.xml
+    max_items: 5
+  - type: web
+    url: https://example.com/articles/1
+```
 
 ### `file://` プロトコルによるローカルフィード・記事の読み込み
 
-アクセス制限などで RSS/Atom フィードに直接アクセスできない場合、手動ダウンロードした XML ファイルをローカルから読み込めます。`feeds[].url` および `articles[]` に `file://` プロトコルを使ったパスを指定します。
+アクセス制限などで RSS/Atom フィードに直接アクセスできない場合、手動ダウンロードした XML ファイルをローカルから読み込めます。`url` に `file://` プロトコルを使ったパスを指定します。
 
 **絶対パス指定**（そのまま使用）:
 
 ```yaml
 source:
-  feeds:
-    - url: "file:///home/user/downloads/feed.xml"
+  - type: feed
+    url: "file:///home/user/downloads/feed.xml"
 ```
 
 **相対パス指定**（spec ファイルのディレクトリを基準に解決）:
@@ -151,10 +156,10 @@ source:
 # /home/user/myshow/episode-spec.yaml に記述した場合、
 # /home/user/myshow/feeds/feed.xml を読み込む
 source:
-  feeds:
-    - url: "file://feeds/feed.xml"
-  articles:
-    - "file://articles/article.html"
+  - type: feed
+    url: "file://feeds/feed.xml"
+  - type: web
+    url: "file://articles/article.html"
 ```
 
 > **注意**: ファイルが存在しない場合は `episodegen gather` 実行時にエラーになります。

--- a/internal/cli/templates-sample/episode-spec.yaml.tmpl
+++ b/internal/cli/templates-sample/episode-spec.yaml.tmpl
@@ -120,9 +120,9 @@ corners:
     end_pause_sec: 2.0
     # 気象情報の取得元（気象庁 防災情報XMLの随時フィード。警報・注意報など）。
     source:
-      feeds:
-        - url: https://www.data.jma.go.jp/developer/xml/feed/extra.xml
-          max_items: 10              # このフィードから使う記事の最大本数
+      - type: feed
+        url: https://www.data.jma.go.jp/developer/xml/feed/extra.xml
+        max_items: 10              # このフィードから使う記事の最大本数
 
   # ここから下の3つは日替わりコーナー。毎回どれか1つだけ放送されます。
   # 回番号で出し分けるので、上の program.id（必須）をキーにした過去回の記憶を使います。
@@ -142,9 +142,9 @@ corners:
       offset: 1                      # 初回は1回目
     # 地震・火山情報の取得元（気象庁 防災情報XMLの地震火山フィード）。
     source:
-      feeds:
-        - url: https://www.data.jma.go.jp/developer/xml/feed/eqvol.xml
-          max_items: 5
+      - type: feed
+        url: https://www.data.jma.go.jp/developer/xml/feed/eqvol.xml
+        max_items: 5
 
   # お天気豆知識コーナー（データソースなし。AIが知識から話題を作ります）
   - id: "weather-trivia"

--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -112,10 +112,11 @@ corners:
     # 記事の取得元（RSSフィードや記事URLから内容を集めたいときに設定）。
     # 取得元が不要なコーナーはこのブロックごと省略してください。
     source:
-      feeds:
-        - url: https://example.com/feed
-          max_items: 5
-      articles: []
+      - type: feed
+        url: https://example.com/feed
+        max_items: 5
+      # - type: web
+      #   url: https://example.com/articles/1
     # 放送する回の条件（省略すると毎回放送される固定コーナー）。
     # condition を書くと、回番号が合ったときだけ放送されます。
     # condition:

--- a/internal/cli/testdata/episode-spec-with-assets.yaml
+++ b/internal/cli/testdata/episode-spec-with-assets.yaml
@@ -100,9 +100,9 @@ corners:
     end_pause_sec: 2.0
     # 気象情報の取得元（気象庁 防災情報XMLの随時フィード。警報・注意報など）。
     source:
-      feeds:
-        - url: https://www.data.jma.go.jp/developer/xml/feed/extra.xml
-          max_items: 10              # このフィードから使う記事の最大本数
+      - type: feed
+        url: https://www.data.jma.go.jp/developer/xml/feed/extra.xml
+        max_items: 10              # このフィードから使う記事の最大本数
 
   # ここから下の3つは日替わりコーナー。毎回どれか1つだけ放送されます。
   # 回番号で出し分けるので、上の program.id（必須）をキーにした過去回の記憶を使います。
@@ -122,9 +122,9 @@ corners:
       offset: 1                      # 初回は1回目
     # 地震・火山情報の取得元（気象庁 防災情報XMLの地震火山フィード）。
     source:
-      feeds:
-        - url: https://www.data.jma.go.jp/developer/xml/feed/eqvol.xml
-          max_items: 5
+      - type: feed
+        url: https://www.data.jma.go.jp/developer/xml/feed/eqvol.xml
+        max_items: 5
 
   # お天気豆知識コーナー（データソースなし。AIが知識から話題を作ります）
   - id: "weather-trivia"

--- a/internal/cli/testdata/episode-spec-without-assets.yaml
+++ b/internal/cli/testdata/episode-spec-without-assets.yaml
@@ -101,9 +101,9 @@ corners:
     end_pause_sec: 2.0
     # 気象情報の取得元（気象庁 防災情報XMLの随時フィード。警報・注意報など）。
     source:
-      feeds:
-        - url: https://www.data.jma.go.jp/developer/xml/feed/extra.xml
-          max_items: 10              # このフィードから使う記事の最大本数
+      - type: feed
+        url: https://www.data.jma.go.jp/developer/xml/feed/extra.xml
+        max_items: 10              # このフィードから使う記事の最大本数
 
   # ここから下の3つは日替わりコーナー。毎回どれか1つだけ放送されます。
   # 回番号で出し分けるので、上の program.id（必須）をキーにした過去回の記憶を使います。
@@ -123,9 +123,9 @@ corners:
       offset: 1                      # 初回は1回目
     # 地震・火山情報の取得元（気象庁 防災情報XMLの地震火山フィード）。
     source:
-      feeds:
-        - url: https://www.data.jma.go.jp/developer/xml/feed/eqvol.xml
-          max_items: 5
+      - type: feed
+        url: https://www.data.jma.go.jp/developer/xml/feed/eqvol.xml
+        max_items: 5
 
   # お天気豆知識コーナー（データソースなし。AIが知識から話題を作ります）
   - id: "weather-trivia"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,25 +150,7 @@ func TestLoadEpisodeSpec(t *testing.T) {
 	})
 
 	t.Run("CornerSource", func(t *testing.T) {
-		var sourceCorner *config.CornerConfig
-		for i := range spec.Corners {
-			if spec.Corners[i].Source != nil {
-				sourceCorner = &spec.Corners[i]
-				break
-			}
-		}
-		if sourceCorner == nil {
-			t.Fatal("no corner with source found")
-		}
-		if len(sourceCorner.Source.Feeds) == 0 {
-			t.Error("Source.Feeds must not be empty")
-		}
-		if sourceCorner.Source.Feeds[0].URL == "" {
-			t.Error("Source.Feeds[0].URL must not be empty")
-		}
-		if len(sourceCorner.Source.Articles) == 0 {
-			t.Error("Source.Articles must not be empty")
-		}
+		testLoadEpisodeSpecCornerSource(t, spec)
 	})
 
 	t.Run("Assets", func(t *testing.T) {
@@ -2229,7 +2211,7 @@ func TestLoadEpisodeSpec_FileURLResolution(t *testing.T) {
 
 	var sourceCorner *config.CornerConfig
 	for i := range spec.Corners {
-		if spec.Corners[i].Source != nil {
+		if len(spec.Corners[i].Source) > 0 {
 			sourceCorner = &spec.Corners[i]
 			break
 		}
@@ -2243,7 +2225,17 @@ func TestLoadEpisodeSpec_FileURLResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	feeds := sourceCorner.Source.Feeds
+	var feeds []config.SourceEntry
+	var articles []config.SourceEntry
+	for _, s := range sourceCorner.Source {
+		switch s.Type {
+		case config.SourceTypeFeed:
+			feeds = append(feeds, s)
+		case config.SourceTypeWeb:
+			articles = append(articles, s)
+		}
+	}
+
 	if len(feeds) < 3 {
 		t.Fatalf("expected 3 feeds, got %d", len(feeds))
 	}
@@ -2264,19 +2256,57 @@ func TestLoadEpisodeSpec_FileURLResolution(t *testing.T) {
 		t.Errorf("feeds[2].URL (https://): got %q, want %q", feeds[2].URL, "https://example.com/rss.xml")
 	}
 
-	articles := sourceCorner.Source.Articles
 	if len(articles) < 2 {
 		t.Fatalf("expected 2 articles, got %d", len(articles))
 	}
 
 	// relative file:// article URL resolved
 	wantRelArticle := "file://" + filepath.Join(absTestdata, "articles/article.html")
-	if articles[0] != wantRelArticle {
-		t.Errorf("articles[0] (relative file://): got %q, want %q", articles[0], wantRelArticle)
+	if articles[0].URL != wantRelArticle {
+		t.Errorf("articles[0].URL (relative file://): got %q, want %q", articles[0].URL, wantRelArticle)
 	}
 
 	// https:// article passthrough
-	if articles[1] != "https://example.com/articles/1" {
-		t.Errorf("articles[1] (https://): got %q, want %q", articles[1], "https://example.com/articles/1")
+	if articles[1].URL != "https://example.com/articles/1" {
+		t.Errorf("articles[1].URL (https://): got %q, want %q", articles[1].URL, "https://example.com/articles/1")
+	}
+}
+
+func testLoadEpisodeSpecCornerSource(t *testing.T, spec *config.EpisodeSpec) {
+	t.Helper()
+	var sourceCorner *config.CornerConfig
+	for i := range spec.Corners {
+		if len(spec.Corners[i].Source) > 0 {
+			sourceCorner = &spec.Corners[i]
+			break
+		}
+	}
+	if sourceCorner == nil {
+		t.Fatal("no corner with source found")
+	}
+	var feeds, webs []config.SourceEntry
+	for _, s := range sourceCorner.Source {
+		switch s.Type {
+		case config.SourceTypeFeed:
+			feeds = append(feeds, s)
+		case config.SourceTypeWeb:
+			webs = append(webs, s)
+		}
+	}
+	if len(feeds) == 0 {
+		t.Error("Source must have at least one feed entry")
+	}
+	if len(feeds) > 0 && feeds[0].URL == "" {
+		t.Error("Source feed[0].URL must not be empty")
+	}
+	if len(webs) == 0 {
+		t.Error("Source must have at least one web entry")
+	}
+}
+
+func TestLoadEpisodeSpec_OldSourceFormatError(t *testing.T) {
+	_, err := config.LoadEpisodeSpec("testdata/episode_spec_old_source.yaml")
+	if err == nil {
+		t.Error("expected error for old source format (feeds:/articles: fields), got nil")
 	}
 }

--- a/internal/config/episode_spec.go
+++ b/internal/config/episode_spec.go
@@ -224,6 +224,24 @@ func validateDefaultAudioRef(parent, field string, ref *AudioRef, assets *Assets
 	return validateAudioRef(parent, field, ref, assets)
 }
 
+// ValidateSource は corners[].source の type/url/max_items を検証する。
+func (p *EpisodeSpec) ValidateSource() error {
+	for i, c := range p.Corners {
+		for j, s := range c.Source {
+			if s.Type != SourceTypeFeed && s.Type != SourceTypeWeb {
+				return fmt.Errorf("corners[%d].source[%d].type: must be %q or %q, got %q", i, j, SourceTypeFeed, SourceTypeWeb, s.Type)
+			}
+			if s.URL == "" {
+				return fmt.Errorf("corners[%d].source[%d].url: required", i, j)
+			}
+			if s.Type == SourceTypeWeb && s.MaxItems != 0 {
+				return fmt.Errorf("corners[%d].source[%d].max_items: not allowed for type %q", i, j, SourceTypeWeb)
+			}
+		}
+	}
+	return nil
+}
+
 // ValidateSingleShot は単発番組モード（program.single_shot）の整合性を検証する。
 // single_shot 時は回番号が無効化されるため、回番号ベースの出現条件（condition）は
 // コーナー・キャストのいずれにも設定できない（設定されていればエラー）。
@@ -251,6 +269,9 @@ func (p *EpisodeSpec) Validate(chars map[string]CharacterConfig) error {
 		return err
 	}
 	if err := p.ValidateCorners(); err != nil {
+		return err
+	}
+	if err := p.ValidateSource(); err != nil {
 		return err
 	}
 	if err := p.ValidateCast(); err != nil {

--- a/internal/config/episode_spec_test.go
+++ b/internal/config/episode_spec_test.go
@@ -265,6 +265,114 @@ func TestEpisodeSpec_ValidateCasts(t *testing.T) {
 	}
 }
 
+func TestEpisodeSpec_ValidateSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    *config.EpisodeSpec
+		wantErr bool
+	}{
+		{
+			name: "source なしのコーナーはエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{ID: "c1", Title: "C1"}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "type=feed, url あり はエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeFeed, URL: "https://example.com/feed.xml"},
+					},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "type=web, url あり はエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeWeb, URL: "https://example.com/article"},
+					},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "type=feed, max_items あり はエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeFeed, URL: "https://example.com/feed.xml", MaxItems: 5},
+					},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "type が空の場合はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: "", URL: "https://example.com/feed.xml"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type が不正値の場合はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: "rss", URL: "https://example.com/feed.xml"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "url が空の場合はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeFeed, URL: ""},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=web で max_items が非ゼロの場合はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeWeb, URL: "https://example.com/article", MaxItems: 3},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.spec.ValidateSource()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSource() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 // TestEpisodeSpec_Validate_CallsAllValidations は Validate が全検証を通過することを確認する。
 func TestEpisodeSpec_Validate_CallsAllValidations(t *testing.T) {
 	chars := map[string]config.CharacterConfig{
@@ -344,6 +452,17 @@ func TestEpisodeSpec_Validate_ErrorCases(t *testing.T) {
 				Program: config.ProgramConfig{ID: "prog"},
 				Corners: []config.CornerConfig{
 					{ID: "c1", Title: "opening", StartAudio: &config.AudioRef{Type: "jingle", ID: "nonexistent"}},
+				},
+				Casts:  map[string]config.CastConfig{},
+				Assets: config.AssetsConfig{Jingle: map[string]config.JingleEntry{}, BGM: map[string]config.BGMEntry{}},
+			},
+		},
+		{
+			name: "source の type が不正なとき Validate はエラーを返す",
+			spec: &config.EpisodeSpec{
+				Program: config.ProgramConfig{ID: "prog"},
+				Corners: []config.CornerConfig{
+					{ID: "c1", Title: "opening", Source: config.SourceConfig{{Type: "invalid", URL: "https://example.com/feed"}}},
 				},
 				Casts:  map[string]config.CastConfig{},
 				Assets: config.AssetsConfig{Jingle: map[string]config.JingleEntry{}, BGM: map[string]config.BGMEntry{}},

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -64,22 +64,12 @@ func loadEpisodeSpecWith(path string, strict bool) (*EpisodeSpec, error) {
 	}
 	for i := range p.Corners {
 		corner := &p.Corners[i]
-		if corner.Source == nil {
-			continue
-		}
-		for j := range corner.Source.Feeds {
-			resolved, err := resolveFileURL(specDir, corner.Source.Feeds[j].URL)
+		for j := range corner.Source {
+			resolved, err := resolveFileURL(specDir, corner.Source[j].URL)
 			if err != nil {
 				return nil, err
 			}
-			corner.Source.Feeds[j].URL = resolved
-		}
-		for j, article := range corner.Source.Articles {
-			resolved, err := resolveFileURL(specDir, article)
-			if err != nil {
-				return nil, err
-			}
-			corner.Source.Articles[j] = resolved
+			corner.Source[j].URL = resolved
 		}
 	}
 	resolveCornerDefaults(p)

--- a/internal/config/program.go
+++ b/internal/config/program.go
@@ -27,21 +27,22 @@ func DurationSecToTargetChars(sec, charsPerMinute int) int {
 	return sec * charsPerMinute / 60
 }
 
-// FeedEntry defines a single RSS/Atom feed source with an optional item limit.
-type FeedEntry struct {
+const (
+	// SourceTypeFeed はRSS/Atomフィードのソース種別。
+	SourceTypeFeed = "feed"
+	// SourceTypeWeb はWebページURLのソース種別。
+	SourceTypeWeb = "web"
+)
+
+// SourceEntry は1件のソース設定。type フィールドで feed / web を判別する。
+type SourceEntry struct {
+	Type     string `yaml:"type"`
 	URL      string `yaml:"url"`
-	MaxItems int    `yaml:"max_items"`
+	MaxItems int    `yaml:"max_items,omitempty"`
 }
 
-// FeedsConfig holds a list of feed sources and individual article URLs.
-type FeedsConfig struct {
-	Feeds    []FeedEntry `yaml:"feeds"`
-	Articles []string    `yaml:"articles"`
-}
-
-// SourceConfig defines the data sources for a corner (feeds and individual article URLs).
-// It is an alias for FeedsConfig, ensuring the two remain in sync.
-type SourceConfig = FeedsConfig
+// SourceConfig はコーナーのソース設定（SourceEntry の配列）。
+type SourceConfig = []SourceEntry
 
 // AudioRef references a jingle or SE asset by type and asset ID.
 type AudioRef struct {
@@ -70,7 +71,7 @@ type CornerConfig struct {
 	Cast          map[string]string `yaml:"cast"`
 	LengthSec     int               `yaml:"length_sec"`
 	SummaryLength int               `yaml:"summary_length,omitempty"`
-	Source        *SourceConfig     `yaml:"source,omitempty"`
+	Source        SourceConfig      `yaml:"source,omitempty"`
 	StartAudio    *AudioRef         `yaml:"start_audio,omitempty"`
 	EndAudio      *AudioRef         `yaml:"end_audio,omitempty"`
 	BGM           *string           `yaml:"bgm,omitempty"`

--- a/internal/config/testdata/episode_spec.yaml
+++ b/internal/config/testdata/episode_spec.yaml
@@ -33,11 +33,11 @@ corners:
       id: ending
     bgm: talk_bgm
     source:
-      feeds:
-        - url: https://example.com/rss.xml
-          max_items: 3
-      articles:
-        - https://example.com/articles/1
+      - type: feed
+        url: https://example.com/rss.xml
+        max_items: 3
+      - type: web
+        url: https://example.com/articles/1
 
 assets_files:
   - assets.yaml

--- a/internal/config/testdata/episode_spec_file_url.yaml
+++ b/internal/config/testdata/episode_spec_file_url.yaml
@@ -14,13 +14,16 @@ corners:
       zundamon: "司会"
     length_sec: 30
     source:
-      feeds:
-        - url: "file://feeds/feed.xml"
-          max_items: 3
-        - url: "file:///abs/feed.xml"
-          max_items: 3
-        - url: "https://example.com/rss.xml"
-          max_items: 3
-      articles:
-        - "file://articles/article.html"
-        - "https://example.com/articles/1"
+      - type: feed
+        url: "file://feeds/feed.xml"
+        max_items: 3
+      - type: feed
+        url: "file:///abs/feed.xml"
+        max_items: 3
+      - type: feed
+        url: "https://example.com/rss.xml"
+        max_items: 3
+      - type: web
+        url: "file://articles/article.html"
+      - type: web
+        url: "https://example.com/articles/1"

--- a/internal/config/testdata/episode_spec_old_source.yaml
+++ b/internal/config/testdata/episode_spec_old_source.yaml
@@ -1,0 +1,19 @@
+program:
+  id: "test-program-old-source"
+
+casts:
+  zundamon:
+    type: regular
+    role: "MC"
+
+corners:
+  - id: "news"
+    title: "ニュースコーナー"
+    content: "テック記事を紹介"
+    cast:
+      zundamon: "司会"
+    length_sec: 30
+    source:
+      feeds:
+        - url: https://example.com/rss.xml
+          max_items: 3

--- a/internal/config/testdata/feeds.yaml
+++ b/internal/config/testdata/feeds.yaml
@@ -1,7 +1,0 @@
-feeds:
-  - url: https://example.com/rss.xml
-    max_items: 5
-  - url: https://another.example.com/feed
-    max_items: 3
-articles:
-  - https://example.com/articles/123

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -60,38 +60,41 @@ func New(client *http.Client, opts ...Option) *Gatherer {
 	return c
 }
 
-// Run collects articles from all feeds and individual URLs in cfg.
+// Run collects articles from all source entries in cfg.
 // excluded is a set of URLs to skip when fetching from feeds (nil means no exclusion).
-func (c *Gatherer) Run(ctx context.Context, cfg config.FeedsConfig, excluded map[string]struct{}) ([]model.Article, error) {
+func (c *Gatherer) Run(ctx context.Context, cfg config.SourceConfig, excluded map[string]struct{}) ([]model.Article, error) {
 	articles := make([]model.Article, 0)
 
-	for _, feed := range cfg.Feeds {
-		items, err := c.fetchFeed(ctx, feed.URL, feed.MaxItems, excluded)
-		if err != nil {
-			return nil, fmt.Errorf("fetch feed %s: %w", feed.URL, err)
-		}
-		for i := range items {
-			flagged, err := c.applySanitize(&items[i])
+	for _, src := range cfg {
+		switch src.Type {
+		case config.SourceTypeFeed:
+			items, err := c.fetchFeed(ctx, src.URL, src.MaxItems, excluded)
+			if err != nil {
+				return nil, fmt.Errorf("fetch feed %s: %w", src.URL, err)
+			}
+			for i := range items {
+				flagged, err := c.applySanitize(&items[i])
+				if err != nil {
+					return nil, err
+				}
+				if !flagged {
+					articles = append(articles, items[i])
+				}
+			}
+		case config.SourceTypeWeb:
+			article, err := c.fetchArticle(ctx, src.URL)
+			if err != nil {
+				return nil, fmt.Errorf("fetch article %s: %w", src.URL, err)
+			}
+			flagged, err := c.applySanitize(article)
 			if err != nil {
 				return nil, err
 			}
 			if !flagged {
-				articles = append(articles, items[i])
+				articles = append(articles, *article)
 			}
-		}
-	}
-
-	for _, u := range cfg.Articles {
-		article, err := c.fetchArticle(ctx, u)
-		if err != nil {
-			return nil, fmt.Errorf("fetch article %s: %w", u, err)
-		}
-		flagged, err := c.applySanitize(article)
-		if err != nil {
-			return nil, err
-		}
-		if !flagged {
-			articles = append(articles, *article)
+		default:
+			return nil, fmt.Errorf("unknown source type %q", src.Type)
 		}
 	}
 
@@ -113,7 +116,7 @@ func (c *Gatherer) RunAll(ctx context.Context, corners []config.CornerConfig, ex
 
 	filtered := make([]config.CornerConfig, 0, len(corners))
 	for _, corner := range corners {
-		if corner.Source != nil {
+		if len(corner.Source) > 0 {
 			filtered = append(filtered, corner)
 		}
 	}
@@ -126,7 +129,7 @@ func (c *Gatherer) RunAll(ctx context.Context, corners []config.CornerConfig, ex
 	for i, corner := range filtered {
 		logger.Info(fmt.Sprintf("コーナー「%s」を収集中 (%d/%d)", corner.Title, i+1, len(filtered)))
 
-		articles, err := c.Run(ctx, *corner.Source, excluded)
+		articles, err := c.Run(ctx, corner.Source, excluded)
 		if err != nil {
 			return model.Articles{}, fmt.Errorf("gather corner %q: %w", corner.Title, err)
 		}

--- a/internal/gather/gather_test.go
+++ b/internal/gather/gather_test.go
@@ -22,10 +22,8 @@ func TestGatherer_Run_ErrorOnHTTPFailure(t *testing.T) {
 	defer server.Close()
 
 	t.Run("feed returns error on non-200", func(t *testing.T) {
-		cfg := config.FeedsConfig{
-			Feeds: []config.FeedEntry{
-				{URL: server.URL + "/feed.xml", MaxItems: 1},
-			},
+		cfg := config.SourceConfig{
+			{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 1},
 		}
 		c := gather.New(server.Client())
 		_, err := c.Run(context.Background(), cfg, nil)
@@ -35,8 +33,8 @@ func TestGatherer_Run_ErrorOnHTTPFailure(t *testing.T) {
 	})
 
 	t.Run("article returns error on non-200", func(t *testing.T) {
-		cfg := config.FeedsConfig{
-			Articles: []string{server.URL + "/article.html"},
+		cfg := config.SourceConfig{
+			{Type: config.SourceTypeWeb, URL: server.URL + "/article.html"},
 		}
 		c := gather.New(server.Client())
 		_, err := c.Run(context.Background(), cfg, nil)
@@ -63,10 +61,8 @@ func TestGatherer_Run_RSSAppliesMaxItems(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed.xml", MaxItems: 2},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 2},
 	}
 
 	c := gather.New(server.Client())
@@ -88,10 +84,8 @@ func TestGatherer_Run_RSSParsesFields(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed.xml", MaxItems: 1},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 1},
 	}
 
 	c := gather.New(server.Client())
@@ -126,8 +120,8 @@ func TestGatherer_Run_ArticleExtractsBody(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Articles: []string{server.URL + "/article.html"},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeWeb, URL: server.URL + "/article.html"},
 	}
 
 	c := gather.New(server.Client())
@@ -159,10 +153,8 @@ func TestGatherer_Run_AtomAppliesMaxItems(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed_atom.xml", MaxItems: 2},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed_atom.xml", MaxItems: 2},
 	}
 
 	c := gather.New(server.Client())
@@ -183,10 +175,8 @@ func TestGatherer_Run_AtomParsesFields(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed_atom.xml", MaxItems: 1},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed_atom.xml", MaxItems: 1},
 	}
 
 	c := gather.New(server.Client())
@@ -223,10 +213,8 @@ func TestGatherer_Run_WarnOnEmptyFeed(t *testing.T) {
 	var buf strings.Builder
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/empty.xml", MaxItems: 5},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/empty.xml", MaxItems: 5},
 	}
 
 	c := gather.New(server.Client(), gather.WithLogger(logger))
@@ -244,7 +232,7 @@ func TestGatherer_Run_WarnOnEmptyFeed(t *testing.T) {
 	if !strings.Contains(buf.String(), "Empty") {
 		t.Errorf("expected feed name in log, got: %q", buf.String())
 	}
-	if strings.Contains(buf.String(), cfg.Feeds[0].URL) {
+	if strings.Contains(buf.String(), cfg[0].URL) {
 		t.Errorf("expected feed name instead of URL in log, but URL was present: %q", buf.String())
 	}
 }
@@ -262,10 +250,8 @@ func TestGatherer_Run_WarnFallsBackToURLWhenFeedTitleEmpty(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
 	feedURL := server.URL + "/no-title.xml"
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: feedURL, MaxItems: 5},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 5},
 	}
 
 	c := gather.New(server.Client(), gather.WithLogger(logger))
@@ -292,10 +278,8 @@ func TestGatherer_Run_ExcludesURLsAndFillsFromLater(t *testing.T) {
 	defer server.Close()
 
 	feedURL := server.URL + "/feed.xml"
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: feedURL, MaxItems: 2},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 2},
 	}
 	// article/1 has no GUID, so material = normalizeContent(title, body)
 	excluded := map[string]struct{}{
@@ -332,10 +316,8 @@ func TestGatherer_Run_WarnWhenInsufficientNonExcludedArticles(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
 	feedURL := server.URL + "/feed.xml"
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: feedURL, MaxItems: 3},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 3},
 	}
 	excluded := map[string]struct{}{
 		gather.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"):  {},
@@ -376,10 +358,8 @@ func TestGatherer_Run_UnlimitedWithExcludedDedupKeys(t *testing.T) {
 	defer server.Close()
 
 	feedURL := server.URL + "/feed.xml"
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: feedURL, MaxItems: 0},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 0},
 	}
 	excluded := map[string]struct{}{
 		gather.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"): {},
@@ -397,12 +377,24 @@ func TestGatherer_Run_UnlimitedWithExcludedDedupKeys(t *testing.T) {
 }
 
 func TestGatherer_RunAll_SkipsSourcelessCorners(t *testing.T) {
+	emptyFeed := `<?xml version="1.0"?><rss version="2.0"><channel><title>Empty</title></channel></rss>`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/rss+xml")
+		_, _ = w.Write([]byte(emptyFeed))
+	}))
+	defer server.Close()
+
 	corners := []config.CornerConfig{
 		{Title: "ソースなし", Content: "挨拶のみ"},
-		{Title: "ソースあり", Content: "ニュース", Source: &config.SourceConfig{}},
+		{
+			Title: "ソースあり", Content: "ニュース",
+			Source: config.SourceConfig{
+				{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml"},
+			},
+		},
 	}
 
-	c := gather.New(nil)
+	c := gather.New(server.Client())
 	result, err := c.RunAll(context.Background(), corners, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -434,14 +426,14 @@ func TestGatherer_RunAll_CollectsPerCorner(t *testing.T) {
 	corners := []config.CornerConfig{
 		{
 			Title: "コーナーA",
-			Source: &config.SourceConfig{
-				Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 1}},
+			Source: config.SourceConfig{
+				{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 1},
 			},
 		},
 		{
 			Title: "コーナーB",
-			Source: &config.SourceConfig{
-				Articles: []string{server.URL + "/article.html"},
+			Source: config.SourceConfig{
+				{Type: config.SourceTypeWeb, URL: server.URL + "/article.html"},
 			},
 		},
 	}
@@ -482,8 +474,8 @@ func TestGatherer_RunAll_ExcludesDedupKeysViaFeed(t *testing.T) {
 	corners := []config.CornerConfig{
 		{
 			Title: "ニュース",
-			Source: &config.SourceConfig{
-				Feeds: []config.FeedEntry{{URL: feedURL, MaxItems: 2}},
+			Source: config.SourceConfig{
+				{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 2},
 			},
 		},
 	}
@@ -524,11 +516,9 @@ func TestGatherer_Run_CombinesFeedsAndArticles(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed.xml", MaxItems: 1},
-		},
-		Articles: []string{server.URL + "/article.html"},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 1},
+		{Type: config.SourceTypeWeb, URL: server.URL + "/article.html"},
 	}
 
 	c := gather.New(server.Client())
@@ -556,8 +546,8 @@ func TestGatherer_RunAll_LogsStartAndComplete(t *testing.T) {
 	corners := []config.CornerConfig{
 		{
 			Title: "テックニュース",
-			Source: &config.SourceConfig{
-				Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 1}},
+			Source: config.SourceConfig{
+				{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 1},
 			},
 		},
 	}
@@ -591,14 +581,14 @@ func TestGatherer_RunAll_LogsPerCornerProgress(t *testing.T) {
 	corners := []config.CornerConfig{
 		{
 			Title: "コーナーA",
-			Source: &config.SourceConfig{
-				Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 1}},
+			Source: config.SourceConfig{
+				{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 1},
 			},
 		},
 		{
 			Title: "コーナーB",
-			Source: &config.SourceConfig{
-				Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 1}},
+			Source: config.SourceConfig{
+				{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 1},
 			},
 		},
 	}
@@ -630,10 +620,8 @@ func TestGatherer_Run_RSS_ExtractsSourceAuthorPublished(t *testing.T) {
 	if err != nil {
 		t.Fatalf("time.LoadLocation: %v", err)
 	}
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed_with_meta.xml"},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed_with_meta.xml"},
 	}
 
 	c := gather.New(server.Client(), gather.WithLocation(loc))
@@ -667,10 +655,8 @@ func TestGatherer_Run_RSS_EmailAuthorExcluded(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed_with_meta.xml"},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed_with_meta.xml"},
 	}
 
 	c := gather.New(server.Client())
@@ -697,10 +683,8 @@ func TestGatherer_Run_RSS_PublishedEmptyWhenNil(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{
-			{URL: server.URL + "/feed_with_meta.xml"},
-		},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed_with_meta.xml"},
 	}
 
 	c := gather.New(server.Client())
@@ -728,8 +712,8 @@ func TestGatherer_Run_RSS_SetsDedupKey(t *testing.T) {
 	defer server.Close()
 
 	feedURL := server.URL + "/feed.xml"
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{{URL: feedURL, MaxItems: 1}},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 1},
 	}
 
 	c := gather.New(server.Client())
@@ -758,8 +742,8 @@ func TestGatherer_Run_Article_SetsDedupKey(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Articles: []string{server.URL + "/article.html"},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeWeb, URL: server.URL + "/article.html"},
 	}
 
 	c := gather.New(server.Client())
@@ -794,11 +778,11 @@ func TestGatherer_Run_RSS_NamespaceIsolation(t *testing.T) {
 	defer server2.Close()
 
 	c := gather.New(server1.Client())
-	result1, err := c.Run(context.Background(), config.FeedsConfig{Feeds: []config.FeedEntry{{URL: server1.URL + "/feed.xml", MaxItems: 1}}}, nil)
+	result1, err := c.Run(context.Background(), config.SourceConfig{{Type: config.SourceTypeFeed, URL: server1.URL + "/feed.xml", MaxItems: 1}}, nil)
 	if err != nil {
 		t.Fatalf("feed1: %v", err)
 	}
-	result2, err := c.Run(context.Background(), config.FeedsConfig{Feeds: []config.FeedEntry{{URL: server2.URL + "/feed.xml", MaxItems: 1}}}, nil)
+	result2, err := c.Run(context.Background(), config.SourceConfig{{Type: config.SourceTypeFeed, URL: server2.URL + "/feed.xml", MaxItems: 1}}, nil)
 	if err != nil {
 		t.Fatalf("feed2: %v", err)
 	}
@@ -838,8 +822,8 @@ func TestGatherer_Run_RSS_ExcludesInjectionArticle(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 10}},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 10},
 	}
 	policy := config.PromptInjectionConfig{OnDetect: config.OnDetectExclude, MaxBodyChars: 10000}
 	c := gather.New(server.Client(), gather.WithSanitizePolicy(policy))
@@ -864,8 +848,8 @@ func TestGatherer_Run_Article_ExcludesInjectionArticle(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Articles: []string{server.URL + "/article.html"},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeWeb, URL: server.URL + "/article.html"},
 	}
 	policy := config.PromptInjectionConfig{OnDetect: config.OnDetectExclude, MaxBodyChars: 10000}
 	c := gather.New(server.Client(), gather.WithSanitizePolicy(policy))
@@ -889,8 +873,8 @@ func TestGatherer_Run_RSS_OnDetectError_ReturnsError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 10}},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 10},
 	}
 	policy := config.PromptInjectionConfig{OnDetect: config.OnDetectError, MaxBodyChars: 10000}
 	c := gather.New(server.Client(), gather.WithSanitizePolicy(policy))
@@ -912,8 +896,8 @@ func TestNew_DefaultClient_FileProtocol_Feed(t *testing.T) {
 	}
 	tmp.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{{URL: "file://" + tmp.Name(), MaxItems: 1}},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: "file://" + tmp.Name(), MaxItems: 1},
 	}
 
 	c := gather.New(nil)
@@ -938,8 +922,8 @@ func TestNew_DefaultClient_FileProtocol_Article(t *testing.T) {
 	}
 	tmp.Close()
 
-	cfg := config.FeedsConfig{
-		Articles: []string{"file://" + tmp.Name()},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeWeb, URL: "file://" + tmp.Name()},
 	}
 
 	c := gather.New(nil)
@@ -953,8 +937,8 @@ func TestNew_DefaultClient_FileProtocol_Article(t *testing.T) {
 }
 
 func TestNew_DefaultClient_FileProtocol_MissingFile(t *testing.T) {
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{{URL: "file:///nonexistent/path/feed.xml", MaxItems: 1}},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: "file:///nonexistent/path/feed.xml", MaxItems: 1},
 	}
 
 	c := gather.New(nil)
@@ -972,8 +956,8 @@ func TestNew_DefaultClient_HTTPS_StillWorks(t *testing.T) {
 	}))
 	defer server.Close()
 
-	cfg := config.FeedsConfig{
-		Feeds: []config.FeedEntry{{URL: server.URL + "/feed.xml", MaxItems: 1}},
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeFeed, URL: server.URL + "/feed.xml", MaxItems: 1},
 	}
 
 	c := gather.New(server.Client())

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -15,7 +15,7 @@ pre-commit:
       stage_fixed: true
     lint:
       glob: "*.go"
-      run: golangci-lint run {staged_files}
+      run: golangci-lint run ./...
 pre-push:
   commands:
     test:


### PR DESCRIPTION
関連タスク: [コーナーの source を discriminated array（type で feed/web を判別）へ再設計する](https://app.todoist.com/app/task/6gvjqVh73rmmrrq3)

## Summary

- `FeedEntry` / `FeedsConfig` を廃止し、`SourceEntry{type/url/max_items}` + `type SourceConfig = []SourceEntry` へ再設計
- `CornerConfig.Source` を `*SourceConfig` → `SourceConfig`（スライス）に変更し、`len()==0` で source なし判定
- `ValidateSource()` を追加（type 必須・url 必須・web+max_items 禁止のバリデーション）
- `gather.Run` / `gather.RunAll` を新型に対応し、`switch src.Type` で feed/web を分岐
- 全 testdata・テンプレート・ドキュメントを新書式（配列形式）に更新
- 旧書式（`source.feeds` / `source.articles`）は strict YAML ロードでエラーになることをテストで確認
- `lefthook.yml` の lint コマンドを `{staged_files}` → `./...` に変更（複数パッケージ staged 時の失敗修正）

## Test plan

- [x] `go test ./...` 全パス
- [x] `golangci-lint run` 0 issues
- [x] `gofmt -l .` 無出力
- [x] 旧書式 YAML ロードエラーテスト（`TestLoadEpisodeSpec_OldSourceFormatError`）
- [x] ValidateSource テスト（8ケース）
- [x] gather.Run / RunAll 既存テスト全パス

---
🤖 Generated with [Claude Code](https://claude.ai/code)