### PR TITLE
fix: 単体manifestコマンドがスキップ済みコーナーをmanifestに含める不整合を解消

### DIFF
--- a/docs/cli/vox-radio_episodegen_manifest.md
+++ b/docs/cli/vox-radio_episodegen_manifest.md
@@ -10,6 +10,9 @@
 マニフェストは別の配信サービスが RSS フィードを生成する際に使用することを想定しており、
 フルパイプラインを再実行せずに済みます。
 
+--rundown を指定すると、各コーナーの記事情報が付与され、実際に放送されたコーナー
+（記事なしでスキップされたコーナー・その回に出ないコーナーを除く）だけがマニフェストに載ります。
+
 --lines を指定すると、共通設定ファイルの LLM 設定を使って
 LLM が 03_lines.json（元表記のセリフ）から番組要約・会話メモ・コーナー単位要約を生成してマニフェストに追加します。
 共通設定ファイルのパスは --config フラグで指定します（省略時は vox-radio.yaml）。
@@ -37,7 +40,7 @@ vox-radio episodegen manifest [flags]
   -h, --help              help for manifest
       --lines string      03_lines.json のパス（任意）。指定すると LLM が元表記のセリフから番組要約・会話メモ・コーナー単位要約を生成する
       --out string        manifest.json の出力先パス（必須）
-      --rundown string    02_rundown.json のパス（任意）。省略するとコーナーの記事は空になる
+      --rundown string    02_rundown.json のパス（任意）。指定すると実際に放送されたコーナーだけに絞られる。省略するとコーナーの記事は空になり、仕様のコーナーがすべて並ぶ
       --script string     04_script.json のパス（任意）。指定すると SE アセットのクレジットを自動収集する
       --spec string       エピソード仕様 YAML ファイルのパス（必須）
       --timeline string   06_timeline.json のパス（任意）。指定するとコーナー別の duration_sec をマニフェストに追加する

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -32,6 +32,9 @@ func newManifestCmd() *cobra.Command {
 マニフェストは別の配信サービスが RSS フィードを生成する際に使用することを想定しており、
 フルパイプラインを再実行せずに済みます。
 
+--rundown を指定すると、各コーナーの記事情報が付与され、実際に放送されたコーナー
+（記事なしでスキップされたコーナー・その回に出ないコーナーを除く）だけがマニフェストに載ります。
+
 --lines を指定すると、共通設定ファイルの LLM 設定を使って
 LLM が 03_lines.json（元表記のセリフ）から番組要約・会話メモ・コーナー単位要約を生成してマニフェストに追加します。
 共通設定ファイルのパスは --config フラグで指定します（省略時は vox-radio.yaml）。
@@ -140,9 +143,19 @@ rundown（記事の事実）に含まれない会話情報を幅広く記録し�
 				cornerDurations = tl.Map()
 			}
 
+			// rundown は condition による除外もスキップも反映済みなので、実際に放送された
+			// コーナーだけを載せるための正とする。未指定時は絞り込めないため spec 全件を維持する。
+			manifestCorners := p.Corners
+			if rundownPath != "" {
+				manifestCorners, err = resolveCornersByRundown(p.Corners, rd)
+				if err != nil {
+					return fmt.Errorf("resolve corners: %w", err)
+				}
+			}
+
 			m := manifest.Build(manifest.BuildParams{
 				Program:           p.Program,
-				Corners:           p.Corners,
+				Corners:           manifestCorners,
 				Rundown:           rd,
 				AudioFile:         filepath.Base(audioPath),
 				GeneratedAt:       time.Now().UTC(),
@@ -169,7 +182,7 @@ rundown（記事の事実）に含まれない会話情報を幅広く記録し�
 	}
 
 	registerSpecFlag(cmd, &specPath)
-	cmd.Flags().StringVar(&rundownPath, "rundown", "", "02_rundown.json のパス（任意）。省略するとコーナーの記事は空になる")
+	cmd.Flags().StringVar(&rundownPath, "rundown", "", "02_rundown.json のパス（任意）。指定すると実際に放送されたコーナーだけに絞られる。省略するとコーナーの記事は空になり、仕様のコーナーがすべて並ぶ")
 	cmd.Flags().StringVar(&audioPath, "audio", "", "音声ファイルのパス。ファイル名のみマニフェストに記録される（必須）")
 	cmd.Flags().StringVar(&out, "out", "", "manifest.json の出力先パス（必須）")
 	cmd.Flags().StringVar(&linesPath, "lines", "", "03_lines.json のパス（任意）。指定すると LLM が元表記のセリフから番組要約・会話メモ・コーナー単位要約を生成する")

--- a/internal/cli/manifest.go
+++ b/internal/cli/manifest.go
@@ -65,10 +65,17 @@ rundown（記事の事実）に含まれない会話情報を幅広く記録し�
 			}
 
 			var rd model.Rundown
