### PR TITLE
feat: 429のサーバー指示待機時間を尊重してリトライする（ADR-0101実装）

### DIFF
--- a/internal/httpretry/retrydelay.go
+++ b/internal/httpretry/retrydelay.go
@@ -1,0 +1,110 @@
+package httpretry
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// maxRetryInfoBodyBytes caps how much of a 429 response body is read while
+// looking for a RetryInfo delay, so a huge or unbounded body can't be forced
+// into memory.
+const maxRetryInfoBodyBytes = 64 * 1024
+
+// retryInfoType is the Google RetryInfo detail's @type discriminator.
+const retryInfoType = "type.googleapis.com/google.rpc.RetryInfo"
+
+// extractServerDelay reads a server-instructed retry delay from resp: the
+// Retry-After header takes priority, then the response body's Google
+// RetryInfo detail. If the body must be read to look for RetryInfo, it is
+// restored onto resp.Body afterward so the caller can still read it.
+// Returns ok=false if no instruction was found.
+func extractServerDelay(resp *http.Response) (time.Duration, bool) {
+	if d, ok := retryDelayFromHeader(resp.Header.Get("Retry-After")); ok {
+		return d, true
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxRetryInfoBodyBytes))
+	// Drain any remainder so the underlying connection can be reused; Close
+	// alone would abandon it if the body exceeded maxRetryInfoBodyBytes.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+
+	return retryDelayFromBody(body)
+}
+
+// retryDelayFromHeader parses a Retry-After header value, which is either a
+// number of seconds or an HTTP-date.
+func retryDelayFromHeader(v string) (time.Duration, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return 0, false
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0, false
+		}
+		return time.Duration(secs) * time.Second, true
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d, true
+		}
+		return 0, true
+	}
+	return 0, false
+}
+
+// retryInfoDetail is one entry of a Google API error's details[] array.
+type retryInfoDetail struct {
+	Type       string `json:"@type"`
+	RetryDelay string `json:"retryDelay"`
+}
+
+// googleErrorBody is a Google API error response, e.g. Gemini's.
+type googleErrorBody struct {
+	Error struct {
+		Details []retryInfoDetail `json:"details"`
+	} `json:"error"`
+}
+
+// retryDelayFromBody looks for a Google RetryInfo detail in a 429 response
+// body. Both the plain object form ({"error": {...}}) and the array-wrapped
+// form ([{"error": {...}}], used by Gemini's OpenAI-compatible endpoint) are
+// supported.
+func retryDelayFromBody(body []byte) (time.Duration, bool) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return 0, false
+	}
+
+	var details []retryInfoDetail
+	if trimmed[0] == '[' {
+		var wrapped []googleErrorBody
+		if err := json.Unmarshal(trimmed, &wrapped); err != nil || len(wrapped) == 0 {
+			return 0, false
+		}
+		details = wrapped[0].Error.Details
+	} else {
+		var parsed googleErrorBody
+		if err := json.Unmarshal(trimmed, &parsed); err != nil {
+			return 0, false
+		}
+		details = parsed.Error.Details
+	}
+
+	for _, d := range details {
+		if d.Type != retryInfoType {
+			continue
+		}
+		if dur, err := time.ParseDuration(d.RetryDelay); err == nil && dur >= 0 {
+			return dur, true
+		}
+	}
+	return 0, false
+}

