### PR TITLE
feat: 起動時に必要リソース（VOICEVOX/LLM/ffmpeg）を検証する preflight を導入する（ADR-0095）

### DIFF
--- a/internal/cli/assets.go
+++ b/internal/cli/assets.go
@@ -90,6 +90,11 @@ loop=true の BGM は、--max-length-sec 未指定時はループせず素材を
 				return err
 			}
 
+			// プレビュー音声は ffmpeg で加工するため、起動直後に存在確認する。
+			if err := checkResources(requireMediaTools); err != nil {
+				return err
+			}
+
 			// ffmpeg のログはターミナルに垂れ流さず、mix/episodegen と同様に
 			// ログファイルへ退避する。ターミナルには成功メッセージのみを出す。
 			_, logFile, err := setupLogger("assets-preview", logDirFlag(cmd))

--- a/internal/cli/episodegen.go
+++ b/internal/cli/episodegen.go
@@ -81,10 +81,6 @@ mp3・マニフェスト・中間ディレクトリのいずれかが既に存�
 			}
 			defer func() { _ = logFile.Close() }()
 
-			if err := requireMediaTools(); err != nil {
-				return err
-			}
-
 			cfg, p, err := loadConfigAndSpec(configPath(cmd), specPath)
 			if err != nil {
 				return err
@@ -122,6 +118,19 @@ mp3・マニフェスト・中間ディレクトリのいずれかが既に存�
 						return fmt.Errorf("%s は既に存在します。上書きするには --force を指定してください", path)
 					}
 				}
+			}
+
+			// 必要な外部リソースをまとめて検証し、LLM でコストを消費する前に早期失敗させる
+			// （VOICEVOX 未到達を synth 段まで見逃さない）。安価な既存出力ガードの後段に置き、
+			// 出力が既存で即失敗するケースで VOICEVOX 待機を無駄に発生させない。
+			ctx := context.Background()
+			engineURL := cfg.Voicevox.EffectiveURL()
+			if err := checkResources(
+				requireMediaTools,
+				func() error { return synth.CheckReadiness(ctx, engineURL, cfg) },
+				func() error { return requireLLMKey(cfg) },
+			); err != nil {
+				return err
 			}
 
 			llmClient := newLLMClient(cfg)
@@ -168,8 +177,6 @@ mp3・マニフェスト・中間ディレクトリのいずれかが既に存�
 				script.WithLogger(logger),
 			)
 
-			engineURL := cfg.Voicevox.EffectiveURL()
-
 			runner := &pipeline.Runner{
 				Spec:              p,
 				Config:            cfg,
@@ -183,7 +190,7 @@ mp3・マニフェスト・中間ディレクトリのいずれかが既に存�
 				CornerSummarizer:  programsummary.NewLLMCornerSummarizer(llmClient, prompts["corner_summary"], stepTemp(cfg.LLM, "corner_summary"), programsummary.WithLogger(logger)),
 			}
 
