### PR TITLE
fix: golangci-lintのインストールをAPI非依存の直接DLに変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ GOBIN ?= $(shell go env GOPATH)/bin
 
 setup:
 	# go install（ソースからビルド）は遅いため、ビルド済みバイナリを取得する。
-	# golangci-lint: 公式 install.sh がチェックサム検証込みでバイナリを配置する。
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(GOBIN) $(GOLANGCI_LINT_VERSION)
+	# golangci-lint: GitHub Releases のバイナリを取得する（公式 install.sh は api.github.com
+	#   経由のタグ解決に依存し、GitHub API アクセスがリポジトリ単位に制限された環境では失敗するため使わない）。
+	./scripts/install-golangci-lint.sh $(GOLANGCI_LINT_VERSION) $(GOBIN)
 	# lefthook: GitHub Releases のバイナリを取得する（goreleaser は release-check で都度取得）。
 	./scripts/install-lefthook.sh $(LEFTHOOK_VERSION) $(GOBIN)
 	$(GOBIN)/lefthook install

--- a/docs/adr/0102-golangci-lint-install-without-github-api.md
+++ b/docs/adr/0102-golangci-lint-install-without-github-api.md
@@ -1,0 +1,25 @@
+# 0102. golangci-lint のインストールを GitHub API 非依存にする
+
+- ステータス: 採用
+- 日付: 2026-08-03
+
+## コンテキスト
+
+golangci-lint は自身をビルドした Go のバージョンが対象プロジェクトの `go.mod` の `go` ディレクティブより低いと実行を拒否する。`go.mod` は `go 1.26.1` を要求しており、Makefile は互換バージョン（`v2.12.2`、公式バイナリは go1.26.2 ビルド）を指定済みだった。
+
+しかし `make setup` は golangci-lint の公式 `install.sh` を使っており、これは `api.github.com` でタグ・チェックサム情報を解決する。GitHub アクセスが対象リポジトリ（`canpok1/vox-radio`）のみに制限される Claude Code のリモートセッションでは、golangci-lint リポジトリへの `api.github.com` 呼び出しが 403 になり `make setup` が失敗する。結果、コンテナに元から入っている古い golangci-lint（go1.25 ビルド）が使われ続け、バージョン不一致エラーが多発していた。
+
+## 決定
+
+`install.sh` を使うのをやめ、GitHub Releases のアセット（tarball と checksums.txt）を `api.github.com` を経由しない直接 URL（`github.com/<repo>/releases/download/...`）から取得し、sha256 検証してから配置するスクリプト `scripts/install-golangci-lint.sh` に置き換えた。既存の `scripts/install-lefthook.sh` と同じ設計。
+
+SessionStart フック（ADR-0084）は `make setup` を呼ぶだけなので、追加変更なしでこの対策の恩恵を受ける。
+
+## 結果
+
+Claude Code のリモートセッションでも `make setup` / `golangci-lint run` が成功するようになった。直接ダウンロード方式は通常の開発機・GitHub Actions CI でも同様に動作するため、退行はない。今後 `go.mod` の `go` バージョンを上げる際は、`GOLANGCI_LINT_VERSION` もビルド Go バージョンが対応するものへ追従して更新する必要がある。
+
+## 検討した代替案
+
+- **`go install` + `GOTOOLCHAIN` 固定**: ソースビルドのため 60〜90 秒かかり、`GOTOOLCHAIN` を `go.mod` のバージョンへ追従させる仕組みが別途必要で複雑なため却下。
+- **`go.mod` の `go` ディレクティブを据え置く**: 根本原因（インストール手段の GitHub API 依存）を残したままの回避策であり、Go の新バージョン採用自体を制約するため却下。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -107,3 +107,4 @@
 | [0099](0099-per-program-state-directory.md) | 番組ごとの状態を `.vox-radio/programs/{program_id}/` へ集約する | 採用 | 2026-07-27 |
 | [0100](0100-deprecate-length-sec-for-target-chars.md) | corners[].target_chars を新設し、length_sec / chars_per_minute を段階的に非推奨化する | 採用 | 2026-07-29 |
 | [0101](0101-honor-server-retry-delay-and-per-attempt-timeout.md) | 429 のサーバー指示待機時間を尊重し、リトライのタイムアウトを試行単位にする（ADR-0051 改訂） | 採用 | 2026-08-02 |
+| [0102](0102-golangci-lint-install-without-github-api.md) | golangci-lint のインストールを GitHub API 非依存にする | 採用 | 2026-08-03 |

