### PR TITLE
test(e2e): フェイクLLMにanalyze/retroを登録しwarn-continueの検知網を復旧する

### DIFF
--- a/e2e/fake_llm.go
+++ b/e2e/fake_llm.go
@@ -29,6 +29,8 @@ var llmRoutes = []llmStepRoute{
 	{step: "proofread", header: "# [C] 発音校正プロンプト"},
 	{step: "summary", header: "# [D] 番組要約プロンプト"},
 	{step: "corner_summary", header: "# [D] コーナー要約プロンプト"},
+	{step: "analyze", header: "# [D] 番組分析プロンプト"},
+	{step: "retro", header: "# [D] 振り返り（retro）プロンプト"},
 }
 
 var idInPromptRe = regexp.MustCompile(`"id":\s*"([^"]+)"`)
@@ -140,6 +142,16 @@ func cannedResponse(step, prompt string) (string, error) {
 			`"conversation_notes":[{"category":"雑談","character_ids":["zundamon"],"note":"テスト用の会話メモ"}]}`, nil
 	case "corner_summary":
 		return `{"summary":"コーナー内容のまとめです。","points":["コーナー要点1"]}`, nil
+	case "analyze":
+		return `{"findings":[` +
+			`{"aspect":"掛け合い","severity":"low","detail":"テスト用の固定分析結果です。","evidence":"ずんだもん「テストなのだ」"}` +
+			`],"patterns":[` +
+			`{"aspect":"つかみ","detail":"テスト用の固定パターンです。"}` +
+			`]}`, nil
+	case "retro":
+		return `{"problems":[` +
+			`{"id":"","problem":"テスト用の固定問題です。","action":"テスト用の固定施策です。","first_seen_episode":1,"last_seen_episode":1}` +
+			`],"recurrences":[]}`, nil
 	}
 	return "", fmt.Errorf("no canned response for step %q", step)
 }

--- a/e2e/features/episodegen_full.feature
+++ b/e2e/features/episodegen_full.feature
@@ -21,3 +21,7 @@
     かつ JSONファイル "out/e2e-radio_ep001_manifest.json" のキー "episode_number" は数値 1 である
     かつ JSONファイル "out/e2e-radio_ep001_manifest.json" のキー "audio_file" は文字列 "e2e-radio_ep001.mp3" である
     かつ ファイル ".vox-radio/programs/e2e-radio/cache.jsonl" の行数は 1 である
+    かつ ファイル "out/intermediate/e2e-radio_ep001/07_analysis.json" が存在する
+    かつ JSONファイル "out/intermediate/e2e-radio_ep001/07_analysis.json" の配列 "findings" の要素数は 1 以上である
+    かつ JSONファイル "out/intermediate/e2e-radio_ep001/07_analysis.json" の配列 "patterns" の要素数は 1 以上である
+    かつ ファイル ".vox-radio/programs/e2e-radio/cache.jsonl" に "analysis" を含む

--- a/e2e/features/retro.feature
+++ b/e2e/features/retro.feature
@@ -1,0 +1,38 @@
+# language: ja
+機能: retro による自動改善ループ
+
+  @ffmpeg
+  シナリオ: 分析付きキャッシュから try/keep ファイルを生成する
+    前提 モックLLMサーバーが起動している
+    かつ モックVOICEVOXサーバーが起動している
+    かつ モックフィードサーバーが起動している
+    かつ テスト用設定一式を配置する
+    かつ "vox-radio episodegen --spec episode-spec.yaml --out-dir out" を実行する
+    もし "vox-radio retro --spec episode-spec.yaml" を実行する
+    ならば 終了コードは 0 である
+    かつ 標準出力に "try file written" を含む
+    かつ 標準出力に "keep file written" を含む
+    かつ ファイル ".vox-radio/programs/e2e-radio/try.yaml" が存在する
+    かつ ファイル ".vox-radio/programs/e2e-radio/keep.yaml" が存在する
+    かつ ファイル ".vox-radio/programs/e2e-radio/try.yaml" に "clear_streak" を含む
+
+  シナリオ: キャッシュが無いときは案内を出して正常終了する
+    前提 モックLLMサーバーが起動している
+    かつ テスト用設定一式を配置する
+    もし "vox-radio retro --spec episode-spec.yaml" を実行する
+    ならば 終了コードは 0 である
+    かつ 標準出力に "キャッシュが存在しません" を含む
+    かつ ファイル ".vox-radio/programs/e2e-radio/try.yaml" が存在しない
+
+  @ffmpeg
+  シナリオ: --dry-run はファイルを書かない
+    前提 モックLLMサーバーが起動している
+    かつ モックVOICEVOXサーバーが起動している
+    かつ モックフィードサーバーが起動している
+    かつ テスト用設定一式を配置する
+    かつ "vox-radio episodegen --spec episode-spec.yaml --out-dir out" を実行する
+    もし "vox-radio retro --spec episode-spec.yaml --dry-run" を実行する
+    ならば 終了コードは 0 である
+    かつ 標準出力に "problems:" を含む
+    かつ 標準出力に "try file written" を含まない
+    かつ ファイル ".vox-radio/programs/e2e-radio/try.yaml" が存在しない


