### PR TITLE
fix(ci): demo-release の mp3 解決を single_shot 命名に対応

### DIFF
--- a/.github/workflows/demo-release.yml
+++ b/.github/workflows/demo-release.yml
@@ -47,8 +47,10 @@ jobs:
       - name: Prepare release assets
         working-directory: demo
         run: |
-          MP3=$(ls output/*_ep*.mp3 | head -n1)
+          # single_shot 番組のため出力ファイル名に回番号サフィックス（_ep{NNN}）は付かない。
+          # mp3 は manifest 名（<base>_manifest.json）から <base>.mp3 を導出する。
           MANIFEST=$(ls output/*_manifest.json | head -n1)
+          MP3="${MANIFEST%_manifest.json}.mp3"
           cp "$MP3" output/vox-radio-demo.mp3
           vox-radio render --manifest "$MANIFEST" --template release-notes.tmpl --output output/RELEASE_NOTES.md
 


### PR DESCRIPTION
## 概要

`demo-release` ワークフローの「Prepare release assets」ステップが失敗していたため修正する。

失敗ジョブ: https://github.com/canpok1/vox-radio/actions/runs/27836108103/job/82384398056

## 原因

`demo/episode-spec.yaml` で `single_shot: true`（単発番組モード）が設定されているため、`EpisodeBaseName`（`internal/fileio/paths.go`）は回番号サフィックス `_ep{NNN}` を付けず、出力ファイルが以下の名前になる。

- mp3: `output/vox-radio-demo.mp3`
- manifest: `output/vox-radio-demo_manifest.json`

しかしワークフローは mp3 を `ls output/*_ep*.mp3` で探しており、`_ep` を含むファイルが存在しないため `ls` がエラーになり、GitHub Actions の `set -eo pipefail` によってステップが即座に失敗していた（manifest 側の `*_manifest.json` は一致するため問題なし）。

## 修正内容

mp3 のパスを manifest 名から導出する形に変更し、single_shot / 非 single_shot のどちらでも動くようにする。

```yaml
MANIFEST=$(ls output/*_manifest.json | head -n1)
MP3="${MANIFEST%_manifest.json}.mp3"
```

## 動作確認

- pre-push の `go test ./...` が全てパス

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeGckPPW2w9nETEKLiCwUg)_