--- a/scripts/install-golangci-lint.sh
+++ b/scripts/install-golangci-lint.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# golangci-lint のビルド済みバイナリを GitHub Releases から取得して BIN_DIR に配置する。
+#
+# `make setup` から呼ばれる開発用スクリプト。
+# 公式 install.sh は api.github.com 経由でタグ解決を行うため、GitHub API アクセスが
+# リポジトリ単位に制限された環境（Claude Code のリモートセッション等）では 403 になり失敗する。
+# そのため release アセットを直接 URL 指定でダウンロードする方式にしている。
+#
+# 使い方:
+#   scripts/install-golangci-lint.sh <version> <bin_dir>
+#   例: scripts/install-golangci-lint.sh v2.12.2 "$(go env GOPATH)/bin"
+set -euo pipefail
+
+REPO="golangci/golangci-lint"
+
+VERSION="${1:-}"
+BIN_DIR="${2:-}"
+
+if [[ -z "$VERSION" || -z "$BIN_DIR" ]]; then
+  echo "Usage: $0 <version> <bin_dir>" >&2
+  echo "  例: $0 v2.12.2 \"\$(go env GOPATH)/bin\"" >&2
+  exit 1
+fi
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "ERROR: $1 が必要です" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+require_cmd tar
+
+# sha256 検証コマンドを選択
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA256CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA256CMD="shasum -a 256"
+else
+  echo "ERROR: sha256sum または shasum が必要です" >&2
+  exit 1
+fi
+
+# ---- OS・arch 判定（golangci-lint のアセット命名規則に合わせる） ----
+os_raw="$(uname -s)"
+case "$os_raw" in
+  Linux)  OS="linux" ;;
+  Darwin) OS="darwin" ;;
+  *)
+    echo "ERROR: 未対応の OS: $os_raw (Linux / macOS のみサポート)" >&2
+    exit 1
+    ;;
+esac
+
+arch_raw="$(uname -m)"
+case "$arch_raw" in
+  x86_64 | amd64)   ARCH="amd64" ;;
+  aarch64 | arm64)  ARCH="arm64" ;;
+  *)
+    echo "ERROR: 未対応の arch: $arch_raw (x86_64 / arm64 のみサポート)" >&2
+    exit 1
+    ;;
+esac
+
+# VERSION から先頭 "v" を除いたもの（アセット・checksums ファイル名用）
+VERSION_NUM="${VERSION#v}"
+
+ASSET_DIR="golangci-lint-${VERSION_NUM}-${OS}-${ARCH}"
+ASSET_NAME="${ASSET_DIR}.tar.gz"
+CHECKSUMS_NAME="golangci-lint-${VERSION_NUM}-checksums.txt"
+BASE_URL="https://github.com/${REPO}/releases/download/${VERSION}"
+
+# ---- 一時ディレクトリ（EXIT 時に自動削除） ----
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# ---- ダウンロード ----
+echo "ダウンロード中: ${BASE_URL}/${ASSET_NAME}"
+curl -fsSL -o "$WORK_DIR/$ASSET_NAME" "${BASE_URL}/${ASSET_NAME}"
+
+echo "ダウンロード中: ${BASE_URL}/${CHECKSUMS_NAME}"
+curl -fsSL -o "$WORK_DIR/$CHECKSUMS_NAME" "${BASE_URL}/${CHECKSUMS_NAME}"
+
+# ---- sha256 検証 ----
+echo "チェックサムを検証しています..."
+checksum_line="$(grep " ${ASSET_NAME}\$" "$WORK_DIR/$CHECKSUMS_NAME" || true)"
+if [[ -z "$checksum_line" ]]; then
+  echo "ERROR: $CHECKSUMS_NAME に $ASSET_NAME のエントリが見つかりません" >&2
+  exit 1
+fi
+echo "$checksum_line" | (cd "$WORK_DIR" && $SHA256CMD --check -)
+echo "チェックサム OK"
+
+# ---- 展開 ----
+tar -xzf "$WORK_DIR/$ASSET_NAME" -C "$WORK_DIR" "${ASSET_DIR}/golangci-lint"
+
+# ---- インストール ----
+if ! mkdir -p "$BIN_DIR" 2>/dev/null; then
+  echo "ERROR: BIN_DIR を作成できません: $BIN_DIR" >&2
+  exit 1
+fi
+install -m 0755 "$WORK_DIR/${ASSET_DIR}/golangci-lint" "$BIN_DIR/golangci-lint"
+
+echo "インストール完了: $BIN_DIR/golangci-lint"
+"$BIN_DIR/golangci-lint" --version


### PR DESCRIPTION
## 概要

Claude Codeのリモートセッション（GitHubアクセスが対象リポジトリのみに制限される環境）で `make setup` が失敗し、`go.mod` の `go 1.26.1` より古いGoでビルドされた golangci-lint が使われ続けてバージョン不一致エラーが多発していた問題を修正する。

## 変更内容

- `make setup` の golangci-lint インストール手段を、`api.github.com` 経由でタグ解決する公式 `install.sh` から、GitHub Releases のアセットを直接URLで取得しsha256検証する自作スクリプト（`scripts/install-lefthook.sh` と同じ設計）に変更
- `scripts/install-golangci-lint.sh` を新規追加
- ADR-0102 を追加（判断の背景と代替案の記録）

## 関連 Issue

なし

## 確認したこと

- [x] `make test` が通る
- [x] `make lint` が通る
- [x] CLI のコマンド/フラグを変更した場合、`make docs` で `docs/cli/` を再生成した（対象外）
- [x] 重要な技術判断を含む場合、ADR（`docs/adr/`）を追加した

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015uznM8JD93Dgo63XaQQwFB)_