### PR TITLE
feat: 記事なし時にコーナーをスキップする skip_if_no_articles オプションを追加

### DIFF
--- a/internal/cli/templates/episode-spec.yaml
+++ b/internal/cli/templates/episode-spec.yaml
@@ -124,6 +124,9 @@ corners:
       # - type: text
       #   path: refs/background.txt  # 参考テキストファイル
       #   title: "背景知識"           # 省略するとファイル名を使用
+    # 記事がないときにコーナーを丸ごとスキップする（省略すると false＝記事なしでも放送）。
+    # お便りコーナーなど素材がないと成り立たないコーナー向け。
+    # skip_if_no_articles: true
     # 放送する回の条件（省略すると毎回放送される固定コーナー）。
     # condition を書くと、回番号が合ったときだけ放送されます。
     # condition:

--- a/internal/config/program.go
+++ b/internal/config/program.go
@@ -70,21 +70,22 @@ type CornerDefaults struct {
 
 // CornerConfig defines a fixed corner in the program structure.
 type CornerConfig struct {
-	ID            string            `yaml:"id"` // コーナーを回をまたいで同定する安定キー（必須・番組内で一意）
-	Title         string            `yaml:"title"`
-	Content       string            `yaml:"content"`
-	Direction     string            `yaml:"direction,omitempty"`
-	ScriptNote    string            `yaml:"script_note,omitempty"` // コーナー個別の台本指示（write専用・非公開）
-	Cast          map[string]string `yaml:"cast"`
-	LengthSec     int               `yaml:"length_sec"`
-	SummaryLength int               `yaml:"summary_length,omitempty"`
-	Source        SourceConfig      `yaml:"source,omitempty"`
-	StartAudio    *AudioRef         `yaml:"start_audio,omitempty"`
-	EndAudio      *AudioRef         `yaml:"end_audio,omitempty"`
-	BGM           *string           `yaml:"bgm,omitempty"`
-	StartPauseSec *float64          `yaml:"start_pause_sec,omitempty"`
-	EndPauseSec   *float64          `yaml:"end_pause_sec,omitempty"`
-	Condition     *EpisodeCondition `yaml:"condition,omitempty"` // 出現条件（nil なら毎回出る固定コーナー）
+	ID               string            `yaml:"id"` // コーナーを回をまたいで同定する安定キー（必須・番組内で一意）
+	Title            string            `yaml:"title"`
+	Content          string            `yaml:"content"`
+	Direction        string            `yaml:"direction,omitempty"`
+	ScriptNote       string            `yaml:"script_note,omitempty"` // コーナー個別の台本指示（write専用・非公開）
+	Cast             map[string]string `yaml:"cast"`
+	LengthSec        int               `yaml:"length_sec"`
+	SummaryLength    int               `yaml:"summary_length,omitempty"`
+	Source           SourceConfig      `yaml:"source,omitempty"`
+	StartAudio       *AudioRef         `yaml:"start_audio,omitempty"`
+	EndAudio         *AudioRef         `yaml:"end_audio,omitempty"`
+	BGM              *string           `yaml:"bgm,omitempty"`
+	StartPauseSec    *float64          `yaml:"start_pause_sec,omitempty"`
+	EndPauseSec      *float64          `yaml:"end_pause_sec,omitempty"`
+	Condition        *EpisodeCondition `yaml:"condition,omitempty"`           // 出現条件（nil なら毎回出る固定コーナー）
+	SkipIfNoArticles bool              `yaml:"skip_if_no_articles,omitempty"` // true なら記事0件時にコーナーごとスキップ
 }
 
 // EffectiveSummaryLength returns the configured SummaryLength, falling back to DefaultCornerSummaryLength.

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -111,12 +111,14 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		return err
 	}
 
+	corners := filterCornersInRundown(r.Spec.Corners, rundown)
+
 	var chars map[string]config.CharacterConfig
 	if r.Config != nil {
 		chars = r.Config.Characters
 	}
 
