### PR TITLE
chore: Claudeのworktreeディレクトリをgit管理対象外に追加

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,1 +1,2 @@
 settings.local.json
+worktrees/


### PR DESCRIPTION
## 概要

Claude Code がサブエージェントを worktree 分離モードで実行すると、リポジトリルートの `.claude/worktrees/` 配下に worktree が作成されます。これは Claude Code の標準（デフォルト）の挙動です。

公式ドキュメント（[Run parallel sessions with worktrees](https://code.claude.com/docs/en/worktrees.md)）でも、worktree の内容がメインのチェックアウト側で未追跡ファイルとして表示されないよう `.claude/worktrees/` を `.gitignore` に追加することが推奨されています。

## 変更内容

`.claude/.gitignore` に `worktrees/` を追加しました。

```
settings.local.json
worktrees/
```

## 確認

- pre-commit / pre-push フック（lint・全テスト）はパス済み

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SmmG8F2kqBzKa5Wxq1uwKn)_