### PR TITLE
feat(synth): VOICEVOX 起動待機ポーリング機能を本体に追加

### DIFF
--- a/.github/workflows/demo-release.yml
+++ b/.github/workflows/demo-release.yml
@@ -35,16 +35,6 @@ jobs:
       - name: Install vox-radio
         run: curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | bash
 
-      - name: Wait for VOICEVOX
-        run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://127.0.0.1:50021/version; then
-              echo "voicevox ready"; exit 0
-            fi
-            echo "waiting voicevox... ($i)"; sleep 5
-          done
-          echo "voicevox did not become ready"; exit 1
-
       # デモは連続性のない単発番組のため、キャッシュは使わず毎回クリーンに生成する。
       - name: Generate demo episode
         working-directory: demo

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install
 ラジオ番組の生成には生成AI・VOICEVOX・ffmpeg が必要です。次の 3 つを準備します。
 
 - **生成AIの API キー**: サンプルは Gemini を使う構成です。[Google AI Studio](https://aistudio.google.com/) でキーを取得しておきます。
-- **VOICEVOX Engine**: いずれかの方法でインストールして起動します（既定 `http://localhost:50021`）。
+- **VOICEVOX Engine**: いずれかの方法でインストールして起動します（既定 `http://localhost:50021`）。vox-radio は起動完了まで自動的に待機します（デフォルト最大 60 秒）。
     - [VOICEVOX 公式アプリ](https://voicevox.hiroshiba.jp/)をインストールして起動する
     - Docker で起動する: `docker run -d -p 50021:50021 voicevox/voicevox_engine:cpu-latest`
 - **ffmpeg**: 音声の結合に使います（`ffprobe` を含む）。

--- a/docs/adr/0088-voicevox-startup-readiness-polling.md
+++ b/docs/adr/0088-voicevox-startup-readiness-polling.md
@@ -1,0 +1,30 @@
+# 0088. VOICEVOX 起動待機ポーリングを vox-radio 本体に組み込む
+
+- ステータス: 採用
+- 日付: 2026-06-19
+
+## コンテキスト
+
+CI（`demo-release.yml`）では VOICEVOX サービスコンテナの起動完了を `curl /version` のループで確認してから音声合成を実行していた。同じレース条件はローカル利用でも起きる（エンジン起動直後の実行）が、ローカルには対策がなかった。
+
+既存の `httpretry` は 5xx/429 をリトライするが、接続レベルのエラー（connection refused）は即返しするため、エンジン未起動時にそのまま失敗する。GitHub Actions のサービスコンテナヘルスチェック（`--health-cmd`）はコンテナ内に `curl` がない可能性が高く見送り、サードパーティ製アクションは依存増加につき不採用とした。
+
+## 決定
+
+`Synth.Run` 冒頭で `waitForReady(ctx, client, timeout, interval)` ヘルパーを呼び、`/version` が 200 を返すまでポーリングしてから合成を開始する。
+
+- `VoicevoxClient` に `Version(ctx) (string, error)` を追加（`GET /version`）。httpretry なしの専用クライアントで呼び出し、失敗を即返して外側ループに委ねる
+- `VoicevoxConfig.StartupTimeoutSeconds *int`（yaml: `startup_timeout_seconds`）と `EffectiveStartupTimeout()` を追加。デフォルト 60 秒、`0` で無効
+- ポーリング間隔: 1 秒固定（名前付き定数 `pollIntervalDefault`）
+
+## 結果
+
+**良い点**: CI・ローカル双方で起動タイミングのレース条件が解消。CI から `Wait for VOICEVOX` ステップを削除でき、依存なしで同等の待機が実現できる。エンジン起動済みの場合は即進むためペナルティなし。
+
+**注意点**: デフォルト 60 秒の待機が有効になるため、VOICEVOX が存在しない環境では最大 60 秒後にタイムアウトエラーとなる。`startup_timeout_seconds: 0` で待機を無効化できる。
+
+## 検討した代替案
+
+- **`httpretry` に接続エラー対応を追加**: 全クライアントに影響するため却下。`Version` 専用の素の HTTP クライアントを使う方が局所的。
+- **CLI フラグで待機秒数を受け取る**: `docs/cli/` 再生成が必要になり負担が大きい。設定ファイルで完結させる方が既存パターンと整合する。
+- **サードパーティ製 GitHub Actions**: 依存追加につき不採用。本体機能として持つことでローカルも同時に改善できる。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -93,3 +93,4 @@
 | [0085](0085-install-dev-tools-via-prebuilt-binary.md) | 開発ツールをビルド済みバイナリで取得し make setup を高速化する | 採用 | 2026-06-18 |
 | [0086](0086-single-shot-program-mode.md) | 単発番組モード（single_shot）で回番号を無効化し命名・キャッシュの例外を導入する | 採用 | 2026-06-19 |
 | [0087](0087-corner-source-as-typed-array.md) | コーナーの source を type 付き配列（discriminated array）へ再設計する | 採用 | 2026-06-19 |
+| [0088](0088-voicevox-startup-readiness-polling.md) | VOICEVOX 起動待機ポーリングを vox-radio 本体に組み込む | 採用 | 2026-06-19 |

--- a/e2e/fake_voicevox.go
+++ b/e2e/fake_voicevox.go
@@ -18,6 +18,10 @@ type fakeVoicevox struct {
 func newFakeVoicevox() *fakeVoicevox {
 	f := &fakeVoicevox{}
 	mux := http.NewServeMux()
+	mux.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`"0.14.7"`))
+	})
 	mux.HandleFunc("/audio_query", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{

--- a/internal/cli/skills/vox-radio/references/vox-radio.md
+++ b/internal/cli/skills/vox-radio/references/vox-radio.md
@@ -55,6 +55,7 @@
 | フィールド | 型 | 必須/任意 | 説明 |
 |---|---|---|---|
 | `url` | string | 必須 | VOICEVOX Engine のURL |
+| `startup_timeout_seconds` | int | 任意 | 音声合成前に VOICEVOX の起動を待つ最大秒数。省略時はデフォルト 60 秒。`0` で待機を無効化 |
 | `presets` | *VoicevoxPresets | 任意 | 抑揚・音高・話速プリセット定義。省略時はコード組込みのデフォルトプリセットが適用される |
 
 `url` は環境変数 `VOX_RADIO_VOICEVOX_URL` で上書きできます。解決順は `VOX_RADIO_VOICEVOX_URL`（環境変数）> `voicevox.url` > 既定値 `http://localhost:50021` です。

--- a/internal/cli/templates-sample/vox-radio.yaml
+++ b/internal/cli/templates-sample/vox-radio.yaml
@@ -40,6 +40,8 @@ voicevox:
   # 環境変数 VOX_RADIO_VOICEVOX_URL を設定すると、この値より優先して上書きされます。
   # devcontainer では VOX_RADIO_VOICEVOX_URL が自動設定されるため、この値の変更は不要です。
   url: http://localhost:50021
+  # VOICEVOX が起動するまで待機する最大秒数。省略時はデフォルト 60 秒。0 で待機を無効化。
+  # startup_timeout_seconds: 0
   # 声の抑揚・高さ・速さの呼び名を数値に対応づけます（省略すると組み込みの標準セットを使用）。
   presets:
     intonation:   # 抑揚の強さ（小さいほど棒読み、大きいほど豊かに。0.0〜2.0）

--- a/internal/cli/templates/vox-radio.yaml
+++ b/internal/cli/templates/vox-radio.yaml
@@ -41,6 +41,8 @@ voicevox:
   # 環境変数 VOX_RADIO_VOICEVOX_URL を設定すると、この値より優先して上書きされます。
   # devcontainer では VOX_RADIO_VOICEVOX_URL が自動設定されるため、この値の変更は不要です。
   url: http://localhost:50021
+  # VOICEVOX が起動するまで待機する最大秒数。省略時はデフォルト 60 秒。0 で待機を無効化。
+  # startup_timeout_seconds: 0
   # 声の抑揚・高さ・速さの呼び名を数値に対応づけます（省略すると組み込みの標準セットを使用）。
   presets:
     intonation:   # 抑揚の強さ（小さいほど棒読み、大きいほど豊かに。0.0〜2.0）

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -566,34 +566,24 @@ func TestVoicevoxConfig_EffectiveURL(t *testing.T) {
 	}
 }
 
-func TestVoicevoxConfig_EffectiveStartupTimeout_DefaultIs60Sec(t *testing.T) {
-	t.Parallel()
-	cfg := config.VoicevoxConfig{}
-	got := cfg.EffectiveStartupTimeout()
-	want := 60 * time.Second
-	if got != want {
-		t.Errorf("EffectiveStartupTimeout() = %v, want %v", got, want)
+func TestVoicevoxConfig_EffectiveStartupTimeout(t *testing.T) {
+	zero, thirty := 0, 30
+	tests := []struct {
+		name string
+		cfg  config.VoicevoxConfig
+		want time.Duration
+	}{
+		{name: "nil uses default 60s", cfg: config.VoicevoxConfig{}, want: 60 * time.Second},
+		{name: "zero disables", cfg: config.VoicevoxConfig{StartupTimeoutSeconds: &zero}, want: 0},
+		{name: "explicit value returned", cfg: config.VoicevoxConfig{StartupTimeoutSeconds: &thirty}, want: 30 * time.Second},
 	}
-}
-
-func TestVoicevoxConfig_EffectiveStartupTimeout_ZeroDisables(t *testing.T) {
-	t.Parallel()
-	zero := 0
-	cfg := config.VoicevoxConfig{StartupTimeoutSeconds: &zero}
-	got := cfg.EffectiveStartupTimeout()
-	if got != 0 {
-		t.Errorf("EffectiveStartupTimeout() = %v, want 0 (disabled)", got)
-	}
-}
-
-func TestVoicevoxConfig_EffectiveStartupTimeout_UsesSetValue(t *testing.T) {
-	t.Parallel()
-	n := 30
-	cfg := config.VoicevoxConfig{StartupTimeoutSeconds: &n}
-	got := cfg.EffectiveStartupTimeout()
-	want := 30 * time.Second
-	if got != want {
-		t.Errorf("EffectiveStartupTimeout() = %v, want %v", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.EffectiveStartupTimeout()
+			if got != tt.want {
+				t.Errorf("EffectiveStartupTimeout() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -566,6 +566,53 @@ func TestVoicevoxConfig_EffectiveURL(t *testing.T) {
 	}
 }
 
+func TestVoicevoxConfig_EffectiveStartupTimeout_DefaultIs60Sec(t *testing.T) {
+	t.Parallel()
+	cfg := config.VoicevoxConfig{}
+	got := cfg.EffectiveStartupTimeout()
+	want := 60 * time.Second
+	if got != want {
+		t.Errorf("EffectiveStartupTimeout() = %v, want %v", got, want)
+	}
+}
+
+func TestVoicevoxConfig_EffectiveStartupTimeout_ZeroDisables(t *testing.T) {
+	t.Parallel()
+	zero := 0
+	cfg := config.VoicevoxConfig{StartupTimeoutSeconds: &zero}
+	got := cfg.EffectiveStartupTimeout()
+	if got != 0 {
+		t.Errorf("EffectiveStartupTimeout() = %v, want 0 (disabled)", got)
+	}
+}
+
+func TestVoicevoxConfig_EffectiveStartupTimeout_UsesSetValue(t *testing.T) {
+	t.Parallel()
+	n := 30
+	cfg := config.VoicevoxConfig{StartupTimeoutSeconds: &n}
+	got := cfg.EffectiveStartupTimeout()
+	want := 30 * time.Second
+	if got != want {
+		t.Errorf("EffectiveStartupTimeout() = %v, want %v", got, want)
+	}
+}
+
+func TestLoadConfig_Voicevox_StartupTimeoutSeconds(t *testing.T) {
+	cfg, err := config.LoadConfig("testdata/config_with_startup_timeout.yaml")
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.Voicevox.StartupTimeoutSeconds == nil {
+		t.Fatal("Voicevox.StartupTimeoutSeconds should be non-nil when specified in YAML")
+	}
+	if *cfg.Voicevox.StartupTimeoutSeconds != 0 {
+		t.Errorf("Voicevox.StartupTimeoutSeconds: got %d, want 0", *cfg.Voicevox.StartupTimeoutSeconds)
+	}
+	if cfg.Voicevox.EffectiveStartupTimeout() != 0 {
+		t.Errorf("EffectiveStartupTimeout() = %v, want 0 (disabled from YAML)", cfg.Voicevox.EffectiveStartupTimeout())
+	}
+}
+
 func TestSlackConfig_EffectiveAPIURL(t *testing.T) {
 	// t.Setenv を使うため t.Parallel() は併用しない。
 	tests := []struct {

--- a/internal/config/testdata/config_with_startup_timeout.yaml
+++ b/internal/config/testdata/config_with_startup_timeout.yaml
@@ -1,0 +1,20 @@
+llm:
+  provider: openai
+  openai:
+    base_url: https://generativelanguage.googleapis.com/v1beta/openai/
+    api_key_env: GEMINI_API_KEY
+    model: gemini-3.1-flash-lite
+
+voicevox:
+  url: http://localhost:50021
+  startup_timeout_seconds: 0
+
+characters:
+  zundamon:
+    name: ずんだもん
+    pronoun: ボク
+    speech_suffix: ["〜のだ"]
+    personality: ["元気"]
+    default_style: ノーマル
+    styles:
+      ノーマル: 3

--- a/internal/config/voicevox.go
+++ b/internal/config/voicevox.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"time"
 )
 
 const (
@@ -10,6 +11,8 @@ const (
 	DefaultVoicevoxURL = "http://localhost:50021"
 	// VoicevoxURLEnv は VOICEVOX URL を上書きする環境変数名。
 	VoicevoxURLEnv = "VOX_RADIO_VOICEVOX_URL"
+	// DefaultStartupTimeoutSeconds は startup_timeout_seconds 未指定時のデフォルト秒数。
+	DefaultStartupTimeoutSeconds = 60
 )
 
 // VoicevoxPresets maps preset names to float64 scale values for each axis.
@@ -73,8 +76,17 @@ var defaultSpeedPresets = map[string]float64{
 }
 
 type VoicevoxConfig struct {
-	URL     string           `yaml:"url"`
-	Presets *VoicevoxPresets `yaml:"presets,omitempty"`
+	URL                   string           `yaml:"url"`
+	Presets               *VoicevoxPresets `yaml:"presets,omitempty"`
+	StartupTimeoutSeconds *int             `yaml:"startup_timeout_seconds,omitempty"`
+}
+
+// EffectiveStartupTimeout は起動待機タイムアウトを返す。nil（未指定）はデフォルト 60 秒、*0 は待機無効（0）。
+func (c VoicevoxConfig) EffectiveStartupTimeout() time.Duration {
+	if c.StartupTimeoutSeconds == nil {
+		return DefaultStartupTimeoutSeconds * time.Second
+	}
+	return time.Duration(*c.StartupTimeoutSeconds) * time.Second
 }
 
 // EffectiveURL は環境変数 > 設定値 > デフォルトの優先順で URL を返す。

--- a/internal/synth/client.go
+++ b/internal/synth/client.go
@@ -14,21 +14,47 @@ import (
 
 // VoicevoxClient is the interface for the VOICEVOX HTTP API
 type VoicevoxClient interface {
+	Version(ctx context.Context) (string, error)
 	AudioQuery(ctx context.Context, text string, speaker int) (*AudioQuery, error)
 	Synthesis(ctx context.Context, query *AudioQuery, speaker int) ([]byte, error)
 }
 
 type httpVoicevoxClient struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL       string
+	httpClient    *http.Client // with retry for audio synthesis operations
+	versionClient *http.Client // without retry for readiness polling
 }
 
 // NewClient creates a new VOICEVOX HTTP API client
 func NewClient(baseURL string) VoicevoxClient {
 	return &httpVoicevoxClient{
-		baseURL:    baseURL,
-		httpClient: httpretry.NewClient(0),
+		baseURL:       baseURL,
+		httpClient:    httpretry.NewClient(0),
+		versionClient: &http.Client{},
 	}
+}
+
+func (c *httpVoicevoxClient) Version(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/version", nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.versionClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("do request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("version returned %d", resp.StatusCode)
+	}
+
+	var version string
+	if err := json.NewDecoder(resp.Body).Decode(&version); err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+	return version, nil
 }
 
 func (c *httpVoicevoxClient) AudioQuery(ctx context.Context, text string, speaker int) (*AudioQuery, error) {

--- a/internal/synth/client_test.go
+++ b/internal/synth/client_test.go
@@ -152,3 +152,37 @@ func TestHTTPVoicevoxClient_Synthesis_ReturnsErrorOnNonOK(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 }
+
+func TestHTTPVoicevoxClient_Version_ReturnsVersionString(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/version" || r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`"0.14.7"`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	got, err := client.Version(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "0.14.7" {
+		t.Errorf("Version() = %q, want %q", got, "0.14.7")
+	}
+}
+
+func TestHTTPVoicevoxClient_Version_ReturnsErrorOnNonOK(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not ready", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	_, err := client.Version(context.Background())
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}

--- a/internal/synth/synth.go
+++ b/internal/synth/synth.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 	"unicode/utf8"
 
 	"github.com/canpok1/vox-radio/internal/config"
@@ -15,12 +16,15 @@ import (
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
+const pollIntervalDefault = time.Second
+
 // Synth synthesizes speech segments from a script using the VOICEVOX HTTP API
 type Synth struct {
-	Client      VoicevoxClient
-	Config      *config.Config
-	getDuration func(path string) (float64, error)
-	logger      *slog.Logger
+	Client       VoicevoxClient
+	Config       *config.Config
+	getDuration  func(path string) (float64, error)
+	logger       *slog.Logger
+	pollInterval time.Duration
 }
 
 // Option configures a Synth.
@@ -34,10 +38,11 @@ func WithLogger(l *slog.Logger) Option {
 // New creates a new Synth with an HTTP VOICEVOX client.
 func New(engineURL string, cfg *config.Config, opts ...Option) *Synth {
 	s := &Synth{
-		Client:      NewClient(engineURL),
-		Config:      cfg,
-		getDuration: mediainfo.Duration,
-		logger:      slog.Default(),
+		Client:       NewClient(engineURL),
+		Config:       cfg,
+		getDuration:  mediainfo.Duration,
+		logger:       slog.Default(),
+		pollInterval: pollIntervalDefault,
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -49,6 +54,14 @@ func New(engineURL string, cfg *config.Config, opts ...Option) *Synth {
 // It also writes clips.json with metadata including durations.
 func (s *Synth) Run(ctx context.Context, script model.Script, outDir string) (*model.ClipsMeta, error) {
 	logger := s.logger.With("step", "synth")
+
+	var timeout time.Duration
+	if s.Config != nil {
+		timeout = s.Config.Voicevox.EffectiveStartupTimeout()
+	}
+	if err := waitForReady(ctx, s.Client, timeout, s.pollInterval); err != nil {
+		return nil, fmt.Errorf("wait for voicevox: %w", err)
+	}
 
 	if err := os.MkdirAll(outDir, 0o755); err != nil {
 		return nil, fmt.Errorf("create output dir: %w", err)
@@ -154,4 +167,34 @@ func (s *Synth) resolveSpeakerID(charID, style string) int {
 	}
 	id, _ := ch.SpeakerID(style)
 	return id
+}
+
+// waitForReady polls the VOICEVOX /version endpoint until it responds successfully.
+// Returns nil immediately when timeout is zero (disabled) or when the engine is ready.
+// Returns an error if the context is cancelled or the timeout expires.
+func waitForReady(ctx context.Context, client VoicevoxClient, timeout, interval time.Duration) error {
+	if timeout == 0 {
+		return nil
+	}
+	deadline := time.Now().Add(timeout)
+	// Try immediately first (fast path when engine is already running)
+	if _, err := client.Version(ctx); err == nil {
+		return nil
+	}
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-timer.C:
+		}
+		if _, err := client.Version(ctx); err == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("voicevox did not become ready within %s", timeout)
+		}
+		timer.Reset(interval)
+	}
 }

--- a/internal/synth/synth.go
+++ b/internal/synth/synth.go
@@ -177,11 +177,7 @@ func waitForReady(ctx context.Context, client VoicevoxClient, timeout, interval 
 		return nil
 	}
 	deadline := time.Now().Add(timeout)
-	// Try immediately first (fast path when engine is already running)
-	if _, err := client.Version(ctx); err == nil {
-		return nil
-	}
-	timer := time.NewTimer(interval)
+	timer := time.NewTimer(0)
 	defer timer.Stop()
 	for {
 		select {

--- a/internal/synth/synth_test.go
+++ b/internal/synth/synth_test.go
@@ -3,19 +3,29 @@ package synth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/canpok1/vox-radio/internal/config"
 	"github.com/canpok1/vox-radio/internal/model"
 )
 
 type mockVoicevoxClient struct {
+	versionFn    func(ctx context.Context) (string, error)
 	audioQueryFn func(ctx context.Context, text string, speaker int) (*AudioQuery, error)
 	synthesisFn  func(ctx context.Context, query *AudioQuery, speaker int) ([]byte, error)
+}
+
+func (m *mockVoicevoxClient) Version(ctx context.Context) (string, error) {
+	if m.versionFn != nil {
+		return m.versionFn(ctx)
+	}
+	return "0.14.7", nil
 }
 
 func (m *mockVoicevoxClient) AudioQuery(ctx context.Context, text string, speaker int) (*AudioQuery, error) {
@@ -639,5 +649,180 @@ func TestSynth_Run_PropagatesCornerID(t *testing.T) {
 	}
 	if meta.Clips[1].CornerID != "tech" {
 		t.Errorf("Clips[1].CornerID: got %q, want tech", meta.Clips[1].CornerID)
+	}
+}
+
+// --- waitForReady tests ---
+
+func TestWaitForReady_SkipsWhenTimeoutZero(t *testing.T) {
+	t.Parallel()
+	client := &mockVoicevoxClient{
+		versionFn: func(_ context.Context) (string, error) {
+			return "", errors.New("not ready")
+		},
+	}
+	err := waitForReady(context.Background(), client, 0, time.Millisecond)
+	if err != nil {
+		t.Errorf("expected nil error when timeout=0, got %v", err)
+	}
+}
+
+func TestWaitForReady_ReturnsImmediatelyWhenReady(t *testing.T) {
+	t.Parallel()
+	client := &mockVoicevoxClient{
+		versionFn: func(_ context.Context) (string, error) {
+			return "0.14.7", nil
+		},
+	}
+	err := waitForReady(context.Background(), client, 5*time.Second, time.Millisecond)
+	if err != nil {
+		t.Errorf("expected nil error when ready, got %v", err)
+	}
+}
+
+func TestWaitForReady_ReturnsErrorOnTimeout(t *testing.T) {
+	t.Parallel()
+	client := &mockVoicevoxClient{
+		versionFn: func(_ context.Context) (string, error) {
+			return "", errors.New("not ready")
+		},
+	}
+	err := waitForReady(context.Background(), client, 50*time.Millisecond, 10*time.Millisecond)
+	if err == nil {
+		t.Error("expected error on timeout, got nil")
+	}
+}
+
+func TestWaitForReady_RetriesUntilReady(t *testing.T) {
+	t.Parallel()
+	attempts := 0
+	client := &mockVoicevoxClient{
+		versionFn: func(_ context.Context) (string, error) {
+			attempts++
+			if attempts < 3 {
+				return "", errors.New("not ready yet")
+			}
+			return "0.14.7", nil
+		},
+	}
+	err := waitForReady(context.Background(), client, 5*time.Second, 10*time.Millisecond)
+	if err != nil {
+		t.Errorf("expected nil error after retries, got %v", err)
+	}
+	if attempts < 3 {
+		t.Errorf("Version should be called at least 3 times, got %d", attempts)
+	}
+}
+
+func TestWaitForReady_RespectsCtxCancel(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &mockVoicevoxClient{
+		versionFn: func(_ context.Context) (string, error) {
+			cancel()
+			return "", errors.New("not ready")
+		},
+	}
+	err := waitForReady(ctx, client, 5*time.Second, 10*time.Millisecond)
+	if err == nil {
+		t.Error("expected error on ctx cancel, got nil")
+	}
+}
+
+// --- Synth.Run readiness tests ---
+
+func TestSynth_Run_CallsVersionForReadiness(t *testing.T) {
+	versionCalled := false
+	s := &Synth{
+		Client: &mockVoicevoxClient{
+			versionFn: func(_ context.Context) (string, error) {
+				versionCalled = true
+				return "0.14.7", nil
+			},
+			audioQueryFn: func(_ context.Context, _ string, _ int) (*AudioQuery, error) {
+				return &AudioQuery{SpeedScale: 1.0}, nil
+			},
+			synthesisFn: func(_ context.Context, _ *AudioQuery, _ int) ([]byte, error) {
+				return fakeWAV, nil
+			},
+		},
+		Config:       &config.Config{},
+		getDuration:  func(_ string) (float64, error) { return 1.0, nil },
+		logger:       slog.Default(),
+		pollInterval: time.Millisecond,
+	}
+	script := model.Script{
+		Segments: []model.ScriptSegment{
+			{Type: model.SegmentTypeSpeech, SpeakerRole: "zundamon", Text: "テスト"},
+		},
+	}
+	if _, err := s.Run(context.Background(), script, t.TempDir()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !versionCalled {
+		t.Error("Version should be called during Run for readiness check")
+	}
+}
+
+func TestSynth_Run_SkipsReadinessWhenStartupTimeoutZero(t *testing.T) {
+	zero := 0
+	versionCalled := false
+	s := &Synth{
+		Client: &mockVoicevoxClient{
+			versionFn: func(_ context.Context) (string, error) {
+				versionCalled = true
+				return "", errors.New("not ready")
+			},
+			audioQueryFn: func(_ context.Context, _ string, _ int) (*AudioQuery, error) {
+				return &AudioQuery{SpeedScale: 1.0}, nil
+			},
+			synthesisFn: func(_ context.Context, _ *AudioQuery, _ int) ([]byte, error) {
+				return fakeWAV, nil
+			},
+		},
+		Config: &config.Config{
+			Voicevox: config.VoicevoxConfig{StartupTimeoutSeconds: &zero},
+		},
+		getDuration:  func(_ string) (float64, error) { return 1.0, nil },
+		logger:       slog.Default(),
+		pollInterval: time.Millisecond,
+	}
+	script := model.Script{
+		Segments: []model.ScriptSegment{
+			{Type: model.SegmentTypeSpeech, SpeakerRole: "zundamon", Text: "テスト"},
+		},
+	}
+	if _, err := s.Run(context.Background(), script, t.TempDir()); err != nil {
+		t.Errorf("unexpected error when startup_timeout_seconds=0: %v", err)
+	}
+	if versionCalled {
+		t.Error("Version should NOT be called when startup_timeout_seconds=0")
+	}
+}
+
+func TestSynth_Run_ReturnsErrorWhenReadinessTimeout(t *testing.T) {
+	n := 1
+	s := &Synth{
+		Client: &mockVoicevoxClient{
+			versionFn: func(_ context.Context) (string, error) {
+				return "", errors.New("not ready")
+			},
+			audioQueryFn: func(_ context.Context, _ string, _ int) (*AudioQuery, error) {
+				return &AudioQuery{SpeedScale: 1.0}, nil
+			},
+			synthesisFn: func(_ context.Context, _ *AudioQuery, _ int) ([]byte, error) {
+				return fakeWAV, nil
+			},
+		},
+		Config: &config.Config{
+			Voicevox: config.VoicevoxConfig{StartupTimeoutSeconds: &n},
+		},
+		getDuration:  func(_ string) (float64, error) { return 1.0, nil },
+		logger:       slog.Default(),
+		pollInterval: time.Millisecond,
+	}
+	_, err := s.Run(context.Background(), model.Script{}, t.TempDir())
+	if err == nil {
+		t.Error("expected error when VOICEVOX startup times out")
 	}
 }


### PR DESCRIPTION
関連タスク: [VOICEVOX 起動を待つ準備完了ポーリング機能を vox-radio 本体に追加](https://app.todoist.com/app/task/6gvmV2grXFG45MQ3)

## 概要

- `VoicevoxClient` に `Version(ctx) (string, error)` を追加（`GET /version`、httpretry なしの専用クライアントで呼び出し）
- `Synth.Run` 冒頭で `waitForReady()` ヘルパーを呼び、VOICEVOX が起動するまでポーリング（1秒間隔・デフォルト最大60秒）
- `VoicevoxConfig` に `StartupTimeoutSeconds *int`（yaml: `startup_timeout_seconds`）と `EffectiveStartupTimeout()` を追加
- CI（`demo-release.yml`）から `Wait for VOICEVOX` ステップを削除
- README・設定テンプレート・リファレンスに `startup_timeout_seconds` を追記
- ADR 0088 を追加

## 動作

- エンジン起動済みなら初回 `/version` 成功で即進む（ペナルティなし）
- 未起動なら 1 秒間隔でポーリングし、起動完了次第進む
- `startup_timeout_seconds: 0` で待機を無効化できる

## テスト

- `waitForReady`: 5ケース（timeout=0スキップ, 即時成功, タイムアウト, リトライ後成功, ctx キャンセル）
- `Synth.Run` 起動待機: 3ケース（version呼び出し確認, timeout=0スキップ, タイムアウトエラー）
- `Version()` HTTP: 2ケース（成功, 非200エラー）
- `EffectiveStartupTimeout()`: テーブル駆動3ケース + YAML ロードテスト

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)