-			if err := runner.Run(context.Background(), pipeline.Options{
+			if err := runner.Run(ctx, pipeline.Options{
 				OutDir:        outDir,
 				EpisodeNumber: episodeNumber,
 				Casts:         selectedCasts,

--- a/internal/cli/mix.go
+++ b/internal/cli/mix.go
@@ -39,7 +39,7 @@ ffmpeg を使ってイントロ・アウトロ・SE をミックスし、最終�
 			}
 			defer func() { _ = logFile.Close() }()
 
-			if err := requireMediaTools(); err != nil {
+			if err := checkResources(requireMediaTools); err != nil {
 				return err
 			}
 

--- a/internal/cli/preflight.go
+++ b/internal/cli/preflight.go
@@ -1,13 +1,63 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/canpok1/vox-radio/internal/config"
 )
 
 // lookPath is exec.LookPath by default; replaced in tests.
 var lookPath = exec.LookPath
+
+// requireLLMKey checks that the API key environment variable for the configured LLM
+// provider is set to a non-empty value. It resolves the api_key_env name for the
+// active provider (openai / dify-chat) and verifies os.Getenv is non-empty.
+//
+// This is a cheap, no-cost startup check (no LLM call): an invalid key still surfaces
+// on the first real Complete call early in the pipeline, but a missing key is caught
+// immediately at startup. os.Getenv is used only in the CLI layer (see architecture.md).
+func requireLLMKey(cfg *config.Config) error {
+	var envName string
+	switch cfg.LLM.EffectiveProvider() {
+	case config.ProviderDifyChat:
+		if cfg.LLM.DifyChat != nil {
+			envName = cfg.LLM.DifyChat.APIKeyEnv
+		}
+	default:
+		if cfg.LLM.OpenAI != nil {
+			envName = cfg.LLM.OpenAI.APIKeyEnv
+		}
+	}
+	if envName == "" {
+		return fmt.Errorf("LLM の api_key_env が設定されていません。設定ファイルの llm を確認してください")
+	}
+	if os.Getenv(envName) == "" {
+		return fmt.Errorf("LLM API キーの環境変数 %s が設定されていません。%s を設定してください", envName, envName)
+	}
+	return nil
+}
+
+// checkResources runs all given resource checks and aggregates their failures into a
+// single error listing each missing resource, so the user sees every problem at once
+// instead of fixing them one run at a time. Returns nil when all checks pass.
+func checkResources(checks ...func() error) error {
+	var errs []error
+	for _, check := range checks {
+		if err := check(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) == 0 {
+		return nil
+	}
+	// errors.Join で集約し、errors.Is/As のアンラップを保つ（architecture.md §6）。
+	// 先頭に見出しを付けて不足リソースを一覧提示する。
+	return errors.Join(append([]error{errors.New("起動時リソースチェックに失敗しました")}, errs...)...)
+}
 
 // requireMediaTools checks that ffmpeg and ffprobe are available in PATH.
 // If any are missing, returns an error listing all absent tools with a link to the README.

--- a/internal/cli/preflight_test.go
+++ b/internal/cli/preflight_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
 )
 
 var testReadmeURL = referenceURL("README.md")
@@ -40,6 +42,82 @@ func TestRequireMediaTools_OneMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), testReadmeURL) {
 		t.Errorf("want README URL %q in error, got: %v", testReadmeURL, err)
+	}
+}
+
+func TestRequireLLMKey_OpenAI(t *testing.T) {
+	cfg := &config.Config{LLM: config.LLMConfig{
+		Provider: "openai",
+		OpenAI:   &config.OpenAIConfig{APIKeyEnv: "TEST_OPENAI_KEY"},
+	}}
+
+	t.Run("set", func(t *testing.T) {
+		t.Setenv("TEST_OPENAI_KEY", "secret")
+		if err := requireLLMKey(cfg); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv("TEST_OPENAI_KEY", "")
+		err := requireLLMKey(cfg)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "TEST_OPENAI_KEY") {
+			t.Errorf("want env var name in error, got: %v", err)
+		}
+	})
+}
+
+func TestRequireLLMKey_DifyChat(t *testing.T) {
+	cfg := &config.Config{LLM: config.LLMConfig{
+		Provider: config.ProviderDifyChat,
+		DifyChat: &config.DifyChatConfig{APIKeyEnv: "TEST_DIFY_KEY"},
+	}}
+
+	t.Run("set", func(t *testing.T) {
+		t.Setenv("TEST_DIFY_KEY", "secret")
+		if err := requireLLMKey(cfg); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv("TEST_DIFY_KEY", "")
+		err := requireLLMKey(cfg)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "TEST_DIFY_KEY") {
+			t.Errorf("want env var name in error, got: %v", err)
+		}
+	})
+}
+
+func TestCheckResources_AllPass(t *testing.T) {
+	if err := checkResources(
+		func() error { return nil },
+		func() error { return nil },
+	); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCheckResources_AggregatesFailures(t *testing.T) {
+	err := checkResources(
+		func() error { return errors.New("resource A missing") },
+		func() error { return nil },
+		func() error { return errors.New("resource B missing") },
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "resource A missing") {
+		t.Errorf("want 'resource A missing' in aggregated error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "resource B missing") {
+		t.Errorf("want 'resource B missing' in aggregated error, got: %v", err)
 	}
 }
 

--- a/internal/cli/rundown.go
+++ b/internal/cli/rundown.go
@@ -41,6 +41,10 @@ func newRundownCmd() *cobra.Command {
 				return err
 			}
 
+			if err := checkResources(func() error { return requireLLMKey(cfg) }); err != nil {
+				return err
+			}
+
 			llmClient := newLLMClient(cfg)
 
 			prompts, err := loadPrompts()

--- a/internal/cli/script.go
+++ b/internal/cli/script.go
@@ -55,6 +55,10 @@ func newScriptCmd() *cobra.Command {
 				return err
 			}
 
+			if err := checkResources(func() error { return requireLLMKey(cfg) }); err != nil {
+				return err
+			}
+
 			llmClient := newLLMClient(cfg)
 
 			prompts, err := loadPrompts()

--- a/internal/cli/synth.go
+++ b/internal/cli/synth.go
@@ -41,6 +41,15 @@ voicevox.url フィールドで VOICEVOX エンジンの URL を指定します�
 				return fmt.Errorf("load config: %w", err)
 			}
 
+			ctx := context.Background()
+			engineURL := cfg.Voicevox.EffectiveURL()
+			if err := checkResources(
+				requireMediaTools,
+				func() error { return synth.CheckReadiness(ctx, engineURL, cfg) },
+			); err != nil {
+				return err
+			}
+
 			data, err := os.ReadFile(in)
 			if err != nil {
 				return fmt.Errorf("read script: %w", err)
@@ -50,10 +59,8 @@ voicevox.url フィールドで VOICEVOX エンジンの URL を指定します�
 				return fmt.Errorf("parse script: %w", err)
 			}
 
-			engineURL := cfg.Voicevox.EffectiveURL()
-
 			s := synth.New(engineURL, cfg, synth.WithLogger(logger))
-			meta, err := s.Run(context.Background(), scr, outDir)
+			meta, err := s.Run(ctx, scr, outDir)
 			if err != nil {
 				return err
 			}

--- a/internal/synth/readiness_test.go
+++ b/internal/synth/readiness_test.go
@@ -1,0 +1,54 @@
+package synth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+)
+
+func TestCheckReadiness_ReturnsNilWhenEngineReady(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/version" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(`"0.14.0"`))
+	}))
+	defer server.Close()
+
+	one := 1
+	cfg := &config.Config{Voicevox: config.VoicevoxConfig{StartupTimeoutSeconds: &one}}
+	if err := CheckReadiness(context.Background(), server.URL, cfg); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCheckReadiness_SkipsWhenStartupTimeoutZero(t *testing.T) {
+	zero := 0
+	cfg := &config.Config{Voicevox: config.VoicevoxConfig{StartupTimeoutSeconds: &zero}}
+	// URL is unreachable, but a zero timeout disables the check so no connection is attempted.
+	if err := CheckReadiness(context.Background(), "http://127.0.0.1:0", cfg); err != nil {
+		t.Fatalf("expected nil (check disabled), got %v", err)
+	}
+}
+
+func TestCheckReadiness_ReturnsErrorWhenUnreachable(t *testing.T) {
+	// Start then immediately close a server so the URL refuses connections.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	one := 1
+	cfg := &config.Config{Voicevox: config.VoicevoxConfig{StartupTimeoutSeconds: &one}}
+	err := CheckReadiness(context.Background(), url, cfg)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "VOICEVOX") {
+		t.Errorf("want 'VOICEVOX' in error, got: %v", err)
+	}
+}

