### PR TITLE
feat: コーナーの source に links / text タイプを追加する

### DIFF
--- a/internal/cli/skills/vox-radio/references/episode-spec.md
+++ b/internal/cli/skills/vox-radio/references/episode-spec.md
@@ -121,13 +121,15 @@ corners:
 
 ### `corners[].source[]` エントリのフィールド
 
-`source` は type で種別を区別する配列です。各エントリに `type` で `feed` または `web` を指定します。
+`source` は type で種別を区別する配列です。`type` は `feed` / `web` / `links` / `text` の4種類です。
 
-| フィールド | 型 | 必須/任意 | 説明 |
-|---|---|---|---|
-| `type` | string | 必須 | `"feed"`（RSS/Atom フィード）または `"web"`（個別記事） |
-| `url` | string | 必須 | フィードまたは記事の URL。`https://` のほか `file://` によるローカルファイル指定も可能（後述） |
-| `max_items` | int | 任意 | `type: feed` のみ。過去使用URLを除外したうえで確保する最大記事数。デフォルト: 0（実質無制限）。除外で減った分はフィード内の後続記事で補う。`type: web` には指定不可。 |
+| フィールド | 型 | 対象タイプ | 必須/任意 | 説明 |
+|---|---|---|---|---|
+| `type` | string | 全 | 必須 | `"feed"` / `"web"` / `"links"` / `"text"` |
+| `url` | string | feed, web | 必須 | フィードまたは記事の URL。`https://` のほか `file://` によるローカルファイル指定も可能（後述） |
+| `path` | string | links, text | 必須 | ローカルファイルのパス。spec ファイルのディレクトリ基準で相対解決（後述） |
+| `title` | string | text | 任意 | text タイプの記事タイトル。省略するとファイル名（拡張子除く）を使用 |
+| `max_items` | int | feed | 任意 | 過去使用 URL を除外したうえで確保する最大記事数。デフォルト: 0（無制限）。除外で減った分は後続記事で補う |
 
 ```yaml
 source:
@@ -136,7 +138,27 @@ source:
     max_items: 5
   - type: web
     url: https://example.com/articles/1
+  - type: links
+    path: refs/urls.txt          # URL 一覧ファイル（1行1URL）
+  - type: text
+    path: refs/background.txt   # 任意テキストファイル
+    title: "背景知識"
 ```
+
+#### `links` タイプ（URL 一覧ファイル）
+
+1行1URLのテキストファイルを読み込み、各行のURLを個別記事として取得します。
+
+- 空行と `#` で始まる行はスキップ
+- 各行 URL を `web` と同様に HTML 取得（`http(s)://` / `file://` 可）
+- 重複判定キー（DedupKey）は「ファイルパス + URL」の組み合わせで固定（ページ内容が変わっても同一URLは同一キー）
+
+#### `text` タイプ（参考テキスト）
+
+テキストファイルの内容をそのまま番組素材として使います。HTML パースは行わず、ファイル内容がそのまま LLM に渡ります。
+
+- `title` 省略時はファイル名（拡張子除く）をタイトルとして使用
+- 重複判定キーは「ファイルパス + タイトル + 本文」の組み合わせ（内容を変更すると新規素材として再採用される）
 
 ### `file://` プロトコルによるローカルフィード・記事の読み込み
 
