### PR TITLE
fix(ci): demo-release の冗長な mp3 リネームを廃止（同一ファイル cp 失敗の解消）

### DIFF
--- a/.github/workflows/demo-release.yml
+++ b/.github/workflows/demo-release.yml
@@ -43,15 +43,13 @@ jobs:
           VOX_RADIO_VOICEVOX_URL: http://127.0.0.1:50021
         run: vox-radio episodegen --spec episode-spec.yaml --out-dir output
 
-      # 安定したダウンロード名にリネームし、manifest からリリースノート（要約＋クレジット）を生成。
-      - name: Prepare release assets
+      # manifest からリリースノート（要約＋クレジット）を生成する。
+      # single_shot 番組のため mp3 は program.id 名（output/vox-radio-demo.mp3）として
+      # 直接生成され、回番号サフィックス（_ep{NNN}）も付かないためリネーム不要。
+      - name: Prepare release notes
         working-directory: demo
         run: |
-          # single_shot 番組のため出力ファイル名に回番号サフィックス（_ep{NNN}）は付かない。
-          # mp3 は manifest 名（<base>_manifest.json）から <base>.mp3 を導出する。
           MANIFEST=$(ls output/*_manifest.json | head -n1)
-          MP3="${MANIFEST%_manifest.json}.mp3"
-          cp "$MP3" output/vox-radio-demo.mp3
           vox-radio render --manifest "$MANIFEST" --template release-notes.tmpl --output output/RELEASE_NOTES.md
 
       # 固定タグ `demo` の prerelease を作り直して上書きする（初回は delete が無いので無視）。


### PR DESCRIPTION
## 概要

`demo-release` ワークフローの「Prepare release assets」ステップが再び失敗していたため修正する。

失敗ジョブ: https://github.com/canpok1/vox-radio/actions/runs/27836664402/job/82386162509

## 原因

実エラーは以下だった。

```
cp: 'output/vox-radio-demo.mp3' and 'output/vox-radio-demo.mp3' are the same file
```

`single_shot` 番組では `program.id`（=`vox-radio-demo`）がそのままファイル名になるため、mp3 は最初から `output/vox-radio-demo.mp3` として生成される。前回の修正（#506）で mp3 パスを manifest 名から導出したところ、コピー元とコピー先が同一になり `cp` が失敗していた。

## 修正内容

リネーム（`cp`）はそもそも不要だったため廃止し、生成済みの mp3 をそのまま公開する。リリースノート生成のみ残す。Publish ステップは従来どおり `demo/output/vox-radio-demo.mp3` を参照する（このファイルは直接生成される）。

```yaml
- name: Prepare release notes
  working-directory: demo
  run: |
    MANIFEST=$(ls output/*_manifest.json | head -n1)
    vox-radio render --manifest "$MANIFEST" --template release-notes.tmpl --output output/RELEASE_NOTES.md
```

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeGckPPW2w9nETEKLiCwUg)_