### PR TITLE
test: config構造体のyamlフィールドとreferencesの記載漏れを検知するテストを追加

### DIFF
--- a/.claude/rules/config-references.md
+++ b/.claude/rules/config-references.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "internal/config/**/*.go"
+---
+
+# 設定スキーマ↔referencesドキュメント反映ルール
+
+`internal/config/**/*.go` の構造体フィールド（yaml タグ）を追加・変更・削除したときは、対応する `internal/cli/skills/vox-radio/references/*.md` を同じコミットで更新すること。
+
+## 対応表（どの構造体がどの references を正とするか）
+
+| ルート構造体 | 対応ドキュメント |
+|---|---|
+| `Config`（`vox-radio.yaml`） | `references/vox-radio.md` |
+| `EpisodeSpec`（`episode-spec.yaml`） | `references/episode-spec.md` |
+| `AssetsConfig`（アセット設定YAML） | `references/assets.md` |
+
+## 実施手順
+
+1. 変更したフィールドについて、対応する references の表に行を追加/更新/削除する（型・必須任意・デフォルト値・効果を明記）。
+2. `go test ./internal/config/...` を実行し、`TestConfigFieldsDocumentedInReferences` が通ることを確認する（yaml タグ名が references に `` `field_name` `` の形式で記載されているかを機械的に突き合わせるテスト）。
+3. 意図的にドキュメント化しないフィールド（内部専用等）がある場合は、`internal/config/references_test.go` の `refDocAllowlist` に理由コメント付きで追加する（テストをスキップさせるだけの対処はしない）。
+
+このテストは表への記載有無のみを見る粗いチェックのため、内容の正確さ（デフォルト値・説明文の妥当性）は上記1で目視確認すること。

--- a/internal/config/references_test.go
+++ b/internal/config/references_test.go
@@ -1,0 +1,106 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/vox-radio/internal/config"
+)
+
+// refDocAllowlist lists yaml field names that are intentionally undocumented in a
+// given reference file (e.g. internal-only fields with no user-facing meaning).
+// Add entries here with a reason comment instead of silently skipping the check.
+var refDocAllowlist = map[string]map[string]string{
+	"vox-radio.md":    {},
+	"episode-spec.md": {},
+	"assets.md":       {},
+}
+
+// collectYAMLFieldNames walks t (following pointers, slices, arrays, and map values)
+// and collects every yaml tag name found on struct fields. visited guards against
+// infinite recursion on self-referential types (e.g. EpisodeCondition.Not).
+func collectYAMLFieldNames(t reflect.Type, names map[string]bool, visited map[reflect.Type]bool) {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	switch t.Kind() {
+	case reflect.Struct:
+		if visited[t] {
+			return
+		}
+		visited[t] = true
+		for i := 0; i < t.NumField(); i++ {
+			f := t.Field(i)
+			tag, ok := f.Tag.Lookup("yaml")
+			if !ok {
+				continue
+			}
+			name, _, _ := strings.Cut(tag, ",")
+			if name == "" || name == "-" {
+				continue
+			}
+			names[name] = true
+			collectYAMLFieldNames(f.Type, names, visited)
+		}
+	case reflect.Slice, reflect.Array, reflect.Map:
+		collectYAMLFieldNames(t.Elem(), names, visited)
+	}
+}
+
+// TestConfigFieldsDocumentedInReferences は internal/config の設定構造体が持つ全 yaml
+// フィールド名を、対応する references/*.md にバックティック表記（例: `field_name`）で
+// 記載されているかを突き合わせる。未記載フィールドがあれば、references の更新漏れ
+// （PR #548 のような事象）として検知する。
+//
+// 意図的にドキュメント化しないフィールドがある場合は、削除するのではなく
+// refDocAllowlist に理由付きで追加すること。
+func TestConfigFieldsDocumentedInReferences(t *testing.T) {
+	roots := []struct {
+		typ     reflect.Type
+		docFile string
+	}{
+		{reflect.TypeOf(config.Config{}), "vox-radio.md"},
+		{reflect.TypeOf(config.EpisodeSpec{}), "episode-spec.md"},
+		{reflect.TypeOf(config.AssetsConfig{}), "assets.md"},
+	}
+
+	for _, root := range roots {
+		t.Run(root.docFile, func(t *testing.T) {
+			fields := map[string]bool{}
+			collectYAMLFieldNames(root.typ, fields, map[reflect.Type]bool{})
+
+			docPath := filepath.Join("..", "cli", "skills", "vox-radio", "references", root.docFile)
+			content, err := os.ReadFile(docPath)
+			if err != nil {
+				t.Fatalf("reading %s: %v", docPath, err)
+			}
+			doc := string(content)
+			allowed := refDocAllowlist[root.docFile]
+
+			names := make([]string, 0, len(fields))
+			for name := range fields {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+
+			var missing []string
+			for _, name := range names {
+				if _, ok := allowed[name]; ok {
+					continue
+				}
+				if !strings.Contains(doc, "`"+name+"`") {
+					missing = append(missing, name)
+				}
+			}
+			if len(missing) > 0 {
+				t.Errorf("%s に未記載のフィールドがあります（表に `フィールド名` の形式で追記するか、意図的なら refDocAllowlist に理由付きで追加してください）: %s",
+					docPath, strings.Join(missing, ", "))
+			}
+		})
+	}
+}


### PR DESCRIPTION
関連タスク: [設定スキーマ↔リファレンスの乖離を防ぐ仕組みを整備する（網羅テスト＋反映ルール）](https://app.todoist.com/app/task/6h49vJmmx9q5gq23)

## 概要

PR #548 で、config構造体にはあるのに `internal/cli/skills/vox-radio/references/*.md` に未記載だったフィールド（`program.timezone` / `corners[].skip_if_no_articles` / `slack.bot_token_env`）が3件見つかった。これはconfig構造体→referencesの反映を促す/検証する仕組みがないという構造的ギャップが原因だった。本PRでは、この乖離をCIで機械的に検知するテストと、更新時のルールを整備する。

## 変更内容

- `internal/config/references_test.go`: `internal/config` のルート構造体（`Config` / `EpisodeSpec` / `AssetsConfig`）を reflection で再帰的に走査し、全 yaml タグ名が対応する `references/*.md`（`vox-radio.md` / `episode-spec.md` / `assets.md`）にバックティック表記（`` `field_name` ``）で記載されているかを突き合わせるテストを追加
  - 意図的に非公開にしたいフィールド向けに `refDocAllowlist`（理由コメント付き）による除外機構を用意
  - フィールド名がテーブルに存在するかの粗いチェックから開始（内容の正確さまでは検証しない）
- `.claude/rules/config-references.md`: `internal/config/**/*.go` を変更したときに対応する references を同じコミットで更新するルールを追加。config構造体→references の対応表・実施手順・allowlist運用を明文化

## 関連 Issue

なし（Todoist タスク管理）

## 確認したこと

- [x] `make test` が通る
- [x] `make lint` が通る（`golangci-lint run ./internal/config/...` で 0 issues）
- [x] CLI のコマンド/フラグの変更なし（`make docs` 不要）
- [x] 重要な技術判断ではなくテスト・ルール整備のため ADR 追加は不要と判断
- [x] 意図的にテスト削除・doc削除で検知できることを手動確認（`timezone` の記載を一時的に消してテストが失敗することを確認済み）

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JF6aKYiSnSHjYVtK65STnw)_