### PR TITLE
docs: ADR-0105を追加（プロンプト品質評価フレームワークの廃止）

### DIFF
--- a/docs/adr/0049-prompt-eval-llm-as-judge-framework.md
+++ b/docs/adr/0049-prompt-eval-llm-as-judge-framework.md
@@ -1,6 +1,6 @@
 # 0049. 組み込みプロンプトの品質を LLM-as-judge で評価するフレームワークを導入する
 
-- ステータス: 採用
+- ステータス: 廃止 → [0105-remove-prompt-eval-framework.md](0105-remove-prompt-eval-framework.md)
 - 日付: 2026-06-07
 
 ## コンテキスト

--- a/docs/adr/0105-remove-prompt-eval-framework.md
+++ b/docs/adr/0105-remove-prompt-eval-framework.md
@@ -1,0 +1,23 @@
+# 0105. プロンプト品質評価フレームワーク（internal/eval, ADR-0049）を廃止する
+
+- ステータス: 採用
+- 日付: 2026-08-06
+
+## コンテキスト
+
+ADR-0049で導入した`internal/eval`は、組み込みプロンプト8種（proofread/summarize/corner_summary/summary/select/flow/write/direct）をGeminiによるLLM-as-judge方式で週次採点し、内容品質の回帰を検知する仕組みである。
+
+ADR-0103の実装（PR #571）でdirect/proofreadの読み変換ルールを変更した結果、`internal/eval/testdata`の回帰ケース・judge採点基準が旧仕様（漢字のかな化前提）のまま陳腐化し、追随修正のタスクを起票した。その過程で調査したところ、evalの実行結果は`.github/workflows/prompt-eval.yml`実行時のGitHub Actionsログにしか出力されず、artifact保存・Slack通知・Issue化・バッジ表示などの可視化/通知手段が一切存在しないことが判明した。結果として、実質「見に行かなければ気づけない」運用になっており、ADR-0049が意図した継続的な回帰検知という価値を回収できていなかった。ADR-0098は「evalは開発者向けCI機構であり本番エピソードの振り返り（retro）には流用しない」と明記しており、代替となる仕組みも存在しない。
+
+## 決定
+
+`internal/eval`パッケージ一式（Goコード・`testdata`）、`.github/workflows/prompt-eval.yml`、`Makefile`の`eval`ターゲット、`.golangci.yml`の`domain-eval`ルール、`docs/development/architecture.md`・`docs/development/README.md`のeval関連記述を削除する。ADR-0049は「廃止」ステータスへ変更し本ADRを参照させる（ADR本文自体は改変しない）。プロンプト内容品質の自動監視機構は持たず、人手レビュー・実運用での気づきに委ねる。
+
+## 結果
+
+- 良い影響: 通知が届かず活用できていなかった週次ジョブの保守コストが消える。ADR-0103のような読み変換仕様の変更のたびに発生していた回帰データ・judge基準の追随作業が今後不要になる。
+- 悪い影響: プロンプト内容品質の劣化を自動検知する唯一の手段が失われる。将来的に自動監視が必要になった場合、通知の仕組みを含めて再構築するコストが発生する。
+
+## 検討した代替案
+
+- 失敗時にSlack通知を追加して存続させる案: 既存のslackpost基盤（ADR-0035/0071）の流用を検討したが、通知先設計・実装スコープが新たに必要になる。「有効活用できていない」現状を踏まえ、まず廃止を優先し、品質監視の必要性が再燃した際に通知付きで作り直す方針とした。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,7 +54,7 @@
 | [0046](0046-article-source-attribution-to-llm.md) | 記事の出典（サイト名・著者名）を rundown 経由で生成 LLM に渡す | 採用 | 2026-06-06 |
 | [0047](0047-program-timezone-and-temporal-context-to-llm.md) | 番組タイムゾーン設定の導入と時間文脈（記事配信日時・収録日時）の生成 LLM への伝達 | 採用 | 2026-06-06 |
 | [0048](0048-program-level-direction-and-non-public-script-note.md) | 番組全体の演出指示（direct専用）と台本指示 script_note（write専用・非公開、番組/コーナー両レベル）を追加する | 採用 | 2026-06-06 |