@@ -163,6 +185,21 @@ source:
 ```
 
 > **注意**: ファイルが存在しない場合は `episodegen gather` 実行時にエラーになります。
+
+### `links` / `text` の `path` フィールド
+
+`path` は spec ファイルのディレクトリを基準に相対解決されます（絶対パスはそのまま使用）。
+
+```yaml
+# /home/user/myshow/episode-spec.yaml に記述した場合、
+# /home/user/myshow/refs/urls.txt を読み込む
+source:
+  - type: links
+    path: "refs/urls.txt"
+  - type: text
+    path: "refs/background.txt"
+    title: "背景知識"
+```
 
 ## `casts` セクション（出演者名簿）
 

--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -117,6 +117,11 @@ corners:
         max_items: 5
       # - type: web
       #   url: https://example.com/articles/1
+      # - type: links
+      #   path: refs/urls.txt        # URL一覧ファイル（1行1URL）
+      # - type: text
+      #   path: refs/background.txt  # 参考テキストファイル
+      #   title: "背景知識"           # 省略するとファイル名を使用
     # 放送する回の条件（省略すると毎回放送される固定コーナー）。
     # condition を書くと、回番号が合ったときだけ放送されます。
     # condition:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2347,3 +2347,66 @@ func TestLoadEpisodeSpec_OldSourceFormatError(t *testing.T) {
 		t.Error("expected error for old source format (feeds:/articles: fields), got nil")
 	}
 }
+
+func TestLoadEpisodeSpec_LinksTextPathResolution(t *testing.T) {
+	spec, err := config.LoadEpisodeSpec("testdata/episode_spec_links_text.yaml")
+	if err != nil {
+		t.Fatalf("LoadEpisodeSpec failed: %v", err)
+	}
+
+	var sourceCorner *config.CornerConfig
+	for i := range spec.Corners {
+		if len(spec.Corners[i].Source) > 0 {
+			sourceCorner = &spec.Corners[i]
+			break
+		}
+	}
+	if sourceCorner == nil {
+		t.Fatal("no corner with source found")
+	}
+
+	absTestdata, err := filepath.Abs("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var linksSources, textSources []config.SourceEntry
+	for _, s := range sourceCorner.Source {
+		switch s.Type {
+		case config.SourceTypeLinks:
+			linksSources = append(linksSources, s)
+		case config.SourceTypeText:
+			textSources = append(textSources, s)
+		}
+	}
+
+	if len(linksSources) < 2 {
+		t.Fatalf("expected 2 links sources, got %d", len(linksSources))
+	}
+	// 相対パスは specDir 基準で絶対パスに解決される
+	wantRelLinks := filepath.Join(absTestdata, "links/urls.txt")
+	if linksSources[0].Path != wantRelLinks {
+		t.Errorf("links[0].Path (relative): got %q, want %q", linksSources[0].Path, wantRelLinks)
+	}
+	// 絶対パスはそのまま
+	if linksSources[1].Path != "/abs/links.txt" {
+		t.Errorf("links[1].Path (absolute): got %q, want %q", linksSources[1].Path, "/abs/links.txt")
+	}
+
+	if len(textSources) < 2 {
+		t.Fatalf("expected 2 text sources, got %d", len(textSources))
+	}
+	// 相対パスは specDir 基準で絶対パスに解決される
+	wantRelText := filepath.Join(absTestdata, "texts/ref.txt")
+	if textSources[0].Path != wantRelText {
+		t.Errorf("text[0].Path (relative): got %q, want %q", textSources[0].Path, wantRelText)
+	}
+	// 絶対パスはそのまま
+	if textSources[1].Path != "/abs/ref.txt" {
+		t.Errorf("text[1].Path (absolute): got %q, want %q", textSources[1].Path, "/abs/ref.txt")
+	}
+	// title フィールドが保持される
+	if textSources[1].Title != "参考資料" {
+		t.Errorf("text[1].Title: got %q, want %q", textSources[1].Title, "参考資料")
+	}
+}

--- a/internal/config/episode_spec.go
+++ b/internal/config/episode_spec.go
@@ -224,18 +224,60 @@ func validateDefaultAudioRef(parent, field string, ref *AudioRef, assets *Assets
 	return validateAudioRef(parent, field, ref, assets)
 }
 
-// ValidateSource は corners[].source の type/url/max_items を検証する。
+// ValidateSource は corners[].source の type/url/path/max_items/title を検証する。
 func (p *EpisodeSpec) ValidateSource() error {
 	for i, c := range p.Corners {
 		for j, s := range c.Source {
-			if s.Type != SourceTypeFeed && s.Type != SourceTypeWeb {
-				return fmt.Errorf("corners[%d].source[%d].type: must be %q or %q, got %q", i, j, SourceTypeFeed, SourceTypeWeb, s.Type)
-			}
-			if s.URL == "" {
-				return fmt.Errorf("corners[%d].source[%d].url: required", i, j)
-			}
-			if s.Type == SourceTypeWeb && s.MaxItems != 0 {
-				return fmt.Errorf("corners[%d].source[%d].max_items: not allowed for type %q", i, j, SourceTypeWeb)
+			pfx := fmt.Sprintf("corners[%d].source[%d]", i, j)
+			switch s.Type {
+			case SourceTypeFeed:
+				if s.URL == "" {
+					return fmt.Errorf("%s.url: required", pfx)
+				}
+				if s.Path != "" {
+					return fmt.Errorf("%s.path: not allowed for type %q", pfx, s.Type)
+				}
+				if s.Title != "" {
+					return fmt.Errorf("%s.title: not allowed for type %q", pfx, s.Type)
+				}
+			case SourceTypeWeb:
+				if s.URL == "" {
+					return fmt.Errorf("%s.url: required", pfx)
+				}
+				if s.MaxItems != 0 {
+					return fmt.Errorf("%s.max_items: not allowed for type %q", pfx, s.Type)
+				}
+				if s.Path != "" {
+					return fmt.Errorf("%s.path: not allowed for type %q", pfx, s.Type)
+				}
+				if s.Title != "" {
+					return fmt.Errorf("%s.title: not allowed for type %q", pfx, s.Type)
+				}
+			case SourceTypeLinks:
+				if s.Path == "" {
+					return fmt.Errorf("%s.path: required", pfx)
+				}
+				if s.URL != "" {
+					return fmt.Errorf("%s.url: not allowed for type %q", pfx, s.Type)
+				}
+				if s.MaxItems != 0 {
+					return fmt.Errorf("%s.max_items: not allowed for type %q", pfx, s.Type)
+				}
+				if s.Title != "" {
+					return fmt.Errorf("%s.title: not allowed for type %q", pfx, s.Type)
+				}
+			case SourceTypeText:
+				if s.Path == "" {
+					return fmt.Errorf("%s.path: required", pfx)
+				}
+				if s.URL != "" {
+					return fmt.Errorf("%s.url: not allowed for type %q", pfx, s.Type)
+				}
+				if s.MaxItems != 0 {
+					return fmt.Errorf("%s.max_items: not allowed for type %q", pfx, s.Type)
+				}
+			default:
+				return fmt.Errorf("%s.type: must be %q, %q, %q, or %q, got %q", pfx, SourceTypeFeed, SourceTypeWeb, SourceTypeLinks, SourceTypeText, s.Type)
 			}
 		}
 	}

--- a/internal/config/episode_spec_test.go
+++ b/internal/config/episode_spec_test.go
@@ -362,6 +362,177 @@ func TestEpisodeSpec_ValidateSource(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		// links タイプ
+		{
+			name: "type=links, path あり はエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeLinks, Path: "/data/links.txt"},
+					},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "type=links, path なし はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeLinks},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=links, url あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeLinks, Path: "/data/links.txt", URL: "https://example.com"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=links, max_items あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeLinks, Path: "/data/links.txt", MaxItems: 3},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=links, title あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeLinks, Path: "/data/links.txt", Title: "見出し"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		// text タイプ
+		{
+			name: "type=text, path あり はエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeText, Path: "/data/ref.txt"},
+					},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "type=text, path あり title あり はエラーなし",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeText, Path: "/data/ref.txt", Title: "参考情報"},
+					},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "type=text, path なし はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeText},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=text, url あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeText, Path: "/data/ref.txt", URL: "https://example.com"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=text, max_items あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeText, Path: "/data/ref.txt", MaxItems: 3},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		// feed・web に path / title は不可
+		{
+			name: "type=feed, path あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeFeed, URL: "https://example.com/feed.xml", Path: "/tmp/feed.txt"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=feed, title あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeFeed, URL: "https://example.com/feed.xml", Title: "見出し"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=web, path あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeWeb, URL: "https://example.com/article", Path: "/tmp/ref.txt"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
+		{
+			name: "type=web, title あり はエラー",
+			spec: &config.EpisodeSpec{
+				Corners: []config.CornerConfig{{
+					ID: "c1", Title: "C1",
+					Source: config.SourceConfig{
+						{Type: config.SourceTypeWeb, URL: "https://example.com/article", Title: "見出し"},
+					},
+				}},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/canpok1/vox-radio/internal/fileio"
@@ -70,6 +71,13 @@ func loadEpisodeSpecWith(path string, strict bool) (*EpisodeSpec, error) {
 				return nil, err
 			}
 			corner.Source[j].URL = resolved
+			if corner.Source[j].Path != "" {
+				absPath, err := filepath.Abs(resolveFile(specDir, corner.Source[j].Path))
+				if err != nil {
+					return nil, fmt.Errorf("resolve path %q: %w", corner.Source[j].Path, err)
+				}
+				corner.Source[j].Path = absPath
+			}
 		}
 	}
 	resolveCornerDefaults(p)

--- a/internal/config/program.go
+++ b/internal/config/program.go
@@ -32,13 +32,19 @@ const (
 	SourceTypeFeed = "feed"
 	// SourceTypeWeb はWebページURLのソース種別。
 	SourceTypeWeb = "web"
+	// SourceTypeLinks はURL一覧テキストファイルのソース種別。各行URLを個別記事として取得する。
+	SourceTypeLinks = "links"
+	// SourceTypeText は参考テキスト本文ファイルのソース種別。内容をそのままBodyに格納する。
+	SourceTypeText = "text"
 )
 
-// SourceEntry は1件のソース設定。type フィールドで feed / web を判別する。
+// SourceEntry は1件のソース設定。type フィールドで feed / web / links / text を判別する。
 type SourceEntry struct {
 	Type     string `yaml:"type"`
-	URL      string `yaml:"url"`
+	URL      string `yaml:"url,omitempty"`
 	MaxItems int    `yaml:"max_items,omitempty"`
+	Path     string `yaml:"path,omitempty"`
+	Title    string `yaml:"title,omitempty"`
 }
 
 // SourceConfig はコーナーのソース設定（SourceEntry の配列）。

--- a/internal/config/testdata/episode_spec_links_text.yaml
+++ b/internal/config/testdata/episode_spec_links_text.yaml
@@ -1,0 +1,27 @@
+program:
+  id: "test-program-links-text"
+
+casts:
+  zundamon:
+    type: regular
+    role: "MC"
+
+corners:
+  - id: "ref"
+    title: "参考コーナー"
+    content: "参考情報の紹介"
+    cast:
+      zundamon: "司会"
+    length_sec: 30
+    source:
+      - type: links
+        path: "links/urls.txt"
+      - type: links
+        path: "/abs/links.txt"
+      - type: text
+        path: "texts/ref.txt"
+      - type: text
+        path: "/abs/ref.txt"
+        title: "参考資料"
+
+assets_files: []

--- a/internal/gather/dedupkey.go
+++ b/internal/gather/dedupkey.go
@@ -19,14 +19,29 @@ func dedupKey(namespace, material string) string {
 }
 
 // FeedDedupKey computes the DedupKey for a feed item.
-// Use guid as material when non-empty; fall back to NormalizeContent(title, body).
+// material priority: guid → link → normalizeContent(title, body).
 // feedURL is the namespace (feed's source URL).
-func FeedDedupKey(feedURL, guid, title, body string) string {
+func FeedDedupKey(feedURL, guid, link, title, body string) string {
 	material := guid
+	if material == "" {
+		material = link
+	}
 	if material == "" {
 		material = normalizeContent(title, body)
 	}
 	return dedupKey(feedURL, material)
+}
+
+// LinksDedupKey computes the DedupKey for an entry in a links-type source file.
+// namespace=filePath, material=lineURL (stable regardless of page content).
+func LinksDedupKey(filePath, lineURL string) string {
+	return dedupKey(filePath, lineURL)
+}
+
+// TextDedupKey computes the DedupKey for a text-type source file.
+// namespace=filePath, material=normalizeContent(title, body) (content-based; changes when content changes).
+func TextDedupKey(filePath, title, body string) string {
+	return dedupKey(filePath, normalizeContent(title, body))
 }
 
 // HTMLDedupKey computes the DedupKey for an HTML article page.

--- a/internal/gather/dedupkey_test.go
+++ b/internal/gather/dedupkey_test.go
@@ -5,6 +5,93 @@ import (
 	"testing"
 )
 
+func TestFeedDedupKey_WithGUID(t *testing.T) {
+	// GUID が非空なら link・content より優先
+	k := FeedDedupKey("https://feed.example.com/rss", "guid-abc", "https://link.example.com", "タイトル", "本文")
+	kNoLinkNoContent := FeedDedupKey("https://feed.example.com/rss", "guid-abc", "", "別タイトル", "別本文")
+	if k != kNoLinkNoContent {
+		t.Errorf("GUID が同じなら link・content が異なってもキーが同一のはず: %q vs %q", k, kNoLinkNoContent)
+	}
+}
+
+func TestFeedDedupKey_WithLinkOnly(t *testing.T) {
+	// GUID が空 かつ link が非空なら link を material に使う
+	k := FeedDedupKey("https://feed.example.com/rss", "", "https://link.example.com/1", "タイトル", "本文")
+	kSameURL := FeedDedupKey("https://feed.example.com/rss", "", "https://link.example.com/1", "別タイトル", "別本文")
+	if k != kSameURL {
+		t.Errorf("GUID なし・同一 link なら content が違ってもキー同一のはず: %q vs %q", k, kSameURL)
+	}
+	kDiffURL := FeedDedupKey("https://feed.example.com/rss", "", "https://link.example.com/2", "タイトル", "本文")
+	if k == kDiffURL {
+		t.Errorf("link が異なれば別キーになるはず: %q == %q", k, kDiffURL)
+	}
+}
+
+func TestFeedDedupKey_FallsBackToContent(t *testing.T) {
+	// GUID・link ともに空 → normalizeContent(title, body) を material に使う
+	k := FeedDedupKey("https://feed.example.com/rss", "", "", "タイトル", "本文")
+	kSame := FeedDedupKey("https://feed.example.com/rss", "", "", "タイトル", "本文")
+	if k != kSame {
+		t.Errorf("同一入力で異なるキーが出るはず: %q vs %q", k, kSame)
+	}
+	kDiff := FeedDedupKey("https://feed.example.com/rss", "", "", "別タイトル", "別本文")
+	if k == kDiff {
+		t.Errorf("content が異なれば別キーになるはず: %q == %q", k, kDiff)
+	}
+}
+
+func TestFeedDedupKey_GUIDTakesPrecedenceOverLink(t *testing.T) {
+	kGUID := FeedDedupKey("https://feed.example.com/rss", "guid-abc", "https://link.example.com", "", "")
+	kLink := FeedDedupKey("https://feed.example.com/rss", "", "https://link.example.com", "", "")
+	if kGUID == kLink {
+		t.Errorf("GUID と link で material が異なるのでキーは別になるはず: %q == %q", kGUID, kLink)
+	}
+}
+
+func TestLinksDedupKey_StableByFilePathAndURL(t *testing.T) {
+	k1 := LinksDedupKey("/data/links.txt", "https://example.com/article")
+	k2 := LinksDedupKey("/data/links.txt", "https://example.com/article")
+	if k1 != k2 {
+		t.Errorf("同一 filePath・lineURL で同一キーになるはず: %q vs %q", k1, k2)
+	}
+	kDiffURL := LinksDedupKey("/data/links.txt", "https://example.com/other")
+	if k1 == kDiffURL {
+		t.Errorf("lineURL が異なれば別キーになるはず: %q == %q", k1, kDiffURL)
+	}
+	kDiffFile := LinksDedupKey("/data/other.txt", "https://example.com/article")
+	if k1 == kDiffFile {
+		t.Errorf("filePath が異なれば別キーになるはず: %q == %q", k1, kDiffFile)
+	}
+}
+
+func TestLinksDedupKey_ContentIndependent(t *testing.T) {
+	// ページ内容が変わっても同一ファイルパス＋同一 URL なら同一キー
+	k := LinksDedupKey("/data/links.txt", "https://example.com/page")
+	// content 変化を模擬するが kLinks に引数はないため、キー自体は不変
+	if k == "" {
+		t.Error("LinksDedupKey must not be empty")
+	}
+	if !strings.HasPrefix(k, "sha256:") {
+		t.Errorf("LinksDedupKey must start with sha256:, got %q", k)
+	}
+}
+
+func TestTextDedupKey_StableByContent(t *testing.T) {
+	k1 := TextDedupKey("/data/ref.txt", "参考情報", "本文テキスト")
+	k2 := TextDedupKey("/data/ref.txt", "参考情報", "本文テキスト")
+	if k1 != k2 {
+		t.Errorf("同一 filePath・title・body で同一キーになるはず: %q vs %q", k1, k2)
+	}
+	kDiffBody := TextDedupKey("/data/ref.txt", "参考情報", "更新された本文")
+	if k1 == kDiffBody {
+		t.Errorf("本文が変われば別キーになるはず（再採用可）: %q == %q", k1, kDiffBody)
+	}
+	kDiffFile := TextDedupKey("/data/other.txt", "参考情報", "本文テキスト")
+	if k1 == kDiffFile {
+		t.Errorf("filePath が異なれば別キーになるはず: %q == %q", k1, kDiffFile)
+	}
+}
+
 func TestDedupKey_Format(t *testing.T) {
 	k := dedupKey("https://feed.example.com/rss", "guid-123")
 	if !strings.HasPrefix(k, "sha256:") {

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -93,6 +93,32 @@ func (c *Gatherer) Run(ctx context.Context, cfg config.SourceConfig, excluded ma
 			if !flagged {
 				articles = append(articles, *article)
 			}
+		case config.SourceTypeLinks:
+			items, err := c.fetchLinks(ctx, src.Path)
+			if err != nil {
+				return nil, fmt.Errorf("fetch links %s: %w", src.Path, err)
+			}
+			for i := range items {
+				flagged, err := c.applySanitize(&items[i])
+				if err != nil {
+					return nil, err
+				}
+				if !flagged {
+					articles = append(articles, items[i])
+				}
+			}
+		case config.SourceTypeText:
+			article, err := fetchText(src.Path, src.Title)
+			if err != nil {
+				return nil, fmt.Errorf("fetch text %s: %w", src.Path, err)
+			}
+			flagged, err := c.applySanitize(article)
+			if err != nil {
+				return nil, err
+			}
+			if !flagged {
+				articles = append(articles, *article)
+			}
 		default:
 			return nil, fmt.Errorf("unknown source type %q", src.Type)
 		}

--- a/internal/gather/gather.go
+++ b/internal/gather/gather.go
@@ -72,52 +72,32 @@ func (c *Gatherer) Run(ctx context.Context, cfg config.SourceConfig, excluded ma
 			if err != nil {
 				return nil, fmt.Errorf("fetch feed %s: %w", src.URL, err)
 			}
-			for i := range items {
-				flagged, err := c.applySanitize(&items[i])
-				if err != nil {
-					return nil, err
-				}
-				if !flagged {
-					articles = append(articles, items[i])
-				}
+			if articles, err = c.appendSanitized(articles, items); err != nil {
+				return nil, err
 			}
 		case config.SourceTypeWeb:
 			article, err := c.fetchArticle(ctx, src.URL)
 			if err != nil {
 				return nil, fmt.Errorf("fetch article %s: %w", src.URL, err)
 			}
-			flagged, err := c.applySanitize(article)
-			if err != nil {
+			if articles, err = c.appendSanitized(articles, []model.Article{*article}); err != nil {
 				return nil, err
-			}
-			if !flagged {
-				articles = append(articles, *article)
 			}
 		case config.SourceTypeLinks:
 			items, err := c.fetchLinks(ctx, src.Path)
 			if err != nil {
 				return nil, fmt.Errorf("fetch links %s: %w", src.Path, err)
 			}
-			for i := range items {
-				flagged, err := c.applySanitize(&items[i])
-				if err != nil {
-					return nil, err
-				}
-				if !flagged {
-					articles = append(articles, items[i])
-				}
+			if articles, err = c.appendSanitized(articles, items); err != nil {
+				return nil, err
 			}
 		case config.SourceTypeText:
 			article, err := fetchText(src.Path, src.Title)
 			if err != nil {
 				return nil, fmt.Errorf("fetch text %s: %w", src.Path, err)
 			}
-			flagged, err := c.applySanitize(article)
-			if err != nil {
+			if articles, err = c.appendSanitized(articles, []model.Article{*article}); err != nil {
 				return nil, err
-			}
-			if !flagged {
-				articles = append(articles, *article)
 			}
 		default:
 			return nil, fmt.Errorf("unknown source type %q", src.Type)
@@ -186,4 +166,18 @@ func (c *Gatherer) applySanitize(a *model.Article) (bool, error) {
 		c.logger.Warn("prompt injection pattern detected; article excluded", "url", a.URL)
 	}
 	return flagged, nil
+}
+
+// appendSanitized sanitizes each item and appends non-flagged ones to articles.
+func (c *Gatherer) appendSanitized(articles []model.Article, items []model.Article) ([]model.Article, error) {
+	for i := range items {
+		flagged, err := c.applySanitize(&items[i])
+		if err != nil {
+			return nil, err
+		}
+		if !flagged {
+			articles = append(articles, items[i])
+		}
+	}
+	return articles, nil
 }

--- a/internal/gather/gather_test.go
+++ b/internal/gather/gather_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -281,9 +282,9 @@ func TestGatherer_Run_ExcludesURLsAndFillsFromLater(t *testing.T) {
 	cfg := config.SourceConfig{
 		{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 2},
 	}
-	// article/1 has no GUID, so material = normalizeContent(title, body)
+	// article/1 has no GUID; link="https://example.com/article/1" is used as material
 	excluded := map[string]struct{}{
-		gather.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"): {},
+		gather.FeedDedupKey(feedURL, "", "https://example.com/article/1", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"): {},
 	}
 
 	c := gather.New(server.Client())
@@ -320,8 +321,8 @@ func TestGatherer_Run_WarnWhenInsufficientNonExcludedArticles(t *testing.T) {
 		{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 3},
 	}
 	excluded := map[string]struct{}{
-		gather.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"):  {},
-		gather.FeedDedupKey(feedURL, "", "オープンソース活動の活発化", "オープンソースプロジェクトへの参加者が増加している。"): {},
+		gather.FeedDedupKey(feedURL, "", "https://example.com/article/1", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"):  {},
+		gather.FeedDedupKey(feedURL, "", "https://example.com/article/2", "オープンソース活動の活発化", "オープンソースプロジェクトへの参加者が増加している。"): {},
 	}
 
 	c := gather.New(server.Client(), gather.WithLogger(logger))
@@ -362,7 +363,7 @@ func TestGatherer_Run_UnlimitedWithExcludedDedupKeys(t *testing.T) {
 		{Type: config.SourceTypeFeed, URL: feedURL, MaxItems: 0},
 	}
 	excluded := map[string]struct{}{
-		gather.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"): {},
+		gather.FeedDedupKey(feedURL, "", "https://example.com/article/1", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"): {},
 	}
 
 	c := gather.New(server.Client())
@@ -480,7 +481,7 @@ func TestGatherer_RunAll_ExcludesDedupKeysViaFeed(t *testing.T) {
 		},
 	}
 	excludedDedupKeys := []string{
-		gather.FeedDedupKey(feedURL, "", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"),
+		gather.FeedDedupKey(feedURL, "", "https://example.com/article/1", "AIチップの最新動向", "新型AIチップが発表された。従来比2倍の性能を実現する。"),
 	}
 
 	c := gather.New(server.Client())
@@ -967,5 +968,199 @@ func TestNew_DefaultClient_HTTPS_StillWorks(t *testing.T) {
 	}
 	if len(result) == 0 {
 		t.Error("expected at least 1 article from http feed")
+	}
+}
+
+// --- links タイプ ---
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fmt.Fprint(f, content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestGatherer_Run_Links_FetchesEachURL(t *testing.T) {
+	htmlData := loadTestdata(t, "article.html")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(htmlData)
+	}))
+	defer server.Close()
+
+	linksContent := server.URL + "/article1\n" + server.URL + "/article2\n"
+	linksFile := writeTempFile(t, linksContent)
+
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeLinks, Path: linksFile},
+	}
+
+	c := gather.New(server.Client())
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 2 {
+		t.Fatalf("articles count: got %d, want 2", len(result))
+	}
+}
+
+func TestGatherer_Run_Links_SkipsEmptyAndCommentLines(t *testing.T) {
+	htmlData := loadTestdata(t, "article.html")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(htmlData)
+	}))
+	defer server.Close()
+
+	linksContent := "# コメント行\n\n" + server.URL + "/article\n  \n# 別コメント\n"
+	linksFile := writeTempFile(t, linksContent)
+
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeLinks, Path: linksFile},
+	}
+
+	c := gather.New(server.Client())
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("articles count: got %d, want 1 (empty/comment lines skipped)", len(result))
+	}
+}
+
+func TestGatherer_Run_Links_DedupKeyStableByFilePathAndURL(t *testing.T) {
+	htmlData := loadTestdata(t, "article.html")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write(htmlData)
+	}))
+	defer server.Close()
+
+	articleURL := server.URL + "/article"
+	linksFile := writeTempFile(t, articleURL+"\n")
+
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeLinks, Path: linksFile},
+	}
+
+	c := gather.New(server.Client())
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("no articles returned")
+	}
+
+	expectedKey := gather.LinksDedupKey(linksFile, articleURL)
+	if result[0].DedupKey != expectedKey {
+		t.Errorf("DedupKey: got %q, want %q", result[0].DedupKey, expectedKey)
+	}
+}
+
+func TestGatherer_Run_Links_ErrorOnMissingFile(t *testing.T) {
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeLinks, Path: "/nonexistent/links.txt"},
+	}
+
+	c := gather.New(nil)
+	_, err := c.Run(context.Background(), cfg, nil)
+	if err == nil {
+		t.Error("expected error for missing links file, got nil")
+	}
+}
+
+// --- text タイプ ---
+
+func TestGatherer_Run_Text_StoresBodyFromFile(t *testing.T) {
+	content := "参考情報のテキスト本文です。\n複数行にわたります。"
+	textFile := writeTempFile(t, content)
+
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeText, Path: textFile, Title: "参考資料"},
+	}
+
+	c := gather.New(nil)
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("articles count: got %d, want 1", len(result))
+	}
+	art := result[0]
+	if art.Body != content {
+		t.Errorf("Body: got %q, want %q", art.Body, content)
+	}
+	if art.Title != "参考資料" {
+		t.Errorf("Title: got %q, want %q", art.Title, "参考資料")
+	}
+	if art.URL != "" {
+		t.Errorf("URL must be empty for text type, got %q", art.URL)
+	}
+}
+
+func TestGatherer_Run_Text_TitleFallsBackToFilename(t *testing.T) {
+	textFile := writeTempFile(t, "本文")
+	// ファイル名から拡張子を除いたものがタイトルになる
+	base := strings.TrimSuffix(filepath.Base(textFile), filepath.Ext(textFile))
+
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeText, Path: textFile},
+	}
+
+	c := gather.New(nil)
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("no articles returned")
+	}
+	if result[0].Title != base {
+		t.Errorf("Title (fallback): got %q, want %q", result[0].Title, base)
+	}
+}
+
+func TestGatherer_Run_Text_DedupKeyContentBased(t *testing.T) {
+	content := "参考情報テキスト"
+	textFile := writeTempFile(t, content)
+
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeText, Path: textFile, Title: "タイトル"},
+	}
+
+	c := gather.New(nil)
+	result, err := c.Run(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) == 0 {
+		t.Fatal("no articles returned")
+	}
+
+	expectedKey := gather.TextDedupKey(textFile, "タイトル", content)
+	if result[0].DedupKey != expectedKey {
+		t.Errorf("DedupKey: got %q, want %q", result[0].DedupKey, expectedKey)
+	}
+}
+
+func TestGatherer_Run_Text_ErrorOnMissingFile(t *testing.T) {
+	cfg := config.SourceConfig{
+		{Type: config.SourceTypeText, Path: "/nonexistent/ref.txt"},
+	}
+
+	c := gather.New(nil)
+	_, err := c.Run(context.Background(), cfg, nil)
+	if err == nil {
+		t.Error("expected error for missing text file, got nil")
 	}
 }

--- a/internal/gather/links.go
+++ b/internal/gather/links.go
@@ -1,0 +1,40 @@
+package gather
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+// fetchLinks reads a links file (one URL per line), fetches each URL as an article,
+// and overwrites the DedupKey with LinksDedupKey(filePath, lineURL) for content-independent deduplication.
+func (c *Gatherer) fetchLinks(ctx context.Context, filePath string) ([]model.Article, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("open links file %q: %w", filePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	articles := make([]model.Article, 0)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		article, err := c.fetchArticle(ctx, line)
+		if err != nil {
+			return nil, fmt.Errorf("fetch links entry %q: %w", line, err)
+		}
+		article.DedupKey = LinksDedupKey(filePath, line)
+		articles = append(articles, *article)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read links file %q: %w", filePath, err)
+	}
+	return articles, nil
+}

--- a/internal/gather/rss.go
+++ b/internal/gather/rss.go
@@ -36,19 +36,19 @@ func (c *Gatherer) fetchFeed(ctx context.Context, url string, maxItems int, excl
 			body = item.Description
 		}
 
-		// GUID が非空なら DedupKey に bodyText 不要 → 除外チェック後まで HTML パースを遅延
+		// GUID または link が非空なら DedupKey に bodyText 不要 → 除外チェック後まで HTML パースを遅延
 		var bodyText string
-		if item.GUID == "" {
+		if item.GUID == "" && item.Link == "" {
 			bodyText = extractTextFromHTML(body)
 		}
-		key := FeedDedupKey(url, item.GUID, item.Title, bodyText)
+		key := FeedDedupKey(url, item.GUID, item.Link, item.Title, bodyText)
 
 		if _, skip := excluded[key]; skip {
 			continue
 		}
 
-		// GUID 非空で遅延した場合はここで HTML パース
-		if item.GUID != "" {
+		// GUID/link 非空で遅延した場合はここで HTML パース
+		if item.GUID != "" || item.Link != "" {
 			bodyText = extractTextFromHTML(body)
 		}
 		articles = append(articles, model.Article{

--- a/internal/gather/text.go
+++ b/internal/gather/text.go
@@ -1,0 +1,29 @@
+package gather
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+// fetchText reads a text file and returns it as a single Article with Body set to the file content.
+// title is used as the article title; when empty the filename without extension is used.
+func fetchText(filePath, title string) (*model.Article, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("read text file %q: %w", filePath, err)
+	}
+	body := string(data)
+	if title == "" {
+		base := filepath.Base(filePath)
+		title = strings.TrimSuffix(base, filepath.Ext(base))
+	}
+	return &model.Article{
+		DedupKey: TextDedupKey(filePath, title, body),
+		Title:    title,
+		Body:     body,
+	}, nil
+}


### PR DESCRIPTION
関連タスク: [コーナーの source に links / text タイプを追加する](https://app.todoist.com/app/task/6gw7cVw9PxqQgqpV)

## Summary

- `links` ソースタイプを追加（URL一覧ファイル）: 1行1URLで各URLをHTMLとして取得し記事化
- `text` ソースタイプを追加（参考テキストファイル）: ファイル内容をそのままArticle.Bodyに格納
- `FeedDedupKey` の material 優先順を `GUID → URL → 正規化(タイトル+本文)` に変更（ADR-0058 一部改訂）
- `appendSanitized` ヘルパーで全ソースタイプの sanitize ループを一本化

## 変更詳細

### config 層

- `SourceTypeLinks`/`SourceTypeText` 定数、`SourceEntry.Path`/`Title` フィールドを追加
- `load.go`: `path` フィールドを specDir 基準で絶対パス解決
- `ValidateSource()`: 4タイプ対応のバリデーション（必須/禁止フィールド）に拡張

### gather 層

- `FeedDedupKey(feedURL, guid, link, title, body)`: シグネチャに `link` を追加
- `LinksDedupKey(filePath, lineURL)` / `TextDedupKey(filePath, title, body)` を新規追加
- `links.go` / `text.go` を新規追加
- `gather.go`: switch case に `links`/`text` を追加、`appendSanitized` で重複ループを除去
- `rss.go`: `FeedDedupKey` 呼び出しに `item.Link` を渡すよう更新

### ドキュメント

- `episode-spec.md`: `links`/`text` 説明・`path`/`title` フィールド表を更新
- `episode-spec.yaml` テンプレ: `links`/`text` のコメント例を追加

## Test plan

- [ ] `go test ./internal/...` がすべて green
- [ ] `golangci-lint run` / `gofmt -l .` が clean
- [ ] `FeedDedupKey` の material 順変更（GUID→URL→内容）の新テストケースが green
- [ ] `links`: URL取得・空行/コメントスキップ・DedupKey 安定性・ファイル未存在エラーの各テストが green
- [ ] `text`: Body格納・title フォールバック・DedupKey 安定性・ファイル未存在エラーの各テストが green
- [ ] `ValidateSource` の links/text バリデーション 12ケースが green

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)