--- a/internal/httpretry/retrydelay_test.go
+++ b/internal/httpretry/retrydelay_test.go
@@ -1,0 +1,92 @@
+package httpretry
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRetryDelayFromHeader(t *testing.T) {
+	cases := []struct {
+		name      string
+		value     string
+		wantOK    bool
+		wantDelay time.Duration
+	}{
+		{"empty", "", false, 0},
+		{"seconds", "51", true, 51 * time.Second},
+		{"zero seconds", "0", true, 0},
+		{"negative seconds", "-1", false, 0},
+		{"garbage", "not-a-value", false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ok := retryDelayFromHeader(tc.value)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && d != tc.wantDelay {
+				t.Fatalf("delay = %v, want %v", d, tc.wantDelay)
+			}
+		})
+	}
+}
+
+func TestRetryDelayFromHeader_HTTPDateInPast(t *testing.T) {
+	past := time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat)
+	d, ok := retryDelayFromHeader(past)
+	if !ok {
+		t.Fatal("expected ok=true for a past HTTP-date (treated as no wait)")
+	}
+	if d != 0 {
+		t.Fatalf("delay = %v, want 0 for a past date", d)
+	}
+}
+
+func TestRetryDelayFromBody(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		wantOK    bool
+		wantDelay time.Duration
+	}{
+		{
+			name:      "object form",
+			body:      `{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"51s"}]}}`,
+			wantOK:    true,
+			wantDelay: 51 * time.Second,
+		},
+		{
+			name:      "array-wrapped form",
+			body:      `[{"error":{"details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"31.5s"}]}}]`,
+			wantOK:    true,
+			wantDelay: 31500 * time.Millisecond,
+		},
+		{
+			name:   "no matching detail type",
+			body:   `{"error":{"details":[{"@type":"type.googleapis.com/other.Thing","retryDelay":"51s"}]}}`,
+			wantOK: false,
+		},
+		{
+			name:   "empty body",
+			body:   ``,
+			wantOK: false,
+		},
+		{
+			name:   "not json",
+			body:   `plain text error`,
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, ok := retryDelayFromBody([]byte(tc.body))
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if ok && d != tc.wantDelay {
+				t.Fatalf("delay = %v, want %v", d, tc.wantDelay)
+			}
+		})
+	}
+}

--- a/internal/httpretry/transport.go
+++ b/internal/httpretry/transport.go
@@ -1,5 +1,6 @@
 // Package httpretry provides an http.RoundTripper that retries requests which
-// fail with retryable HTTP status codes (5xx and 429) using exponential backoff.
+// fail with retryable HTTP status codes (5xx and 429) using exponential backoff,
+// honoring a server-supplied retry delay when present.
 //
 // Use NewClient to build a retry-enabled *http.Client, or wrap an existing
 // client's Transport with NewTransport. Either way requests become resilient
@@ -7,6 +8,7 @@
 package httpretry
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"time"
@@ -19,16 +21,26 @@ const (
 	defaultBaseDelay = 1 * time.Second
 	// defaultMaxDelay caps the per-attempt backoff wait.
 	defaultMaxDelay = 8 * time.Second
+	// maxServerDelay is the longest server-instructed retry wait we honor.
+	// A longer instruction is treated as unrecoverable within a single call
+	// and returned to the caller instead of retried (see ADR-0101).
+	maxServerDelay = 60 * time.Second
 )
 
 // Transport is an http.RoundTripper that retries retryable responses
-// (HTTP 5xx and 429) with exponential backoff. The backoff parameters are
-// fixed at construction time via NewTransport.
+// (HTTP 5xx and 429) with exponential backoff. On a 429 it honors a
+// server-supplied retry delay (Retry-After header, then the response body's
+// RetryInfo) in place of the backoff when present. The backoff parameters
+// are fixed at construction time via NewTransport.
 type Transport struct {
 	base       http.RoundTripper
 	maxRetries int
 	baseDelay  time.Duration
 	maxDelay   time.Duration
+	// perAttemptTimeout, when non-zero, bounds each individual attempt via
+	// its own context so a long server-instructed wait between attempts
+	// doesn't count against it. Set by NewClient.
+	perAttemptTimeout time.Duration
 }
 
 // NewTransport wraps base with retry logic using fixed backoff settings.
@@ -46,28 +58,28 @@ func NewTransport(base http.RoundTripper) *Transport {
 }
 
 // NewClient returns an *http.Client whose Transport retries 5xx/429 responses