--- a/internal/synth/synth.go
+++ b/internal/synth/synth.go
@@ -169,6 +169,26 @@ func (s *Synth) resolveSpeakerID(charID, style string) int {
 	return id
 }
 
+// CheckReadiness verifies the VOICEVOX engine at engineURL is reachable by polling
+// its /version endpoint, waiting up to the configured startup timeout
+// (config.VoicevoxConfig.EffectiveStartupTimeout; zero disables the check).
+//
+// It is intended to be called at command startup — before any LLM work — so an
+// unreachable engine fails fast instead of only surfacing at the synth stage after
+// expensive LLM steps have already run. Synth.Run keeps its own waitForReady as a
+// defence for standalone use; when this ran first the engine is already ready so
+// that later poll returns immediately.
+func CheckReadiness(ctx context.Context, engineURL string, cfg *config.Config) error {
+	var timeout time.Duration
+	if cfg != nil {
+		timeout = cfg.Voicevox.EffectiveStartupTimeout()
+	}
+	if err := waitForReady(ctx, NewClient(engineURL), timeout, pollIntervalDefault); err != nil {
+		return fmt.Errorf("VOICEVOX エンジンに接続できません (%s): %w。VOICEVOX を起動してください（起動待機は voicevox.startup_timeout_seconds で調整、0 で無効）", engineURL, err)
+	}
+	return nil
+}
+
 // waitForReady polls the VOICEVOX /version endpoint until it responds successfully.
 // Returns nil immediately when timeout is zero (disabled) or when the engine is ready.
 // Returns an error if the context is cancelled or the timeout expires.


