### PR TITLE
feat(release): Homebrew Cask で vox-radio を配布（ffmpeg 依存付き）

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -55,3 +55,17 @@ release:
     ---
 
     Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
+
+homebrew_casks:
+  - repository:
+      owner: canpok1
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    dependencies:
+      - formula: ffmpeg
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/{{ .ProjectName }}"]
+          end

--- a/README.md
+++ b/README.md
@@ -6,32 +6,24 @@
 
 [デモ番組を聴く](https://github.com/canpok1/vox-radio/releases/tag/demo)
 
-## インストール
-
-```bash
-curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | bash
-```
-
-設置先の変更・特定バージョンの指定などは[インストールガイド](docs/installation.md)を参照してください。
-
 ## クイックスタート
 
 すぐ動くサンプル設定で番組を 1 本作る最短手順です（サンプルの詳細は[設定方法](#設定方法)）。
 
-### 1. 実行環境を整える
+### 1. vox-radio を導入する
 
-ラジオ番組の生成には生成AI・VOICEVOX・ffmpeg が必要です。次の 3 つを準備します。
+```bash
+brew install --cask canpok1/homebrew-tap/vox-radio
+```
+
+ffmpeg も同時に導入されます。Homebrew を使わない場合は「[インストール](#インストール)」章を参照してください。
+
+### 2. 実行環境を整える
 
 - **生成AIの API キー**: サンプルは Gemini を使う構成です。[Google AI Studio](https://aistudio.google.com/) でキーを取得しておきます。
-- **VOICEVOX Engine**: いずれかの方法でインストールして起動します（既定 `http://localhost:50021`）。vox-radio は起動完了まで自動的に待機します（デフォルト最大 60 秒）。
-    - [VOICEVOX 公式アプリ](https://voicevox.hiroshiba.jp/)をインストールして起動する
-    - Docker で起動する: `docker run -d -p 50021:50021 voicevox/voicevox_engine:cpu-latest`
-- **ffmpeg**: 音声の結合に使います（`ffprobe` を含む）。
-    - macOS: `brew install ffmpeg`
-    - Ubuntu / Debian: `sudo apt-get install ffmpeg`
-    - その他は [ffmpeg 公式サイト](https://ffmpeg.org/download.html)
+- **VOICEVOX Engine**: インストールして起動します。導入方法は「[インストール](#インストール)」章を参照してください。
 
-### 2. 設定ファイルを用意する
+### 3. 設定ファイルを用意する
 
 **BGM・効果音なし**と**BGM・効果音あり**のどちらか一方を選んでください。
 
@@ -53,7 +45,7 @@ unzip vox-radio-sample-assets.zip -d assets
 vox-radio init --sample-with-assets
 ```
 
-`init` で生成された `.env` の `GEMINI_API_KEY` 欄に、手順 1 で取得した API キーを記入します（実行時に自動で読み込まれます）。
+`init` で生成された `.env` の `GEMINI_API_KEY` 欄に、手順 2 で取得した API キーを記入します（実行時に自動で読み込まれます）。
 
 ```
 GEMINI_API_KEY=<your-key>
@@ -61,13 +53,49 @@ GEMINI_API_KEY=<your-key>
 
 サンプルはこのまま番組を生成できます。番組内容やキャラクターを変えたい場合は各設定ファイルを編集します（詳細は[設定方法](#設定方法)）。
 
-### 3. 番組を生成する
+### 4. 番組を生成する
 
 ```bash
 vox-radio episodegen --spec episode-spec.yaml
 ```
 
 番組は `output/{program.id}_ep{NNN}.mp3` に生成されます（マニフェスト・中間ファイルも `output/` 配下に出力）。
+
+## インストール
+
+### vox-radio の導入
+
+1. **Homebrew（推奨・macOS / Linux）**
+
+   ```bash
+   brew install --cask canpok1/homebrew-tap/vox-radio
+   ```
+
+   ffmpeg も同時に導入されます。
+
+2. **install.sh（macOS / Linux）**
+
+   ```bash
+   curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | bash
+   ```
+
+3. **バイナリ手動ダウンロード（全OS・Windows 含む）**
+
+   [GitHub Releases](https://github.com/canpok1/vox-radio/releases/latest) から `tar.gz` / `zip` を取得して PATH に配置します。ffmpeg も別途導入が必要です。
+
+### 依存ソフトの導入
+
+- **VOICEVOX Engine**: いずれかの方法でインストールして起動します（既定 `http://localhost:50021`）。vox-radio は起動完了まで自動的に待機します（デフォルト最大 60 秒）。
+    - [VOICEVOX 公式アプリ](https://voicevox.hiroshiba.jp/)をインストールして起動する
+    - Docker で起動する: `docker run -d -p 50021:50021 voicevox/voicevox_engine:cpu-latest`
+- **ffmpeg**（`ffprobe` を含む）: Homebrew でインストールした場合は自動で導入されます。手動導入の場合:
+    - macOS: `brew install ffmpeg`
+    - Ubuntu / Debian: `sudo apt-get install ffmpeg`
+    - その他は [ffmpeg 公式サイト](https://ffmpeg.org/download.html)
+
+### 詳細
+
+設置先の変更・特定バージョンの指定・対応環境などは[インストールガイド](docs/installation.md)を参照してください。
 
 ## 使い方
 


### PR DESCRIPTION
関連タスク: [Homebrew Cask で vox-radio を配布する（ffmpeg を依存に含める）](https://app.todoist.com/app/task/6gvp6xRh9QRRr4QV)

## Summary

- `.goreleaser.yaml` に `homebrew_casks` 節を追加
  - tap: `canpok1/homebrew-tap`（vox-actor と共用）
  - ffmpeg を `dependencies` で自動導入
  - macOS の quarantine 属性を解除する post-install フックを含む
  - 認証トークン: `HOMEBREW_TAP_GITHUB_TOKEN`
- README を Homebrew 中心に再構成
  - 章順を「クイックスタート」→「インストール」に変更
  - クイックスタートを Homebrew 前提・最小限に圧縮（`brew install --cask` を先頭に）
  - インストール章を新設：Homebrew / install.sh / バイナリ手動DL の3方法、VOICEVOX・ffmpeg の導入手順

## 関連 ADR

- ADR-0089: `docs/adr/0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md`

## 確認済み

- `make release-check`（goreleaser check）: 通過
- 全テスト: 通過

---

🤖 Generated with [Claude Code](https://claude.ai/code)