### PR TITLE
feat: 紹介LPに Google アナリティクスを追加

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,6 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-W4RELWHX4M"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-W4RELWHX4M');
+  </script>
+
   <title>vox-radio｜設定ファイルから生成AIとVOICEVOXでラジオ番組を自動生成</title>
   <meta name="description" content="設定ファイルから生成AI(Gemini)とVOICEVOXでラジオ番組（ポッドキャスト）の音声を自動生成するOSS CLIツール。記事収集から台本生成・音声合成・MP3書き出しまでコマンド一つで。">
 


### PR DESCRIPTION
## 概要

紹介LP（`site/index.html`）に Google アナリティクス（GA4 / gtag.js, 計測ID `G-W4RELWHX4M`）の計測タグを `<head>` 内に追加します。

## 変更内容

- `site/index.html`: `<head>` 先頭付近に gtag.js のスニペットを追加

## 確認済み

- ✅ ローカル配信で gtag.js 読み込み・`config` 設定が含まれること
- ✅ 既存コンテンツが壊れていないこと

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPikEEZhpV5Lc8piKaDYtj)_