-// with exponential backoff. If timeout > 0 it is set as the client's timeout.
-// Use this so every retry-enabled client is constructed the same way.
+// with exponential backoff (or a server-instructed delay, see ADR-0101).
+// timeout, if > 0, bounds each individual attempt rather than the whole
+// call, since the whole call may legitimately include a long retry wait.
 func NewClient(timeout time.Duration) *http.Client {
-	c := &http.Client{Transport: NewTransport(nil)}
-	if timeout > 0 {
-		c.Timeout = timeout
-	}
-	return c
+	tr := NewTransport(nil)
+	tr.perAttemptTimeout = timeout
+	return &http.Client{Transport: tr}
 }
 
 // RoundTrip implements http.RoundTripper. It retries the request while the
-// response status is retryable and attempts remain, waiting with exponential
-// backoff between tries. A non-nil transport error is returned immediately
-// (the underlying transport already handles connection-level retries).
+// response status is retryable and attempts remain, waiting between tries.
+// On 429 it prefers a server-instructed delay over the exponential backoff;
+// a non-nil transport error is returned immediately (the underlying
+// transport already handles connection-level retries).
 func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var delay time.Duration
 	for attempt := 0; ; attempt++ {
 		reqToSend := req
 		if attempt > 0 {
-			if err := t.wait(req, attempt); err != nil {
+			if err := t.wait(req, delay); err != nil {
 				return nil, err
 			}
-			// Rebuild the body for the retry; the first attempt sends req as-is.
 			clone, err := cloneRequest(req)
 			if err != nil {
 				return nil, err
@@ -75,7 +87,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			reqToSend = clone
 		}
 
-		resp, err := t.base.RoundTrip(reqToSend)
+		resp, err := t.roundTripAttempt(reqToSend)
 		if err != nil {
 			return nil, err
 		}
@@ -84,16 +96,61 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			return resp, nil
 		}
 
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if serverDelay, ok := extractServerDelay(resp); ok {
+				if serverDelay > maxServerDelay {
+					return resp, nil
+				}
+				delay = serverDelay
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+				continue
+			}
+		}
+
+		delay = t.backoff(attempt + 1)
 		// Will retry: drain and close the body so the connection can be reused.
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}
 }
 
