### PR TITLE
docs: ADR-0089 Homebrew Cask 配布（ffmpeg 依存）の決定記録

### DIFF
--- a/docs/adr/0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md
+++ b/docs/adr/0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md
@@ -5,28 +5,28 @@
 
 ## コンテキスト
 
-現状の配布は `install.sh`（GitHub Releases）とエージェントスキル（ADR-0039）で、必須依存の ffmpeg（ADR-0007・ADR-0070）は利用者が別途導入する必要がある。とくに ADR-0070 は「Apple Silicon での ffmpeg 導入の手間が未解決」と記録していた。macOS 利用者が vox-radio 本体と ffmpeg をワンステップで導入できる経路が欲しい。
+現状の配布は `install.sh`（GitHub Releases）とエージェントスキル（ADR-0039）で、必須依存の ffmpeg（ADR-0007・ADR-0070）は利用者が別途導入する必要がある。とくに ADR-0070 は「Apple Silicon での ffmpeg 導入の手間が未解決」と記録していた。利用者が vox-radio 本体と ffmpeg をワンステップで導入できる経路が欲しい。
 
-別リポジトリ vox-actor は既に Homebrew Cask（tap: `canpok1/homebrew-tap`）で配布しており、同じ仕組みを踏襲できる。vox-radio は既に GoReleaser とタグ起動のリリースワークフローを持つため、設定追加だけで対応できる。
+別リポジトリ vox-actor は既に Homebrew Cask（tap: `canpok1/homebrew-tap`）で配布しており、同じ仕組みを踏襲できる。vox-radio は既に GoReleaser とタグ起動のリリースワークフローを持つため、設定追加だけで対応できる。なお Homebrew は brew#19121（4.5.0, 2025）以降 Linux の Cask に対応し、GoReleaser の `homebrew_casks` はビルド済みバイナリ全対象（macOS/Linux）の Cask を生成できる。実際に vox-actor の Cask も Darwin/Linux × amd64/arm64 を含み、devcontainer（Ubuntu）でも `brew install --cask` で導入している。
 
 ## 決定
 
 GoReleaser に `homebrew_casks` を追加し、vox-actor と共用の tap `canpok1/homebrew-tap` へ Cask を publish する。
 
-- **ffmpeg を Cask の依存に含める**（GoReleaser の `dependencies` で `depends_on formula: "ffmpeg"` を生成）。`brew install --cask` 時に ffmpeg を自動導入する。
-- vox-actor と同様に post-install で macOS の quarantine 属性を解除する。
+- **ffmpeg を Cask の依存に含める**（GoReleaser の `dependencies` で `depends_on formula: "ffmpeg"` を生成）。`brew install --cask` 時に ffmpeg を自動導入する。formula は Linux でも動くため両 OS で効く。
+- 生成される Cask は vox-radio の既存ビルド対象（macOS/Linux × amd64/arm64）をカバーし、macOS・Linux 双方の Homebrew で導入できる。
+- post-install で macOS の quarantine 属性を解除する（`OS.mac?` ガード付き。Linux では no-op）。
 - tap への push 認証は `HOMEBREW_TAP_GITHUB_TOKEN`（vox-actor 用と同じ PAT を流用）を使う。
-- 配布は Cask 一本とし、Linux 向けは既存 `install.sh`／apt を継続する（Linuxbrew は Cask 非対応のため）。
+- `install.sh` は Homebrew を使わない利用者向け・Windows 向けの経路として継続する。
 
 ## 結果
 
-- macOS 利用者は `brew install --cask` 一発で vox-radio と ffmpeg を導入でき、ADR-0070 の Apple Silicon 課題が解消する。
+- macOS・Linux の Homebrew 利用者は `brew install --cask` 一発で vox-radio と ffmpeg を導入でき、ADR-0070 の Apple Silicon 課題（および Linux での導入の手間）が解消する。
 - vox-actor と tap・配布方式を共有し保守が一貫する。
