### PR TITLE
fix: リリースCIのhomebrew cask公開でトークン未渡しを修正

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -34,3 +34,4 @@ jobs:
           args: ${{ inputs.goreleaser-args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

リリース用CI（goreleaser）の **homebrew cask 公開ステップ** が以下のエラーで失敗していたため修正します。

```
homebrew cask: template: tmpl:1:7: executing "tmpl" at <.Env.HOMEBREW_TAP_GITHUB_TOKEN>:
map has no entry for key "HOMEBREW_TAP_GITHUB_TOKEN"
```

参考: https://github.com/canpok1/vox-radio/actions/runs/27892662546/job/82538814058

## 原因

`HOMEBREW_TAP_GITHUB_TOKEN` は Repository secrets に登録済みですが、goreleaser を実行するステップの `env` に渡されていませんでした。`.goreleaser.yaml` の `homebrew_casks` は `token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"` で**プロセスの環境変数**を参照するため、未定義となりテンプレート展開に失敗していました。

## 修正

`.github/workflows/goreleaser.yml` の `Run GoReleaser` ステップの `env` に `HOMEBREW_TAP_GITHUB_TOKEN` を追加しました。

- `release.yml` は `secrets: inherit` で呼び出しているため、再利用ワークフロー側で `secrets.HOMEBREW_TAP_GITHUB_TOKEN` を参照可能です。
- `demo-release.yml` は goreleaser.yml を呼んでおらず独立しているため影響ありません。

## 補足

- 既にリリース済みの `v0.0.27`（Release・タグ）はそのまま残します。本修正は次回以降のリリースから有効です。

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzZe7Et4KcWhuo4mC43sVn)_