-// wait sleeps for the backoff duration of the given attempt, returning early
-// with the context error if the request context is cancelled.
-func (t *Transport) wait(req *http.Request, attempt int) error {
-	timer := time.NewTimer(t.backoff(attempt))
+// roundTripAttempt performs a single attempt, applying perAttemptTimeout to
+// its own context when set. The returned response's body cancels that
+// context on Close, once the caller (or the retry loop) is done with it.
+func (t *Transport) roundTripAttempt(req *http.Request) (*http.Response, error) {
+	if t.perAttemptTimeout <= 0 {
+		return t.base.RoundTrip(req)
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), t.perAttemptTimeout)
+	resp, err := t.base.RoundTrip(req.WithContext(ctx))
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	resp.Body = &cancelOnCloseBody{ReadCloser: resp.Body, cancel: cancel}
+	return resp, nil
+}
+
+// cancelOnCloseBody cancels an attempt's per-attempt context once its body
+// is closed, so the context is released whether the response is consumed
+// by the caller or drained by the retry loop.
+type cancelOnCloseBody struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnCloseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
+}
+
+// wait sleeps for delay, returning early with the context error if the
+// request context is cancelled.
+func (t *Transport) wait(req *http.Request, delay time.Duration) error {
+	timer := time.NewTimer(delay)
 	defer timer.Stop()
 	select {
 	case <-timer.C:

--- a/internal/httpretry/transport_test.go
+++ b/internal/httpretry/transport_test.go
@@ -199,17 +199,245 @@ func TestRoundTrip_ContextCancelledDuringBackoff(t *testing.T) {
 	}
 }
 
-func TestNewClient_AttachesRetryTransportAndTimeout(t *testing.T) {
-	c := NewClient(5 * time.Second)
-	if c.Timeout != 5*time.Second {
-		t.Fatalf("timeout = %v, want 5s", c.Timeout)
+func TestRoundTrip_HonorsRetryAfterHeaderSeconds(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := NewTransport(nil)
+	// Backoff is deliberately slow; a fast response proves the header (not
+	// the backoff) governed the wait.
+	tr.baseDelay = time.Second
+	tr.maxDelay = time.Second
+
+	start := time.Now()
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, ok := c.Transport.(*Transport); !ok {
-		t.Fatalf("transport type = %T, want *Transport", c.Transport)
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("calls = %d, want 2", got)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("took %v, want well under the 1s backoff (Retry-After: 0 should have governed the wait)", elapsed)
+	}
+}
+
+func TestRoundTrip_HonorsRetryAfterHeaderHTTPDate(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.Header().Set("Retry-After", time.Now().Add(50*time.Millisecond).UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := NewTransport(nil)
+	tr.baseDelay = time.Second
+	tr.maxDelay = time.Second
+
+	start := time.Now()
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("took %v, want well under the 1s backoff (Retry-After date should have governed the wait)", elapsed)
+	}
+}
+
+func TestRoundTrip_HonorsRetryInfoInBody(t *testing.T) {
+	const body = `{"error":{"code":429,"message":"rate limited","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"0.05s"}]}}`
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, body)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := NewTransport(nil)
+	tr.baseDelay = time.Second
+	tr.maxDelay = time.Second
+
+	start := time.Now()
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("took %v, want well under the 1s backoff (body RetryInfo should have governed the wait)", elapsed)
+	}
+}
+
+func TestRoundTrip_HonorsRetryInfoInArrayWrappedBody(t *testing.T) {
+	const body = `[{"error":{"code":429,"message":"rate limited","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"0.05s"}]}}]`
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = io.WriteString(w, body)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	tr := NewTransport(nil)
+	tr.baseDelay = time.Second
+	tr.maxDelay = time.Second
+
+	client := &http.Client{Transport: tr}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("calls = %d, want 2", got)
+	}
+}
+
+func TestRoundTrip_DoesNotRetryWhenServerDelayExceedsLimit(t *testing.T) {
+	const body = `{"error":{"code":429,"message":"rate limited","details":[{"@type":"type.googleapis.com/google.rpc.RetryInfo","retryDelay":"61s"}]}}`
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, body)
+	}))
+	defer srv.Close()
+
+	client := &http.Client{Transport: newFastTransport()}
+	resp, err := client.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("calls = %d, want 1 (no retry once the instructed delay exceeds the limit)", got)
 	}
 
-	if c0 := NewClient(0); c0.Timeout != 0 {
-		t.Fatalf("timeout = %v, want 0 (unset)", c0.Timeout)
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(got) != body {
+		t.Fatalf("body = %q, want %q (body must be restored for the caller)", got, body)
+	}
+}
+
+func TestRoundTrip_PerAttemptTimeoutAppliesToEachAttempt(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(10 * time.Millisecond)
+	c.Transport.(*Transport).maxRetries = 0 // isolate a single attempt
+
+	_, err := c.Get(srv.URL)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestRoundTrip_PerAttemptTimeoutExcludesRetryWait(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClient(80 * time.Millisecond)
+	tr := c.Transport.(*Transport)
+	tr.baseDelay = 60 * time.Millisecond
+	tr.maxDelay = 60 * time.Millisecond
+	tr.maxRetries = 2
+
+	start := time.Now()
+	resp, err := c.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("calls = %d, want 3", got)
+	}
+	// Total retry wait (2 * 60ms = 120ms) exceeds perAttemptTimeout (80ms);
+	// this must still succeed because the timeout bounds each attempt, not the whole call.
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("elapsed = %v, want >= 100ms (retry waits should not be cut short)", elapsed)
+	}
+}
+
+func TestNewClient_AttachesRetryTransportWithPerAttemptTimeout(t *testing.T) {
+	c := NewClient(5 * time.Second)
+	if c.Timeout != 0 {
+		t.Fatalf("client.Timeout = %v, want 0 (timeout applies per attempt, not to the whole call)", c.Timeout)
+	}
+	tr, ok := c.Transport.(*Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *Transport", c.Transport)
+	}
+	if tr.perAttemptTimeout != 5*time.Second {
+		t.Fatalf("perAttemptTimeout = %v, want 5s", tr.perAttemptTimeout)
+	}
+
+	c0 := NewClient(0)
+	if got := c0.Transport.(*Transport).perAttemptTimeout; got != 0 {
+		t.Fatalf("perAttemptTimeout = %v, want 0 (unset)", got)
 	}
 }
 


