### PR TITLE
docs: ローカル実行向け Docker イメージ提供の ADR-0092 を追加

### DIFF
--- a/docs/adr/0092-provide-docker-image-for-local-execution.md
+++ b/docs/adr/0092-provide-docker-image-for-local-execution.md
@@ -1,0 +1,30 @@
+# 0092. ローカル実行向けに公式 Docker イメージを提供する（ADR-0006 改訂）
+
+- ステータス: 採用
+- 日付: 2026-06-28
+
+## コンテキスト
+
+配布は prebuilt binary（install.sh）・Homebrew Cask（[ADR-0089](0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md)）・エージェントスキル（[ADR-0039](0039-distribute-vox-radio-as-installable-agent-skill.md)）の3経路がある。だがローカル実行には Go・ffmpeg・VOICEVOX の個別準備が要り、とくに Apple Silicon の ffmpeg 導入の手間は[ADR-0070](0070-keep-ffmpeg-over-mp3-alternatives.md)で未解決のまま残っていた。一方 [ADR-0006](0006-ghpages-hosting-github-actions-runtime.md) は「運用用 docker-compose / Dockerfile は作らない」と決めていたが、「設定ファイルを置いてコンテナを起動するだけ」で動かせる需要があり、依存準備の手間を一掃できる。
+
+## 決定
+
+公式 Docker イメージを提供し、ADR-0006 の「運用用 Dockerfile は作らない」方針を改訂する。
+
+- イメージは vox-radio バイナリ + ffmpeg のみの軽量構成（プロンプトはバイナリ埋め込み＝[ADR-0023](0023-embed-prompts-in-binary.md)）。
+- VOICEVOX は同梱せず、公式イメージ `voicevox/voicevox_engine` を併用する。
+- `compose.yaml` はリポジトリに同梱せず、README/ドキュメントにサンプルとして記載する。
+- 配布は ghcr.io。リリース CI から `vX.Y.Z` と `latest` を push し、amd64 / arm64 のマルチアーキに対応する。
+
+## 結果
+
+- 利用者は設定ファイルと compose だけで起動でき、Go・ffmpeg・VOICEVOX の個別準備が不要になる。Apple Silicon の ffmpeg 手間（ADR-0070）も解消する。
+- 配布チャネルが4つに増え、CI（マルチアーキビルド・publish）と保守の負担が増える。
+- compose を同梱しないため、利用者はドキュメントのサンプルをコピーする必要がある（その分リポジトリの保守対象は増えない）。
+- VOICEVOX 非同梱のため、利用者は別途 VOICEVOX コンテナを用意する（公式イメージで容易）。
+
+## 検討した代替案
+
+- **VOICEVOX 同梱の単一イメージ**: 1コマンドで完結するが、イメージが +1GB 超に肥大し、同梱配布のライセンス/クレジット責任と CPU/GPU・アーキ差を抱えるため却下。
+- **compose.yaml のリポジトリ同梱**: 利用者の手間は減るが、運用ファイルをリポジトリで保守する負担と ADR-0006 の精神からドキュメント記載に留める。
+- **Docker Hub 配布**: 知名度と短い名前は利点だが、匿名 pull のレート制限があり CI 連携に追加シークレットが要る。ghcr.io は public で pull 無制限・CI 連携が容易なため主とする（将来 Docker Hub 併用も可）。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -97,3 +97,4 @@
 | [0089](0089-distribute-via-homebrew-cask-with-ffmpeg-dependency.md) | vox-radio を Homebrew Cask で配布し ffmpeg を依存に含める | 採用 | 2026-06-19 |
 | [0090](0090-keep-mp3-only-output-format.md) | 出力音声形式を mp3 固定とし他形式（AAC/Opus 等）対応を見送る | 採用 | 2026-06-21 |
 | [0091](0091-add-links-and-text-source-types.md) | コーナーの source に links / text タイプを追加する | 採用 | 2026-06-21 |
+| [0092](0092-provide-docker-image-for-local-execution.md) | ローカル実行向けに公式 Docker イメージを提供する（ADR-0006 改訂） | 採用 | 2026-06-28 |


### PR DESCRIPTION
関連タスク: [vox-radio の公式 Docker イメージを提供する（ghcr.io・マルチアーキ）](https://app.todoist.com/app/task/6gxpqCWGJx8XVR93)

## 概要

ローカル実行を容易にするため、vox-radio の公式 Docker イメージを提供する方針を ADR として記録する。ADR-0006「運用用 Dockerfile は作らない」を改訂する。Go・ffmpeg・VOICEVOX の個別準備（特に Apple Silicon の ffmpeg 導入、ADR-0070 で未解決）を不要にし、「設定ファイルを置いてコンテナを起動するだけ」を実現する狙い。

※本 PR は ADR（判断の記録）のみ。実装（Dockerfile・CI・ドキュメント）は別タスクで対応する。

## 変更内容

- `docs/adr/0092-provide-docker-image-for-local-execution.md` を新規追加
  - イメージは vox-radio バイナリ + ffmpeg のみの軽量構成（プロンプトはバイナリ埋め込み＝ADR-0023）
  - VOICEVOX は非同梱、公式イメージ `voicevox/voicevox_engine` を併用
  - `compose.yaml` はリポジトリ同梱せず README/ドキュメントにサンプル記載
  - 配布は ghcr.io、リリース CI から `vX.Y.Z` と `latest` を push、amd64/arm64 マルチアーキ対応
- `docs/adr/README.md` のインデックスに 0092 を追記

## 関連 Issue

なし

## 確認したこと

- [x] `make test` が通る（push 時の lefthook で実行・通過）
- [x] `make lint` が通る（Go ファイル変更なしのためスキップ）
- [ ] CLI のコマンド/フラグを変更した場合、`make docs` で `docs/cli/` を再生成した（CLI 変更なしのため対象外）
- [x] 重要な技術判断を含む場合、ADR（`docs/adr/`）を追加した

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVatedVhLvCpPbWZfrHuhQ)_