### PR DESCRIPTION
関連タスク: [e2e のフェイク LLM に analyze / retro を登録し両ステップを検証する](https://app.todoist.com/app/task/6h8jwVppjv9pCcV3)

## 概要

`e2e/fake_llm.go` の `llmRoutes` に analyze・retroのプロンプト見出しが未登録で、analyzeのLLM呼び出しがe2eで一度も成功していなかった。analyzeの失敗はwarn-continue仕様（ADR-0098）のためパイプライン全体は緑のまま通り、この配線漏れが回帰検知の外にあった。retroにはe2eが一切なかった。

## 変更内容

- `e2e/fake_llm.go`
  - `llmRoutes` に `analyze`（`# [D] 番組分析プロンプト`）・`retro`（`# [D] 振り返り（retro）プロンプト`）を登録
  - `cannedResponse` に両ステップの固定レスポンスを追加。`analyze`は`model.AnalysisFinding`/`model.AnalysisPattern`のJSONタグに適合する`findings`/`patterns`を返し、`retro`は`internal/cli/prompts/retro.md`の出力形式に適合する`problems`/`recurrences`を返す（新規問題として`id`は空文字列、`recurrences`は空配列）
- `e2e/features/episodegen_full.feature`
  - `07_analysis.json`の存在、`findings`/`patterns`の要素数、`cache.jsonl`に`analysis`を含むことの検証を追加
- `e2e/features/retro.feature`（新規）
  - 3シナリオ（try/keep生成・キャッシュ無し案内・`--dry-run`）。episodegenを回す2シナリオには`@ffmpeg`タグを付与。新規のステップ定義は追加せず既存の語彙のみで記述

## 検知網の実効性確認

`llmRoutes` から `analyze` を一時的に外して `go test -tags=e2e ./e2e/...` を実行し、`episodegen_full.feature`（および `retro.feature` の関連シナリオ）が失敗することを確認した上で元に戻した。

## 変えていないこと

analyzeの失敗はwarn-continueのまま（ADR-0098）。エラー停止への変更はしていない。検知はe2eのassertion側で行う。

## 関連 Issue

なし

## 確認したこと

- [x] `make test` が通る
- [ ] `make lint` が通る（環境のgolangci-lint（go1.25.12ビルド）とgo.modのgo1.26.1指定が不整合のため実行不可。mainブランチの既存コードでも同様に失敗する環境側の問題で、今回の変更に起因しない。`gofmt -l .`・`go vet -tags=e2e ./e2e/...`は問題なし）
- [x] CLI のコマンド/フラグは変更していないため `make docs` は対象外
- [x] 重要な技術判断を含まないため ADR は対象外
- [x] `make e2e` 相当（ffmpeg導入環境で `@ffmpeg` シナリオを含め）全31シナリオが緑
- [x] `llmRoutes` から `analyze` を外すと `episodegen_full.feature` が失敗することを確認済み（検知網が機能する裏付け）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)