-| [0049](0049-prompt-eval-llm-as-judge-framework.md) | 組み込みプロンプトの品質を LLM-as-judge で評価するフレームワークを導入する | 採用 | 2026-06-07 |
+| [0049](0049-prompt-eval-llm-as-judge-framework.md) | 組み込みプロンプトの品質を LLM-as-judge で評価するフレームワークを導入する | 廃止 | 2026-06-07 |
 | [0050](0050-fail-on-cache-corruption-instead-of-degraded-mode.md) | キャッシュ破損時は degraded mode ではなくエラー停止する | 採用 | 2026-06-07 |
 | [0051](0051-http-retry-with-exponential-backoff.md) | 外部 HTTP API 呼び出しに指数バックオフのリトライを導入する | 採用 | 2026-06-08 |
 | [0052](0052-corner-id-and-appearance-context-to-llm.md) | コーナーに ID を導入し扱い回数・前回出演回番号を生成 LLM に渡す | 採用 | 2026-06-08 |
@@ -110,3 +110,4 @@
 | [0102](0102-golangci-lint-install-without-github-api.md) | golangci-lint のインストールを GitHub API 非依存にする | 採用 | 2026-08-03 |
 | [0103](0103-drop-llm-kanji-kana-conversion-rely-on-voicevox.md) | 読み変換における漢字のLLMかな化を廃止し、VOICEVOXの読み推定に一本化する（ADR-0045・0094 改訂） | 採用 | 2026-08-05 |
 | [0104](0104-split-lines-per-sentence-and-move-voice-params-to-direct.md) | セリフを機械的に1文単位へ分割し、抑揚パラメータの付与を write から direct へ移す | 採用 | 2026-08-05 |
+| [0105](0105-remove-prompt-eval-framework.md) | プロンプト品質評価フレームワーク（internal/eval, ADR-0049）を廃止する | 採用 | 2026-08-06 |


### PR DESCRIPTION
## 概要

Todoistに登録していた「ADR-0103実装（PR #571）に伴うeval回帰テストデータ・ルールファイルの更新漏れを修正」タスクについて、ユーザーから「evalの結果を有効活用できていないため、eval機能自体を削除したい」という相談があった。

調査したところ、`internal/eval`（ADR-0049）の実行結果はGitHub Actionsログにしか出力されず、artifact保存・Slack通知・Issue化・バッジ等の可視化/通知手段が一切なく、実質「見なければ気づけない」運用になっていたことが判明。ADR-0098も「evalは開発者向けCI機構であり本番の振り返りには流用しない」と明記しており代替手段もないため、削除を妥当と判断し、その方針をADRとして記録した。

実装（`internal/eval`一式・`prompt-eval.yml`・`Makefile`・`.golangci.yml`・関連ドキュメントの削除）は本PRの範囲外で、Todoistタスクを更新のうえ別途進める。

## 変更内容

- `docs/adr/0105-remove-prompt-eval-framework.md` を追加（ADR-0049を廃止する決定）
- `docs/adr/0049-prompt-eval-llm-as-judge-framework.md` のステータスを「採用」→「廃止 → 0105」に更新
- `docs/adr/README.md` の索引を更新（0049のステータス変更、0105を追加）

## 関連 Issue

なし

## 確認したこと

- [x] `make test` が通る
- [x] `make lint` が通る（Markdown/ADRファイルのみの変更のため対象外）
- [ ] CLI のコマンド/フラグを変更した場合、`make docs` で `docs/cli/` を再生成した（該当なし）
- [x] 重要な技術判断を含む場合、ADR（`docs/adr/`）を追加した

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBQMqDGS5yeL8H9stYQDnt)_