### PR TITLE
docs: キャッシュパス移行案内の誤りを修正しActionsガイドに移行ステップを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ pronunciation:
 
 **キャッシュ（過去回の記憶）** — vox-radio は過去に放送した番組の情報（扱った話題や放送回など）をキャッシュに記録し、過去回で触れた内容を新しい回の会話に織り込んだり、放送回数を管理したりします。キャッシュは番組ごとに `episode-spec.yaml` の `program.id` をキーとして、番組ごとのディレクトリに保存されます（`.vox-radio/programs/<program.id>/cache.jsonl`）。**このため `program.id` は必須**で、未設定だと `episodegen`（番組生成）や `episodegen check` でエラーになります。
 
-> **旧バージョンからの移行** — v0.99 以前は `.vox-radio/cache/<program.id>.jsonl` に保存していました。過去回の連続性を保つには、アップグレード後に以下で新しい配置へ移してください（移さない場合は履歴が引き継がれず回番号が 1 から再開します）。
+> **旧バージョンからの移行** — v1.0.5 以前は `.vox-radio/cache/<program.id>.jsonl` に保存していました。過去回の連続性を保つには、アップグレード後に以下で新しい配置へ移してください（移さない場合は履歴が引き継がれず回番号が 1 から再開します）。
 >
 > ```bash
 > mkdir -p .vox-radio/programs/<program.id>

--- a/docs/adr/0099-per-program-state-directory.md
+++ b/docs/adr/0099-per-program-state-directory.md
@@ -49,7 +49,7 @@
 |---|---|
 | ローカルの履歴 | `.vox-radio/cache/{id}.jsonl` を `.vox-radio/programs/{id}/cache.jsonl` へ移す。移さないと回番号が 1 に戻る |
 | `feedgen --cache` | 新しいパスを渡す。ファイルが無ければ失敗するので気づける |
-| GitHub Actions | `actions/cache` の `path` を `.vox-radio/programs` に変える。移行期は旧パスも併記する。指定を直さないと復元が静かに失敗する |
+| GitHub Actions | `actions/cache` の `path` を `.vox-radio/programs` に変える。移行期は旧パスも併記し、復元後にワークフロー内で `mv` する移行ステップを追加する。移行ステップが無いと、旧パスを併記しても復元が静かに失敗する |
 
 ## 検討した代替案
 

--- a/docs/adr/0099-per-program-state-directory.md
+++ b/docs/adr/0099-per-program-state-directory.md
@@ -49,7 +49,7 @@
 |---|---|
 | ローカルの履歴 | `.vox-radio/cache/{id}.jsonl` を `.vox-radio/programs/{id}/cache.jsonl` へ移す。移さないと回番号が 1 に戻る |
 | `feedgen --cache` | 新しいパスを渡す。ファイルが無ければ失敗するので気づける |
-| GitHub Actions | `actions/cache` の `path` を `.vox-radio/programs` に変える。移行期は旧パスも併記し、復元後にワークフロー内で `mv` する移行ステップを追加する。移行ステップが無いと、旧パスを併記しても復元が静かに失敗する |
+| GitHub Actions | `actions/cache` の `path` を `.vox-radio/programs` に変える。移行期は旧パスも併記し、復元後にワークフロー内で `mv` する移行ステップを追加する。移行ステップが無いと、旧パスを併記しても新バイナリが履歴を見つけられず回番号が 1 に戻る |
 
 ## 検討した代替案
 

--- a/docs/guides/github-actions-slack.md
+++ b/docs/guides/github-actions-slack.md
@@ -49,8 +49,9 @@ jobs:
       - uses: actions/checkout@v4
 
       # 1. キャッシュ復元。実行ごとに新しいキーで保存し、直近のキャッシュを引き継ぐ書き方。
-      # 旧パス（.vox-radio/cache）は移行期の併記。指定を外すと移行前の履歴が復元されず、
-      # 回番号が 1 に戻って静かに失敗するので、移行が済むまでは両方を指定すること。
+      # 旧パス（.vox-radio/cache）は移行期の併記。自動移行は行われないため、次の
+      # 「Migrate cache layout」ステップが旧ファイルを見つけられるよう、移行が済むまでは
+      # 両方を指定すること（併記だけでは履歴は引き継がれない）。
       - uses: actions/cache@v4
         with:
           path: |
@@ -65,14 +66,26 @@ jobs:
       - name: Install vox-radio
         run: curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | bash
 
-      # 2. 番組生成
+      # 2. 旧レイアウト（v1.0.5 以前）のキャッシュを新レイアウトへ移す。自動移行は行われないため
+      # このステップが無いと、旧パスを復元しても回番号が 1 に戻る。
+      # 何度実行しても安全（移行済みなら何もしない）。
+      - name: Migrate cache layout
+        run: |
+          for f in .vox-radio/cache/*.jsonl; do
+            [ -e "$f" ] || continue
+            id=$(basename "$f" .jsonl)
+            mkdir -p ".vox-radio/programs/$id"
+            mv "$f" ".vox-radio/programs/$id/cache.jsonl"
+          done
+
+      # 3. 番組生成
       - name: Generate episode
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           VOX_RADIO_VOICEVOX_URL: http://127.0.0.1:50021
         run: vox-radio episodegen --spec episode-spec.yaml --out-dir output
 
-      # 3. Slack 投稿
+      # 4. Slack 投稿
       - name: Post to Slack
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -85,10 +98,11 @@ jobs:
 ## 仕組み
 
 1. **キャッシュ復元** — 過去回の履歴（`.vox-radio/programs/`）を `actions/cache` で復元し、前回までの内容を踏まえた番組を生成します。初回（キャッシュ無し）でも動作し、回番号は 1 から始まります。
-2. **番組生成** — `episodegen` が記事収集から音声合成までを一括実行し（詳細は[README の番組生成](../../README.md#番組生成)）、`output/` に mp3 とマニフェストを出力します。
-3. **Slack 投稿** — `slackpost` がマニフェストをもとに mp3 を Slack へ直接アップロードします。GitHub Release など公開 URL の準備は不要です。
-4. **キャッシュ保存** — 新しい履歴を含む `.vox-radio/programs/` は、復元に使った `actions/cache` の post 処理で自動保存されます。専用ステップは要りません。移行が済んだらワークフローから `.vox-radio/cache` の指定を外してください。
-5. **VOICEVOX NEMO などを併用する場合** — `services` にサービスを追加してポートをマップし、`vox-radio.yaml` の `voicevox.engines` でエンジンを定義したうえで、エンジンごとに `VOX_RADIO_VOICEVOX_URL_<エンジン名を大文字化し - を _ に置換した名前>` 環境変数を設定します（詳細は[vox-radio.md](../../internal/cli/skills/vox-radio/references/vox-radio.md)）。
+2. **キャッシュレイアウトの移行** — 旧パス（`.vox-radio/cache`）に復元されたファイルがあれば `.vox-radio/programs/` へ移します。旧パスの併記も本ステップも不要になった（＝すべての履歴が新パスにある）ことを確認したら、ワークフローから両方をまとめて外してください。
+3. **番組生成** — `episodegen` が記事収集から音声合成までを一括実行し（詳細は[README の番組生成](../../README.md#番組生成)）、`output/` に mp3 とマニフェストを出力します。
+4. **Slack 投稿** — `slackpost` がマニフェストをもとに mp3 を Slack へ直接アップロードします。GitHub Release など公開 URL の準備は不要です。
+5. **キャッシュ保存** — 新しい履歴を含む `.vox-radio/programs/` は、復元に使った `actions/cache` の post 処理で自動保存されます。専用ステップは要りません。
+6. **VOICEVOX NEMO などを併用する場合** — `services` にサービスを追加してポートをマップし、`vox-radio.yaml` の `voicevox.engines` でエンジンを定義したうえで、エンジンごとに `VOX_RADIO_VOICEVOX_URL_<エンジン名を大文字化し - を _ に置換した名前>` 環境変数を設定します（詳細は[vox-radio.md](../../internal/cli/skills/vox-radio/references/vox-radio.md)）。
 
 ## 注意事項
 

--- a/docs/guides/github-actions-slack.md
+++ b/docs/guides/github-actions-slack.md
@@ -18,6 +18,7 @@ GitHub Actions のスケジュール実行で、定期的に番組を生成し�
   | 投稿先チャンネル ID | Variable | `SLACK_CHANNEL_ID` | `slack-spec.yaml` の `slack.channel_env` |
 
   環境変数名は設定ファイル側で変更できます。変えた場合はワークフローの `env:` の名前も合わせてください。
+- v1.0.5 以前からアップグレードした場合、キャッシュは旧パス（`.vox-radio/cache`）に保存されています。サンプルワークフローの旧パス併記と移行ステップは、この履歴を新パスへ引き継ぐためのものです（新規導入時は不要ですが、入れておいても無害です）。
 
 ## サンプルワークフロー
 
@@ -49,9 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # 1. キャッシュ復元。実行ごとに新しいキーで保存し、直近のキャッシュを引き継ぐ書き方。
-      # 旧パス（.vox-radio/cache）は移行期の併記。自動移行は行われないため、次の
-      # 「Migrate cache layout」ステップが旧ファイルを見つけられるよう、移行が済むまでは
-      # 両方を指定すること（併記だけでは履歴は引き継がれない）。
+      # 旧パス（.vox-radio/cache）は移行期の併記（理由は次のステップのコメントを参照）。
       - uses: actions/cache@v4
         with:
           path: |
@@ -59,12 +58,6 @@ jobs:
             .vox-radio/programs
           key: vox-radio-cache-${{ github.run_id }}
           restore-keys: vox-radio-cache-
-
-      - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
-
-      - name: Install vox-radio
-        run: curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | bash
 
       # 2. 旧レイアウト（v1.0.5 以前）のキャッシュを新レイアウトへ移す。自動移行は行われないため
       # このステップが無いと、旧パスを復元しても回番号が 1 に戻る。
@@ -77,6 +70,12 @@ jobs:
             mkdir -p ".vox-radio/programs/$id"
             mv "$f" ".vox-radio/programs/$id/cache.jsonl"
           done
+
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+
+      - name: Install vox-radio
+        run: curl -fsSL https://github.com/canpok1/vox-radio/releases/latest/download/install.sh | bash
 
       # 3. 番組生成
       - name: Generate episode
@@ -98,7 +97,7 @@ jobs:
 ## 仕組み
 
 1. **キャッシュ復元** — 過去回の履歴（`.vox-radio/programs/`）を `actions/cache` で復元し、前回までの内容を踏まえた番組を生成します。初回（キャッシュ無し）でも動作し、回番号は 1 から始まります。
-2. **キャッシュレイアウトの移行** — 旧パス（`.vox-radio/cache`）に復元されたファイルがあれば `.vox-radio/programs/` へ移します。旧パスの併記も本ステップも不要になった（＝すべての履歴が新パスにある）ことを確認したら、ワークフローから両方をまとめて外してください。
+2. **キャッシュレイアウトの移行** — 旧パス（`.vox-radio/cache`）に復元されたファイルがあれば `.vox-radio/programs/` へ移します。
 3. **番組生成** — `episodegen` が記事収集から音声合成までを一括実行し（詳細は[README の番組生成](../../README.md#番組生成)）、`output/` に mp3 とマニフェストを出力します。
 4. **Slack 投稿** — `slackpost` がマニフェストをもとに mp3 を Slack へ直接アップロードします。GitHub Release など公開 URL の準備は不要です。
 5. **キャッシュ保存** — 新しい履歴を含む `.vox-radio/programs/` は、復元に使った `actions/cache` の post 処理で自動保存されます。専用ステップは要りません。
@@ -108,3 +107,4 @@ jobs:
 
 - **キャッシュの保持期間** — `actions/cache` は 7 日間アクセスのないキャッシュを自動削除します。実行間隔が空くと過去回の文脈（番組の連続性）が失われます。日次など定期実行のサンプル用途では問題になりません。連続性を確実に保ちたい場合は、専用ブランチへコミットして永続化する方式もあります（その分ワークフローは長くなります）。
 - **クレジット表記・利用規約** — 合成音声を公開する際の VOICEVOX のクレジット表記など、規約まわりの責任は利用者にあります。詳細は[DISCLAIMER.md](../../DISCLAIMER.md)を参照してください。
+- **移行完了後の片付け** — 旧パスの併記と「Migrate cache layout」ステップは、すべての履歴が新パスへ移った後は不要です（残しても無害ですが）。確認できたらワークフローから両方をまとめて外してください。


### PR DESCRIPTION
関連タスク: [キャッシュパス変更の移行案内を修正する（README のバージョン表記と Actions ガイド）](https://app.todoist.com/app/task/6h8pHXRQj9Xc7q63)

## 概要

ADR-0099（キャッシュを `.vox-radio/programs/{program_id}/cache.jsonl` へ移動）後の移行案内に、利用者が黙って過去回の履歴を失う2件の誤りがあったため修正した。

## 変更内容

- `README.md`: 存在しないバージョン表記「v0.99 以前」を、旧パスを使う最後のリリース「v1.0.5 以前」に修正
- `docs/guides/github-actions-slack.md`:
  - サンプルワークフローに、旧レイアウトのキャッシュを新レイアウトへ移す「Migrate cache layout」ステップを追加（キャッシュ復元の直後、番組生成の前）。冪等（旧ファイルが無ければ何もしない）
  - `actions/cache` のコメントを、「旧パス併記だけで履歴が引き継がれる」と誤読できない文面に修正
  - 「仕組み」「注意事項」節を、移行ステップの動作説明と撤去タイミングの案内が正しく対応するように整理
  - 前提セクションに、移行手順は既存ユーザー向けの一時的な措置であることを追記
- `docs/adr/0099-per-program-state-directory.md`: 「利用者に必要な作業」表の GitHub Actions 行に、移行ステップの必要性を追記（決定・代替案の内容は変更なし）

移行ステップのシェルスクリプトはハイフンを含む `program.id` でも動くこと、複数回実行しても冪等であることを手元で確認済み。

## 関連 Issue

なし

## 確認したこと

- [x] `make test` が通る（`git push` の pre-push フックで実行、全パッケージ green）
- [x] `make lint` が通る（pre-commit フックで対象ファイルなしのためスキップ、変更は Markdown/YAML のみで Go の lint 対象外）
- [x] CLI のコマンド/フラグを変更した場合、`make docs` で `docs/cli/` を再生成した — 該当なし（CLI変更なし）
- [x] 重要な技術判断を含む場合、ADR（`docs/adr/`）を追加した — 該当なし（既存 ADR-0099 の決定内容は変更せず、利用者向け手順の記述不備を補っただけ）
- [x] `doc-structure-checker` / `user-doc-reviewer` サブエージェントによる自己レビューを実施し、指摘（ADR-0099 の表現不整合、コメントの重複、手順順序、前提の網羅性）を反映済み

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpAkaoCFE8FAijJ6tjFWDr)_