### PR DESCRIPTION
関連タスク: [起動時リソースチェック（preflight）を全コマンドに導入し VOICEVOX/LLM/ffmpeg を実行前に検証する](https://app.todoist.com/app/task/6h2pFJ65fvp7CpMV)

## 概要

`episodegen` は VOICEVOX に到達できない場合でも、LLM でセリフ生成等のコストを消費した**後**（synth 段）で初めて接続エラーになり非効率でした。各コマンドが使う外部リソースを LLM/パイプライン着手前にまとめて検証し、早期に失敗させます（[ADR-0095](https://github.com/canpok1/vox-radio/blob/main/docs/adr/0095-startup-resource-preflight.md)）。

## 変更内容

- 共通ヘルパーを追加（`internal/cli/preflight.go`, `internal/synth/synth.go`）
  - `synth.CheckReadiness`: 既存 `waitForReady` を流用し、起動時に VOICEVOX の疎通を `EffectiveStartupTimeout()`（既定60秒, 0で無効）ぶん待機して確認する（ADR-0088 の待機を synth 段から起動時へ前倒し。`Synth.Run` の待機は多重防御で維持）
  - `requireLLMKey`: 設定 provider（openai / dify-chat）の `api_key_env` 環境変数が非空かを検証（LLM 呼び出しはせず無コスト）
  - `checkResources`: 複数チェックの失敗を `errors.Join` で集約し、不足リソースを一括で列挙
- 各コマンドを配線表どおりに配線
  - `episodegen`: ffmpeg/VOICEVOX/LLMキー
  - `synth`: ffmpeg/VOICEVOX
  - `rundown` / `script`: LLMキー
  - `mix`: ffmpeg（既存の `requireMediaTools` を機構経由に統一）
  - `assets preview`: ffmpeg
  - slackpost（既存 `VerifyScopes` で副作用前チェック済み）・gather・manifest 等は対象外

## セルフレビューでの修正

- `episodegen` の preflight を既存出力ガード（`--force` 未指定時の存在チェック）の**後段**に配置。出力が既存で即失敗すべきケースで VOICEVOX 待機（最大60秒）を無駄に発生させないようにした。
- エラー集約を `errors.Join` に統一（architecture.md §6）。

## 関連 Issue

なし（ADR-0095 / ADR-0088 を参照）

## 確認したこと

- [x] `go test ./...` が通る
- [ ] `make lint`（`golangci-lint`）: 実行環境の golangci-lint が Go ツールチェーンのバージョン不整合（build go1.25 < target go1.26.1）で起動できず未実行。`gofmt -l`（差分なし）・`go build`・`go vet` は確認済み。CI での lint に委ねます
- [x] CLI のコマンド/フラグ/`Short`/`Long` は不変のため `make docs` 再生成・README 反映は不要（挙動のみの変更）
- [x] 重要な技術判断は ADR-0095 に記録済み（#540 でマージ済み）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CM9tkoGf3XuFNGmnvKA8Fy)_