-	scr, scriptLines, pr, err := r.Scripter.Generate(ctx, r.Spec.Program, rundown, r.Spec.Corners, chars)
+	scr, scriptLines, pr, err := r.Scripter.Generate(ctx, r.Spec.Program, rundown, corners, chars)
 	if err != nil {
 		return fmt.Errorf("script: %w", err)
 	}
@@ -178,13 +180,13 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		return fmt.Errorf("mix: %w", err)
 	}
 
-	if err := writeTimeline(layout, r.Spec.Corners, cornerDurations); err != nil {
+	if err := writeTimeline(layout, corners, cornerDurations); err != nil {
 		return fmt.Errorf("write timeline: %w", err)
 	}
 
 	m := manifest.Build(manifest.BuildParams{
 		Program:           r.Spec.Program,
-		Corners:           r.Spec.Corners,
+		Corners:           corners,
 		Rundown:           rundown,
 		AudioFile:         fileio.EpisodeFileName(r.Spec.Program.ID, opts.EpisodeNumber),
 		GeneratedAt:       generatedAt,
@@ -205,4 +207,20 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 	}
 
 	return nil
+}
+
+// filterCornersInRundown returns only the corners whose IDs appear in the rundown.
+// This handles corners skipped by the rundowner (e.g. skip_if_no_articles).
+func filterCornersInRundown(corners []config.CornerConfig, rd model.Rundown) []config.CornerConfig {
+	included := make(map[string]struct{}, len(rd.Corners))
+	for _, rc := range rd.Corners {
+		included[rc.ID] = struct{}{}
+	}
+	filtered := make([]config.CornerConfig, 0, len(rd.Corners))
+	for _, c := range corners {
+		if _, ok := included[c.ID]; ok {
+			filtered = append(filtered, c)
+		}
+	}
+	return filtered
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -405,6 +405,11 @@ func TestRunner_Run_CallsCornerSummarizer(t *testing.T) {
 func TestRunner_Run_ManifestIncludesCornerSummary(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
+	s.rnd.rundown = model.Rundown{
+		Corners: []model.RundownCorner{
+			{ID: "test", Title: "テストコーナー", Articles: make([]model.RundownArticle, 0)},
+		},
+	}
 	s.scr.lines = model.ScriptLines{
 		Corners: []model.CornerLines{
 			{Title: "テストコーナー", Lines: []model.Line{{Text: "テスト"}}},
@@ -414,7 +419,7 @@ func TestRunner_Run_ManifestIncludesCornerSummary(t *testing.T) {
 
 	r := newRunner(s)
 	r.Spec = &config.EpisodeSpec{
-		Corners: []config.CornerConfig{{Title: "テストコーナー"}},
+		Corners: []config.CornerConfig{{ID: "test", Title: "テストコーナー"}},
 	}
 
 	if err := r.Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
@@ -621,6 +626,12 @@ func TestRunner_Run_ManifestIncludesCharacterCredits(t *testing.T) {
 func TestRunner_Run_WritesTimeline(t *testing.T) {
 	outDir := t.TempDir()
 	s := defaultStubs()
+	s.rnd.rundown = model.Rundown{
+		Corners: []model.RundownCorner{
+			{ID: "op", Title: "OP", Articles: make([]model.RundownArticle, 0)},
+			{ID: "tech", Title: "技術", Articles: make([]model.RundownArticle, 0)},
+		},
+	}
 	s.asm.cornerDurations = map[string]float64{"op": 12.5, "tech": 30.0}
 
 	r := newRunner(s)
@@ -673,5 +684,58 @@ func TestRunner_Run_EpisodeMetaPassedToMixer(t *testing.T) {
 
 	if s.asm.capturedMeta.Number != 3 {
 		t.Errorf("EpisodeMeta.Number = %d, want 3", s.asm.capturedMeta.Number)
+	}
+}
+
+func TestRunner_Run_SkippedCornersFilteredFromDownstream(t *testing.T) {
+	outDir := t.TempDir()
+	s := defaultStubs()
+	// Rundowner returns only 2 corners (mail was skipped)
+	s.rnd.rundown = model.Rundown{
+		Corners: []model.RundownCorner{
+			{ID: "opening", Title: "オープニング", Articles: make([]model.RundownArticle, 0)},
+			{ID: "ending", Title: "エンディング", Articles: make([]model.RundownArticle, 0)},
+		},
+	}
+	s.asm.cornerDurations = map[string]float64{"opening": 10.0, "ending": 15.0}
+
+	r := newRunner(s)
+	r.Spec = &config.EpisodeSpec{
+		Corners: []config.CornerConfig{
+			{ID: "opening", Title: "オープニング", Content: "導入", LengthSec: 30},
+			{ID: "mail", Title: "お便りコーナー", Content: "お便り紹介", LengthSec: 120, SkipIfNoArticles: true},
+			{ID: "ending", Title: "エンディング", Content: "締め", LengthSec: 30},
+		},
+	}
+
+	if err := r.Run(context.Background(), pipeline.Options{OutDir: outDir}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Timeline should only have the 2 included corners
+	var tl model.Timeline
+	if err := fileio.ReadJSON(outLayout(outDir).Timeline(), &tl); err != nil {
+		t.Fatalf("read timeline: %v", err)
+	}
+	if len(tl.Corners) != 2 {
+		t.Fatalf("Timeline.Corners: got %d, want 2", len(tl.Corners))
+	}
+	if tl.Corners[0].ID != "opening" {
+		t.Errorf("Timeline.Corners[0].ID: got %q, want %q", tl.Corners[0].ID, "opening")
+	}
+	if tl.Corners[1].ID != "ending" {
+		t.Errorf("Timeline.Corners[1].ID: got %q, want %q", tl.Corners[1].ID, "ending")
+	}
+
+	// Manifest should only have the 2 included corners
+	got := mustReadManifest(t, outDir)
+	if strings.Contains(got, "お便りコーナー") {
+		t.Error("manifest should not contain skipped corner title")
+	}
+	if !strings.Contains(got, "オープニング") {
+		t.Error("manifest should contain opening corner")
+	}
+	if !strings.Contains(got, "エンディング") {
+		t.Error("manifest should contain ending corner")
 	}
 }

--- a/internal/rundown/rundown.go
+++ b/internal/rundown/rundown.go
@@ -70,6 +70,7 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 
 	articleMap := articles.CornerMap()
 	rundownCorners := make([]model.RundownCorner, 0, len(corners))
+	includedCorners := make([]config.CornerConfig, 0, len(corners))
 
 	// フェーズ1: 各コーナーの記事選別・要約・選別理由を収集
 	for _, corner := range corners {
@@ -93,6 +94,10 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 		cornerArticles = filtered
 
 		if len(cornerArticles) == 0 {
+			if corner.SkipIfNoArticles {
+				r.logger.Info("記事なしのためコーナーをスキップ", "corner", corner.Title)
+				continue
+			}
 			rundownCorners = append(rundownCorners, model.RundownCorner{
 				ID:                corner.ID,
 				Title:             corner.Title,
@@ -100,6 +105,7 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 				AppearanceCount:   appearanceCount,
 				LastEpisodeNumber: lastEpisodeNumber,
 			})
+			includedCorners = append(includedCorners, corner)
 			continue
 		}
 
@@ -143,6 +149,7 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 			AppearanceCount:   appearanceCount,
 			LastEpisodeNumber: lastEpisodeNumber,
 		})
+		includedCorners = append(includedCorners, corner)
 	}
 
 	// キャストをセット
@@ -152,8 +159,8 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 	}
 
 	// フェーズ2: 番組構成全体を文脈に全コーナーの flow を設計
-	last := len(corners) - 1
-	for i, corner := range corners {
+	last := len(includedCorners) - 1
+	for i, corner := range includedCorners {
 		designed, err := r.flowDesigner.DesignFlow(ctx, corner, flow.PositionFor(i, last), rd.Corners[i], rd)
 		if err != nil {
 			return model.Rundown{}, fmt.Errorf("design flow for corner %q: %w", corner.Title, err)
@@ -161,6 +168,6 @@ func (r *LLMRundowner) Run(ctx context.Context, corners []config.CornerConfig, a
 		rd.Corners[i].Flow = designed
 	}
 
-	done(fmt.Sprintf("%dコーナー", len(corners)))
+	done(fmt.Sprintf("%dコーナー", len(includedCorners)))
 	return rd, nil
 }

--- a/internal/rundown/rundown_test.go
+++ b/internal/rundown/rundown_test.go
@@ -756,3 +756,133 @@ func TestLLMRundowner_Run_PropagatesSourceAuthorPublished(t *testing.T) {
 		t.Errorf("Published: got %q, want %q", a.Published, "2026-06-06T19:00:00+09:00")
 	}
 }
+
+func TestLLMRundowner_Run_SkipIfNoArticles_SkipsCorner(t *testing.T) {
+	ms := &mockSelector{result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"}}
+	mfd := &mockFlowDesigner{flow: "flow"}
+	rd := newRundowner(ms, &mockSummarizer{}, nil, mfd)
+
+	corners := []config.CornerConfig{
+		{ID: "opening", Title: "オープニング", Content: "導入", LengthSec: 30},
+		{ID: "mail", Title: "お便りコーナー", Content: "お便り紹介", LengthSec: 120, SkipIfNoArticles: true},
+		{ID: "tech", Title: "テック", Content: "ニュース", LengthSec: 180},
+	}
+	articles := model.Articles{
+		Corners: []model.CornerArticles{
+			{CornerTitle: "オープニング", Articles: []model.Article{}},
+			{CornerTitle: "お便りコーナー", Articles: []model.Article{}},
+			{CornerTitle: "テック", Articles: []model.Article{{DedupKey: "u1", URL: "u1", Title: "t", Description: "b"}}},
+		},
+	}
+
+	got, err := rd.Run(context.Background(), corners, articles, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Corners) != 2 {
+		t.Fatalf("len(Corners): got %d, want 2 (mail corner should be skipped)", len(got.Corners))
+	}
+	if got.Corners[0].Title != "オープニング" {
+		t.Errorf("Corners[0].Title: got %q, want %q", got.Corners[0].Title, "オープニング")
+	}
+	if got.Corners[1].Title != "テック" {
+		t.Errorf("Corners[1].Title: got %q, want %q", got.Corners[1].Title, "テック")
+	}
+}
+
+func TestLLMRundowner_Run_SkipIfNoArticles_KeepsCornerWithArticles(t *testing.T) {
+	ms := &mockSelector{result: sel.SelectResult{SelectedIDs: []string{"u1"}, SelectionReason: "理由"}}
+	mfd := &mockFlowDesigner{flow: "flow"}
+	rd := newRundowner(ms, &mockSummarizer{}, nil, mfd)
+
+	corners := []config.CornerConfig{
+		{ID: "mail", Title: "お便りコーナー", Content: "お便り紹介", LengthSec: 120, SkipIfNoArticles: true},
+	}
+	articles := model.Articles{
+		Corners: []model.CornerArticles{
+			{CornerTitle: "お便りコーナー", Articles: []model.Article{{DedupKey: "u1", URL: "u1", Title: "お便り1", Description: "内容"}}},
+		},
+	}
+
+	got, err := rd.Run(context.Background(), corners, articles, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Corners) != 1 {
+		t.Fatalf("len(Corners): got %d, want 1 (corner with articles should be kept)", len(got.Corners))
+	}
+	if got.Corners[0].Title != "お便りコーナー" {
+		t.Errorf("Corners[0].Title: got %q, want %q", got.Corners[0].Title, "お便りコーナー")
+	}
+}
+
+func TestLLMRundowner_Run_SkipIfNoArticles_FlowPositionAdjusted(t *testing.T) {
+	ms := &mockSelector{}
+	var capturedPositions []flow.Position
+	customDesigner := &positionCapturingDesigner{positions: &capturedPositions, flow: "flow"}
+	rd := rundown.NewLLMRundowner(ms, &mockSummarizer{}, customDesigner, nil)
+
+	corners := []config.CornerConfig{
+		{ID: "opening", Title: "オープニング", Content: "導入", LengthSec: 30},
+		{ID: "mail", Title: "お便りコーナー", Content: "お便り紹介", LengthSec: 120, SkipIfNoArticles: true},
+		{ID: "ending", Title: "エンディング", Content: "締め", LengthSec: 30},
+	}
+	articles := model.Articles{
+		Corners: []model.CornerArticles{
+			{CornerTitle: "オープニング", Articles: []model.Article{}},
+			{CornerTitle: "お便りコーナー", Articles: []model.Article{}},
+			{CornerTitle: "エンディング", Articles: []model.Article{}},
+		},
+	}
+
+	got, err := rd.Run(context.Background(), corners, articles, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Corners) != 2 {
+		t.Fatalf("len(Corners): got %d, want 2", len(got.Corners))
+	}
+	if len(capturedPositions) != 2 {
+		t.Fatalf("expected 2 position calls, got %d", len(capturedPositions))
+	}
+	if capturedPositions[0] != flow.PositionOpening {
+		t.Errorf("first corner position: got %q, want %q", capturedPositions[0], flow.PositionOpening)
+	}
+	if capturedPositions[1] != flow.PositionEnding {
+		t.Errorf("last corner position: got %q, want %q", capturedPositions[1], flow.PositionEnding)
+	}
+}
+
+func TestLLMRundowner_Run_SkipIfNoArticles_LogOutput(t *testing.T) {
+	var buf bytes.Buffer
+	handler := logging.NewTextHandler(&buf, slog.LevelInfo)
+	logger := slog.New(handler)
+
+	mfd := &mockFlowDesigner{flow: "flow"}
+	rd := newRundowner(&mockSelector{}, &mockSummarizer{}, nil, mfd, rundown.WithLogger(logger))
+
+	corners := []config.CornerConfig{
+		{ID: "mail", Title: "お便りコーナー", Content: "お便り紹介", LengthSec: 120, SkipIfNoArticles: true},
+	}
+	articles := model.Articles{
+		Corners: []model.CornerArticles{
+			{CornerTitle: "お便りコーナー", Articles: []model.Article{}},
+		},
+	}
+
+	got, err := rd.Run(context.Background(), corners, articles, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Corners) != 0 {
+		t.Fatalf("len(Corners): got %d, want 0", len(got.Corners))
+	}
+
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "記事なしのためコーナーをスキップ") {
+		t.Errorf("log should contain skip message, got: %q", logOutput)
+	}
+	if !strings.Contains(logOutput, "corner=お便りコーナー") {
+		t.Errorf("log should contain corner name, got: %q", logOutput)
+	}
+}


### PR DESCRIPTION
## 概要

`CornerConfig` に `skip_if_no_articles` オプションを追加し、記事が0件のコーナーを丸ごとスキップできるようにしました。お便りコーナーなど、記事（素材）がないと成り立たないコーナーで利用します。

## 変更内容

- **`internal/config/program.go`**: `CornerConfig` に `SkipIfNoArticles bool` フィールドを追加
- **`internal/rundown/rundown.go`**: Phase 1 で記事0件 × `SkipIfNoArticles=true` のコーナーを `includedCorners` から除外。Phase 2 のフロー設計は `includedCorners` で回すことでインデックス整合性を維持
- **`internal/pipeline/pipeline.go`**: Rundown 後に `filterCornersInRundown()` で採用コーナーを絞り込み、Scripter・Timeline・Manifest の下流処理に一貫して渡す
- **`internal/cli/templates/episode-spec.yaml`**: 設定例をコメントで追加

## テスト

- `internal/rundown/rundown_test.go`: 4テスト追加（スキップ動作、記事ありの非スキップ、フロー位置調整、ログ出力）
- `internal/pipeline/pipeline_test.go`: 1テスト追加（スキップされたコーナーが下流から除外されること）+ 既存テスト2件をID整合性修正

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUeU4MDKbCP18Mg79hM4Xm)_