-- トレードオフ: Linux は Homebrew 経路を持たず既存手段を継続する。tap publish に PAT の事前設定が要る。Cask は概念上 GUI 向けだが GoReleaser が `binary` stanza を生成し CLI も symlink される。
+- トレードオフ: tap publish に PAT の事前設定が要る。Homebrew 非利用者・Windows 向けに `install.sh` を併存させる（チャネルは増えるが既存資産の継続）。Cask は概念上 GUI 向けだが GoReleaser が `binary` stanza を生成し CLI も symlink される。
 
 ## 検討した代替案
 
-- **Homebrew Formula（`brews`）**: macOS/Linux 両対応だが vox-actor と方式が分かれ、`brews` は Cask より将来の保守優先度が低い。Linux は `install.sh` で足りるため不採用。
-- **Cask と Formula の両方**: 双方をカバーできるが設定・tap 管理が増え、利点に対し保守負担が大きく不採用。
-- **ffmpeg を依存にせず手動導入を案内**: 現状維持で導入の手間が残り ADR-0070 の課題が解消しないため不採用。
+- **Homebrew Formula（`brews`）**: かつては Linux 対応が Cask に対する利点だったが、Homebrew が Linux Cask に対応した現在その差は消え、GoReleaser も `brews` を非推奨化して `homebrew_casks` を推奨している。利点が無く不採用。
+- **ffmpeg を依存にせず手動導入を案内**: 現状維持で導入の手間が残り、ADR-0070 の課題が解消しないため不採用。
 - **専用 tap を新設**: 管理対象が増えるだけで利点が薄く、既存 tap を再利用した。

--- a/docs/adr/0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md
+++ b/docs/adr/0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md
@@ -1,0 +1,32 @@
+# 0089. vox-radio を Homebrew Cask で配布し ffmpeg を依存に含める
+
+- ステータス: 採用
+- 日付: 2026-06-19
+
+## コンテキスト
+
+現状の配布は `install.sh`（GitHub Releases）とエージェントスキル（ADR-0039）で、必須依存の ffmpeg（ADR-0007・ADR-0070）は利用者が別途導入する必要がある。とくに ADR-0070 は「Apple Silicon での ffmpeg 導入の手間が未解決」と記録していた。macOS 利用者が vox-radio 本体と ffmpeg をワンステップで導入できる経路が欲しい。
+
+別リポジトリ vox-actor は既に Homebrew Cask（tap: `canpok1/homebrew-tap`）で配布しており、同じ仕組みを踏襲できる。vox-radio は既に GoReleaser とタグ起動のリリースワークフローを持つため、設定追加だけで対応できる。
+
+## 決定
+
+GoReleaser に `homebrew_casks` を追加し、vox-actor と共用の tap `canpok1/homebrew-tap` へ Cask を publish する。
+
+- **ffmpeg を Cask の依存に含める**（GoReleaser の `dependencies` で `depends_on formula: "ffmpeg"` を生成）。`brew install --cask` 時に ffmpeg を自動導入する。
+- vox-actor と同様に post-install で macOS の quarantine 属性を解除する。
+- tap への push 認証は `HOMEBREW_TAP_GITHUB_TOKEN`（vox-actor 用と同じ PAT を流用）を使う。
+- 配布は Cask 一本とし、Linux 向けは既存 `install.sh`／apt を継続する（Linuxbrew は Cask 非対応のため）。
+
+## 結果
+
+- macOS 利用者は `brew install --cask` 一発で vox-radio と ffmpeg を導入でき、ADR-0070 の Apple Silicon 課題が解消する。
+- vox-actor と tap・配布方式を共有し保守が一貫する。
+- トレードオフ: Linux は Homebrew 経路を持たず既存手段を継続する。tap publish に PAT の事前設定が要る。Cask は概念上 GUI 向けだが GoReleaser が `binary` stanza を生成し CLI も symlink される。
+
+## 検討した代替案
+
+- **Homebrew Formula（`brews`）**: macOS/Linux 両対応だが vox-actor と方式が分かれ、`brews` は Cask より将来の保守優先度が低い。Linux は `install.sh` で足りるため不採用。
+- **Cask と Formula の両方**: 双方をカバーできるが設定・tap 管理が増え、利点に対し保守負担が大きく不採用。
+- **ffmpeg を依存にせず手動導入を案内**: 現状維持で導入の手間が残り ADR-0070 の課題が解消しないため不採用。
+- **専用 tap を新設**: 管理対象が増えるだけで利点が薄く、既存 tap を再利用した。