### PR DESCRIPTION
関連タスク: [429レスポンスのサーバー指示待機時間（Retry-After / RetryInfo）を尊重してリトライする](https://app.todoist.com/app/task/6hC7pjGFXjwvj8wV)

## 概要

vox-radio-broadcast の番組生成が Gemini API の 429（レート制限）で失敗した際、レスポンスに含まれる「51秒後に再試行せよ」という待機指示（`Retry-After` ヘッダ / 本文の `google.rpc.RetryInfo`）を `internal/httpretry` が一切参照せず、固定の指数バックオフ（最大7秒）で諦めていた問題を修正する。方針は ADR-0101（PR #567 で追加済み）のとおり実装した。

## 変更内容

- `internal/httpretry/retrydelay.go`（新規）: 429 レスポンスから待機指示を抽出する `extractServerDelay`
  - `Retry-After` ヘッダ（秒数形式 / HTTP-date 形式）を優先
  - ヘッダがなければ本文の Google RetryInfo (`error.details[].retryDelay`) を読む。通常のオブジェクト形式と、Gemini の OpenAI 互換エンドポイントが返す `[{"error": {...}}]` の配列ラップ形式の両方に対応
  - 本文の読み込みは `io.LimitReader`（64KiB）で上限を設け、読み取り後は `resp.Body` に復元して呼び出し元が読めるようにする
- `internal/httpretry/transport.go`:
  - 429 で待機指示が見つかり 60 秒以内ならその時間だけ待ってリトライ（指数バックオフより優先）。60 秒を超える指示ならリトライせず 429 をそのまま返す
  - 指示のない 429 / 5xx は従来どおりの指数バックオフ
  - `NewClient(timeout)` の `timeout` を「クライアント全体のタイムアウト」から「1試行あたりのタイムアウト」に変更（`perAttemptTimeout`）。各試行を `context.WithTimeout` でラップし、レスポンスの `Body` を `cancelOnCloseBody`（Close 時に context を cancel するラッパー）で包むことで、リトライの待機時間がタイムアウトに含まれないようにした
  - 呼び出し側（`internal/script/llm/client.go` / `internal/synth/client.go` / `internal/gather/gather.go`）は無変更で成立する（`go build ./...` / `go test ./...` で確認済み）
- テスト追加（`transport_test.go` / `retrydelay_test.go`）: ヘッダ/本文（配列ラップ含む）の待機指示尊重、60秒超過時の非リトライとボディ復元、per-attempt タイムアウトが試行単位で効きリトライ待機を含まないこと、パース境界値（0秒・負値・不正JSON・`@type` 不一致）を検証

自己レビュー（別エージェントによる独立レビュー）を実施し、`cancelOnCloseBody` のリーク・二重cancel、`resp.Body` 復元の全経路、`cloneRequest` との合成、データ競合、5xx への影響を確認。指摘のあった「本文が64KiBを超えた場合に接続が再利用されない」点は軽微な効率改善として反映済み（`retrydelay.go` で drain してから Close）。

## 関連 Issue

なし

## 確認したこと

- [x] `go test ./...` が通る
- [x] `make lint` が通る — ローカルのサンドボックス環境では `golangci-lint` バイナリが go1.25 ビルドで `go.mod`（go1.26.1）との互換チェックに失敗し実行できなかったため、`gofmt -l .` / `go vet ./...` の通過のみ確認してコミットした。**CI の `build` ジョブ（`make lint` を含む）で成功を確認済み**
- [x] CLI のコマンド/フラグの変更なし（`make docs` 不要）
- [x] 重要な技術判断は ADR-0101（PR #567）にて記録済み。本 PR はその実装のため新規 ADR は追加していない

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)