+			corners := p.Corners
 			if rundownPath != "" {
 				rd, err = readJSON[model.Rundown](rundownPath)
 				if err != nil {
 					return fmt.Errorf("read rundown: %w", err)
+				}
+				// rundown は condition による除外もスキップも反映済みなので、実際に放送された
+				// コーナーを判断する正とする。
+				corners, err = resolveCornersByRundown(p.Corners, rd)
+				if err != nil {
+					return fmt.Errorf("resolve corners: %w", err)
 				}
 			}
 
@@ -143,19 +150,9 @@ rundown（記事の事実）に含まれない会話情報を幅広く記録し�
 				cornerDurations = tl.Map()
 			}
 
-			// rundown は condition による除外もスキップも反映済みなので、実際に放送された
-			// コーナーだけを載せるための正とする。未指定時は絞り込めないため spec 全件を維持する。
-			manifestCorners := p.Corners
-			if rundownPath != "" {
-				manifestCorners, err = resolveCornersByRundown(p.Corners, rd)
-				if err != nil {
-					return fmt.Errorf("resolve corners: %w", err)
-				}
-			}
-
 			m := manifest.Build(manifest.BuildParams{
 				Program:           p.Program,
-				Corners:           manifestCorners,
+				Corners:           corners,
 				Rundown:           rd,
 				AudioFile:         filepath.Base(audioPath),
 				GeneratedAt:       time.Now().UTC(),

--- a/internal/cli/manifest_test.go
+++ b/internal/cli/manifest_test.go
@@ -21,7 +21,8 @@ corners:
     length_sec: 60
 `
 
-// runManifestCmd は 2 コーナー（c1, c2）の spec で manifest コマンドを実行し、生成された manifest を返す。
+// runManifestCmd は manifestTestSpec を spec として manifest コマンドを実行し、生成された manifest を返す。
+// ログ出力先が cwd 相対のため、dir には chdirTemp の戻り値を渡すこと。
 func runManifestCmd(t *testing.T, dir string, extraArgs ...string) model.Manifest {
 	t.Helper()
 
@@ -32,13 +33,14 @@ func runManifestCmd(t *testing.T, dir string, extraArgs ...string) model.Manifes
 	outPath := filepath.Join(dir, "manifest.json")
 
 	args := []string{
+		"episodegen", "manifest",
 		"--spec", specPath,
 		"--audio", filepath.Join(dir, "episode.mp3"),
 		"--out", outPath,
 	}
 	args = append(args, extraArgs...)
 
-	cmd := newManifestCmd()
+	cmd := NewRootCmd()
 	cmd.SetArgs(args)
 	cmd.SetOut(io.Discard)
 	cmd.SetErr(io.Discard)

--- a/internal/cli/manifest_test.go
+++ b/internal/cli/manifest_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/model"
+)
+
+const manifestTestSpec = `program:
+  id: "prog"
+  title: "テスト番組"
+corners:
+  - id: "c1"
+    title: "コーナー1"
+    length_sec: 30
+  - id: "c2"
+    title: "コーナー2"
+    length_sec: 60
+`
+
+// runManifestCmd は 2 コーナー（c1, c2）の spec で manifest コマンドを実行し、生成された manifest を返す。
+func runManifestCmd(t *testing.T, dir string, extraArgs ...string) model.Manifest {
+	t.Helper()
+
+	specPath := filepath.Join(dir, "episode-spec.yaml")
+	if err := os.WriteFile(specPath, []byte(manifestTestSpec), 0644); err != nil {
+		t.Fatalf("write spec: %v", err)
+	}
+	outPath := filepath.Join(dir, "manifest.json")
+
+	args := []string{
+		"--spec", specPath,
+		"--audio", filepath.Join(dir, "episode.mp3"),
+		"--out", outPath,
+	}
+	args = append(args, extraArgs...)
+
+	cmd := newManifestCmd()
+	cmd.SetArgs(args)
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute manifest: %v", err)
+	}
+
+	m, err := readJSON[model.Manifest](outPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	return m
+}
+
+// A corner skipped by the rundown was never broadcast, so it must not appear in the manifest
+// as a 0-second corner with no articles.
+func TestManifestCmd_ExcludesCornersMissingFromRundown(t *testing.T) {
+	dir := chdirTemp(t)
+
+	rundownPath := filepath.Join(dir, "02_rundown.json")
+	rd := model.Rundown{Corners: []model.RundownCorner{{ID: "c1", Title: "コーナー1"}}}
+	if err := writeJSON(rundownPath, rd); err != nil {
+		t.Fatalf("write rundown: %v", err)
+	}
+
+	m := runManifestCmd(t, dir, "--rundown", rundownPath)
+
+	if len(m.Corners) != 1 || m.Corners[0].ID != "c1" {
+		t.Errorf("Corners = %+v, want 1 entry for c1 (skipped c2 must not appear)", m.Corners)
+	}
+}
+
+func TestManifestCmd_WithoutRundownKeepsAllSpecCorners(t *testing.T) {
+	dir := chdirTemp(t)
+
+	m := runManifestCmd(t, dir)
+
+	if len(m.Corners) != 2 || m.Corners[0].ID != "c1" || m.Corners[1].ID != "c2" {
+		t.Errorf("Corners = %+v, want c1 and c2 (spec order)", m.Corners)
+	}
+}


### PR DESCRIPTION
関連タスク: [単体 manifest コマンドがスキップ済みコーナーを manifest に含める不整合を解消する](https://app.todoist.com/app/task/6h8vFgrfjG4V8pQ3)

## 概要

単体 `episodegen manifest` コマンドが `p.Corners`（spec の全コーナー）をそのまま `manifest.Build` へ渡していたため、実際には放送されていないコーナー（`skip_if_no_articles` でスキップされたもの・`condition` でその回に出ないもの）が manifest の `corners[]` に載っていました。`target_sec` だけが入り `speech_sec` / `duration_sec` / `char_count` は 0、記事参照も空のエントリになります。

`--rundown` 指定時は rundown に含まれるコーナーだけを渡すようにして解消します。rundown には `condition` 除外もスキップも反映済みのため、これ1つで両方をカバーできます。

PR #558（analyze 側の同種修正）のスコープ外として分離していた残りの対応です。本体パイプライン（`internal/pipeline/pipeline.go`）は `filterCornersInRundown` 済みのコーナーを渡しており、もともと影響はありません。

## 変更内容

- `internal/cli/manifest.go`: `--rundown` 指定時に `resolveCornersByRundown` でコーナーを絞り込み、その結果を `manifest.Build` に渡す。`--rundown` 未指定時は絞り込めないため従来どおり spec 全件を維持（フラグは任意のまま）
- `internal/cli/manifest.go`: `--rundown` のヘルプ文言と `Long` 説明に、指定すると実際に放送されたコーナーだけに絞られる旨を追記
- `docs/cli/vox-radio_episodegen_manifest.md`: `make docs` による再生成
- `internal/cli/manifest_test.go`: 回帰テストを新規追加（rundown に `c1` のみ含む場合に `corners[]` が `c1` の1件になること／`--rundown` 省略時は spec の2件がそのまま並ぶこと）

## 関連 Issue

なし（タスク管理は Todoist）

## 確認したこと

- [x] `make test` が通る
- [x] `make lint` が通る
- [x] CLI のコマンド/フラグを変更した場合、`make docs` で `docs/cli/` を再生成した
- [x] 重要な技術判断を含む場合、ADR（`docs/adr/`）を追加した → 対象外。pipeline が既に採っている方針への実装追随であり、新規の設計判断を含まないため作成していません（#558 と同じ判断）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VWHMUsfp4GLxuCsxWzJ7cv)_