--- a/docs/adr/0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md
+++ b/docs/adr/0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md
@@ -17,13 +17,13 @@ GoReleaser に `homebrew_casks` を追加し、vox-actor と共用の tap `canpo
 - 生成される Cask は vox-radio の既存ビルド対象（macOS/Linux × amd64/arm64）をカバーし、macOS・Linux 双方の Homebrew で導入できる。
 - post-install で macOS の quarantine 属性を解除する（`OS.mac?` ガード付き。Linux では no-op）。
 - tap への push 認証は `HOMEBREW_TAP_GITHUB_TOKEN`（vox-actor 用と同じ PAT を流用）を使う。
-- `install.sh` は Homebrew を使わない利用者向け・Windows 向けの経路として継続する。
+- `install.sh`（Linux/macOS 対応）は Homebrew を使わない利用者向けの経路として継続する。Windows は従来どおりリリースの zip を手動取得する（install.sh・Homebrew とも非対応）。
 
 ## 結果
 
 - macOS・Linux の Homebrew 利用者は `brew install --cask` 一発で vox-radio と ffmpeg を導入でき、ADR-0070 の Apple Silicon 課題（および Linux での導入の手間）が解消する。
 - vox-actor と tap・配布方式を共有し保守が一貫する。
-- トレードオフ: tap publish に PAT の事前設定が要る。Homebrew 非利用者・Windows 向けに `install.sh` を併存させる（チャネルは増えるが既存資産の継続）。Cask は概念上 GUI 向けだが GoReleaser が `binary` stanza を生成し CLI も symlink される。
+- トレードオフ: tap publish に PAT の事前設定が要る。Homebrew 非利用者（Linux/macOS）向けに `install.sh` を併存させ、Windows はリリース zip の手動取得を継続する（チャネルは増えるが既存資産の継続）。Cask は概念上 GUI 向けだが GoReleaser が `binary` stanza を生成し CLI も symlink される。
 
 ## 検討した代替案
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -94,3 +94,4 @@
 | [0086](0086-single-shot-program-mode.md) | 単発番組モード（single_shot）で回番号を無効化し命名・キャッシュの例外を導入する | 採用 | 2026-06-19 |
 | [0087](0087-corner-source-as-typed-array.md) | コーナーの source を type 付き配列（discriminated array）へ再設計する | 採用 | 2026-06-19 |
 | [0088](0088-voicevox-startup-readiness-polling.md) | VOICEVOX 起動待機ポーリングを vox-radio 本体に組み込む | 採用 | 2026-06-19 |
+| [0089](0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md) | vox-radio を Homebrew Cask で配布し ffmpeg を依存に含める | 採用 | 2026-06-19 |


### PR DESCRIPTION
関連タスク: [Homebrew Cask で vox-radio を配布する（ffmpeg を依存に含める）](https://app.todoist.com/app/task/6gvp6xRh9QRRr4QV)

## 概要

vox-radio を Homebrew でインストールできるようにするための配布方式の判断を ADR-0089 として記録します。

「vox-actor の Homebrew 対応を参考にしたい・ffmpeg も一緒に入るようにしたい」という相談（discuss）の結論です。

## 決定内容（ADR-0089）

- **Homebrew Cask** で配布する（`homebrew_casks`。Formula は採用しない）
- tap は vox-actor と共用の **canpok1/homebrew-tap を再利用**
- **ffmpeg を Cask の依存に含める**（`brew install --cask` 時に自動導入）→ ADR-0070 の「Apple Silicon での ffmpeg 導入の手間」を解消
- post-install で macOS の quarantine 解除（vox-actor 同様）、認証は `HOMEBREW_TAP_GITHUB_TOKEN`
- Linux 向けは既存 install.sh／apt を継続（Linuxbrew は Cask 非対応のため）

## このPRの内容

- `docs/adr/0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md` 追加
- `docs/adr/README.md` の索引に 1 行追記

実装（`.goreleaser.yaml` への `homebrew_casks` 追記、README/installation.md 更新）は別タスクで対応します。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCfdh2LCi25zvJFSrPpZ1Q)_